### PR TITLE
Update messaging version to 3.0.2 in transport-http

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportContextHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportContextHolder.java
@@ -23,7 +23,6 @@ import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonMessageProcessor;
-import org.wso2.carbon.messaging.TransportListenerManager;
 import org.wso2.transport.http.netty.config.ListenerConfiguration;
 
 import java.util.HashMap;
@@ -40,7 +39,6 @@ public class HTTPTransportContextHolder {
     private BundleContext bundleContext;
     private HandlerExecutor handlerExecutor;
     private Map<String, ListenerConfiguration> listenerConfigurations = new HashMap<>();
-    private TransportListenerManager manager;
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private CarbonMessageProcessor singleCarbonMessageProcessor;
@@ -117,18 +115,6 @@ public class HTTPTransportContextHolder {
             messageProcessorMap.clear();
             singleCarbonMessageProcessor = null;
         }
-    }
-
-    public TransportListenerManager getManager() {
-        return manager;
-    }
-
-    public void removeManager() {
-        manager = null;
-    }
-
-    public void setManager(TransportListenerManager manager) {
-        this.manager = manager;
     }
 
     public void setHandlerExecutor(HandlerExecutor handlerExecutor) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportServiceComponent.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportServiceComponent.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.messaging.CarbonMessageProcessor;
-import org.wso2.carbon.messaging.TransportListenerManager;
 
 /**
  * Declarative service component for the Netty transport. This handles registration &amp; unregistration of relevant
@@ -66,20 +65,6 @@ public class HTTPTransportServiceComponent implements RequiredCapabilityListener
 
     protected void removeMessageProcessor(CarbonMessageProcessor carbonMessageProcessor) {
         HTTPTransportContextHolder.getInstance().removeMessageProcessor(carbonMessageProcessor);
-    }
-
-    @Reference(
-            name = "transport-listener-manager",
-            service = TransportListenerManager.class,
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "removeManager")
-    protected void addManager(TransportListenerManager manager) {
-        HTTPTransportContextHolder.getInstance().setManager(manager);
-    }
-
-    protected void removeManager(TransportListenerManager manager) {
-        HTTPTransportContextHolder.getInstance().removeManager();
     }
 
     @Reference(

--- a/pom.xml
+++ b/pom.xml
@@ -284,8 +284,8 @@
         <org.apache.commons.pool2.version>2.4.2</org.apache.commons.pool2.version>
         <commons-net.version>3.6</commons-net.version>
 
-        <carbon.messaging.version>2.3.7</carbon.messaging.version>
-        <carbon.messaging.package.import.version.range>[2.0.0, 3.0.0)</carbon.messaging.package.import.version.range>
+        <carbon.messaging.version>3.0.2</carbon.messaging.version>
+        <carbon.messaging.package.import.version.range>[3.0.0, 4.0.0)</carbon.messaging.package.import.version.range>
         <slf4j.version>1.7.5</slf4j.version>
         <!--Logging API version range-->
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>


### PR DESCRIPTION
## Purpose
Resolves #9 

## Goals
Current transport version have carbon-messaging dependency for 2.3.7 version which is referring to carbon kernel milestone 3. And we have latest carbon-messaging version 3.0.2 which is referring to latest kernel GA version(5.2.0).

## Approach
Update carbon-messaging version from 2.3.7 -> 3.0.2
Fix related transport code.

## Release note
Upgrade carbon-messaging version to 3.0.2

## Automation tests
This is just updating the carbon-messaging version. no code level changes.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
