### PR TITLE
Remove content-Type for empty payloads and add content length zero

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -186,7 +186,6 @@ public final class Constants {
     public static final String HTTP_POST_METHOD = "POST";
     public static final String HTTP_HEAD_METHOD = "HEAD";
     public static final String HTTP_PUT_METHOD = "PUT";
-    public static final String HTTP_DELETE_METHOD = "DELETE";
     public static final String HTTP_PATCH_METHOD = "PATCH";
 
     //HTTP server connector creation parameters

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -185,6 +185,9 @@ public final class Constants {
     public static final String HTTP_GET_METHOD = "GET";
     public static final String HTTP_POST_METHOD = "POST";
     public static final String HTTP_HEAD_METHOD = "HEAD";
+    public static final String HTTP_PUT_METHOD = "PUT";
+    public static final String HTTP_DELETE_METHOD = "DELETE";
+    public static final String HTTP_PATCH_METHOD = "PATCH";
 
     //HTTP server connector creation parameters
     public static final String HTTP_HOST = "host";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -159,7 +159,7 @@ public class Util {
             int contentLength = cMsg.getFullMessageLength();
             if (contentLength > 0) {
                 cMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
-            } else if (isMethodAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
+            } else if (isEntityBodyAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
                 cMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(0));
             }
         }
@@ -169,7 +169,8 @@ public class Util {
         if (cMsg.isAlreadyRead() || (cMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null && !cMsg.isEmpty())) {
             HttpContent httpContent = cMsg.peek();
             if (httpContent instanceof LastHttpContent) {
-                if (httpContent.content().readableBytes() == 0 && !isMethodAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
+                if (httpContent.content().readableBytes() == 0 &&
+                        !isEntityBodyAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
                     return;
                 }
             }
@@ -177,9 +178,9 @@ public class Util {
         }
     }
 
-    private static boolean isMethodAllowed(String method) {
+    private static boolean isEntityBodyAllowed(String method) {
         return method.equals(Constants.HTTP_POST_METHOD) || method.equals(Constants.HTTP_PUT_METHOD)
-                || method.equals(Constants.HTTP_PATCH_METHOD) || method.equals(Constants.HTTP_DELETE_METHOD);
+                || method.equals(Constants.HTTP_PATCH_METHOD);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpResponseListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpResponseListener.java
@@ -50,7 +50,7 @@ public class HttpResponseListener implements HttpConnectorListener {
 
     @Override
     public void onMessage(HTTPCarbonMessage httpResponseMessage) {
-        Util.setupTransferEncodingForResponse(httpResponseMessage, requestDataHolder);
+        Util.setupTransferEncodingAndContentTypeForResponse(httpResponseMessage, requestDataHolder);
 
         sourceContext.channel().eventLoop().execute(() -> {
             boolean keepAlive = isKeepAlive(httpResponseMessage);


### PR DESCRIPTION
## Purpose
> PR removes the content-type header from the response if the payload is empty. 
> PR adds content length zero headers for the POST, PUT, DELETE, PATCH requests which contain an empty body. 
> PR fixes https://github.com/ballerinalang/ballerina/issues/4022

## Goals
> To maintain consistent the response headers. Since the content type represents the payload of the response, empty payloads should not have content-type headers. So PR manages to remove it when the content-length header value is zero and content-length header do not exist. 

