### PR TITLE
Add default values to field variables instead of defining in default method

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ConfigurationBuilder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ConfigurationBuilder.java
@@ -93,7 +93,7 @@ public class ConfigurationBuilder {
         } else { // return a default config
             log.warn("Netty transport configuration file not found in: " + configFileLocation +
                      " ,hence using default configuration");
-            transportsConfiguration = TransportsConfiguration.getDefault();
+            transportsConfiguration = new TransportsConfiguration();
         }
 
         return transportsConfiguration;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ListenerConfiguration.java
@@ -39,6 +39,7 @@ public class ListenerConfiguration {
 
     public static final String DEFAULT_KEY = "default";
 
+    @Deprecated
     public static ListenerConfiguration getDefault() {
         ListenerConfiguration defaultConfig;
         defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080);
@@ -46,13 +47,13 @@ public class ListenerConfiguration {
     }
 
     @XmlAttribute(required = true)
-    private String id;
+    private String id = DEFAULT_KEY;
 
     @XmlAttribute
-    private String host;
+    private String host = "0.0.0.0";
 
     @XmlAttribute(required = true)
-    private int port;
+    private int port = 8080;
 
     @XmlAttribute
     private boolean bindOnStartup = false;
@@ -100,7 +101,7 @@ public class ListenerConfiguration {
     @XmlElement(name = "parameter")
     private List<Parameter> parameters = getDefaultParameters();
 
-    private RequestSizeValidationConfiguration requestSizeValidationConfig;
+    private RequestSizeValidationConfiguration requestSizeValidationConfig = new RequestSizeValidationConfiguration();
 
     public ListenerConfiguration() {
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/RequestSizeValidationConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/RequestSizeValidationConfiguration.java
@@ -80,6 +80,9 @@ public class RequestSizeValidationConfiguration {
         });
     }
 
+    public RequestSizeValidationConfiguration() {
+    }
+
     public boolean isRequestSizeValidation() {
         return requestSizeValidation;
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
@@ -22,6 +22,7 @@ import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -39,7 +40,7 @@ public class SenderConfiguration {
 
     public static final String DEFAULT_KEY = "netty";
 
-
+    @Deprecated
     public static SenderConfiguration getDefault() {
         SenderConfiguration defaultConfig;
         defaultConfig = new SenderConfiguration(DEFAULT_KEY);
@@ -47,7 +48,7 @@ public class SenderConfiguration {
     }
 
     @XmlAttribute(required = true)
-    private String id;
+    private String id = DEFAULT_KEY;
 
     @XmlAttribute
     private String scheme = "http";
@@ -81,7 +82,7 @@ public class SenderConfiguration {
 
     @XmlElementWrapper(name = "parameters")
     @XmlElement(name = "parameter")
-    private List<Parameter> parameters;
+    private List<Parameter> parameters = new ArrayList<>();
 
     private boolean followRedirect;
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/TransportProperty.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/TransportProperty.java
@@ -18,6 +18,7 @@ public class TransportProperty {
     @XmlValue
     protected Object value;
 
+    @Deprecated
     public static TransportProperty getDefault() {
         return new TransportProperty();
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/TransportsConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/TransportsConfiguration.java
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TransportsConfiguration {
 
+    @Deprecated
     public static TransportsConfiguration getDefault() {
         TransportsConfiguration defaultConfig = new TransportsConfiguration();
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
@@ -52,9 +53,19 @@ public class TransportsConfiguration {
         return defaultConfig;
     }
 
+    public TransportsConfiguration () {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfigurations = new HashSet<>();
+        listenerConfigurations.add(listenerConfiguration);
+
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfigurations = new HashSet<>();
+        senderConfigurations.add(senderConfiguration);
+    }
+
     @XmlElementWrapper(name = "properties")
     @XmlElement(name = "property")
-    private Set<TransportProperty> transportProperties = Collections.EMPTY_SET;
+    private Set<TransportProperty> transportProperties = new HashSet<>();
 
 
     @XmlElementWrapper(name = "listeners")


### PR DESCRIPTION
## Purpose
This PR is to add default values to fields instead of defining in separate static method. If user need to create object with default values, he can simply create an object of the class.

## Goals
Remove default method usage when create object with default values.

## Approach
Add default values to field variables.
depreciate default static method.