### PR TITLE
Refactor HttpResponseStatusFuture sync method

### DIFF
--- a/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatus.java
+++ b/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatus.java
@@ -1,0 +1,16 @@
+package org.wso2.carbon.transport.http.netty.contractimpl;
+
+/**
+ * Class represents the status of outbound response.
+ */
+public class HttpResponseStatus {
+    private Throwable cause;
+
+    public HttpResponseStatus(Throwable throwable) {
+        this.cause = throwable;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
+++ b/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
@@ -35,14 +35,6 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
     private Semaphore executionWaitSem;
 
     @Override
-    public void setHttpConnectorListener(HttpConnectorListener connectorListener) {
-    }
-
-    @Override
-    public void removeHttpListener() {
-    }
-
-    @Override
     public void notifyHttpListener(HTTPCarbonMessage httpCarbonMessage) {
         this.httpCarbonMessage = httpCarbonMessage;
         if (executionWaitSem != null) {
@@ -58,7 +50,7 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
         }
     }
 
-    public Throwable sync() throws InterruptedException {
+    public HttpResponseStatusFuture sync() throws InterruptedException {
         executionWaitSem = new Semaphore(0);
         if (this.httpCarbonMessage == null && this.throwable == null) {
             executionWaitSem.acquire();
@@ -71,6 +63,18 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
             status = throwable;
             throwable = null;
         }
+        return this;
+    }
+
+    public Throwable getStatus() {
         return status;
+    }
+
+    @Override
+    public void setHttpConnectorListener(HttpConnectorListener connectorListener) {
+    }
+
+    @Override
+    public void removeHttpListener() {
     }
 }

--- a/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
+++ b/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
@@ -66,7 +66,7 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
         return this;
     }
 
-    public HttpResponseStatus getFailureStatus() {
+    public HttpResponseStatus getStatus() {
         return this.returnError != null ? new HttpResponseStatus(this.returnError) : new HttpResponseStatus(null);
     }
 

--- a/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
+++ b/components/org.wso2.carbon.transport.http.netty/src/main/java/org/wso2/carbon/transport/http/netty/contractimpl/HttpResponseStatusFuture.java
@@ -26,12 +26,12 @@ import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
 import java.util.concurrent.Semaphore;
 
 /**
- * Implementation of the response status future.
+ * Implementation of the response returnError future.
  */
 public class HttpResponseStatusFuture implements HttpResponseFuture {
 
     private HTTPCarbonMessage httpCarbonMessage;
-    private Throwable throwable, status;
+    private Throwable throwable, returnError;
     private Semaphore executionWaitSem;
 
     @Override
@@ -56,18 +56,18 @@ public class HttpResponseStatusFuture implements HttpResponseFuture {
             executionWaitSem.acquire();
         }
         if (httpCarbonMessage != null) {
-            status = null;
+            returnError = null;
             httpCarbonMessage = null;
         }
         if (throwable != null) {
-            status = throwable;
+            returnError = throwable;
             throwable = null;
         }
         return this;
     }
 
-    public Throwable getStatus() {
-        return status;
+    public HttpResponseStatus getFailureStatus() {
+        return this.returnError != null ? new HttpResponseStatus(this.returnError) : new HttpResponseStatus(null);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Make HttpResponseStatusFuture sync method returns the future itself and add a seperate getter to get the status of the future.

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
>N/A

## Automation tests
 >N/A

## Security checks
 >N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A