### PR TITLE
Set the connection:close header when keep-alive is disabled

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -51,6 +51,7 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
     private int socketIdleTimeout;
     private boolean followRedirect;
     private boolean chunkDisabled;
+    private boolean keepAlive;
 
     public HttpClientConnectorImpl(ConnectionManager connectionManager, SenderConfiguration senderConfiguration) {
         this.connectionManager = connectionManager;
@@ -88,11 +89,14 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                         targetChannel.setEndPointTimeout(socketIdleTimeout, followRedirect);
                         targetChannel.setCorrelationIdForLogging();
                         targetChannel.setChunkDisabled(chunkDisabled);
-                        targetChannel.setRequestWritten(true);
                         if (followRedirect) {
                             setChannelAttributes(channelFuture.channel(), httpCarbonRequest, httpResponseFuture,
                                                  targetChannel);
                         }
+                        if (!keepAlive) {
+                            httpCarbonRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_CLOSE);
+                        }
+                        targetChannel.setRequestWritten(true);
                         targetChannel.writeContent(httpCarbonRequest);
                     } else {
                         notifyErrorState(channelFuture);
@@ -194,5 +198,6 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
         this.followRedirect = senderConfiguration.isFollowRedirect();
         this.socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(Constants.ENDPOINT_TIMEOUT);
         this.sslConfig = senderConfiguration.getSslConfig();
+        this.keepAlive = senderConfiguration.isKeepAlive();
     }
 }


### PR DESCRIPTION
## Purpose
> Currently, the Connection:Close header is not set when sending a request using the client connector while keep-alive is diabled. This will fix this issue by setting the Connection:Close header if keep-alive is enabled. 

## Test environment
> JDK 1.8.0_121
Ubuntu Gnome 16.04
tools: cURL, Chrome 60.0.3112.78