### PR TITLE
Remove DataSource From transport implementation

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -186,21 +186,21 @@ public class Util {
     /**
      * Prepare response message with Transfer-Encoding/Content-Length/Content-Type.
      *
-     * @param outBoundResMsg Carbon message.
+     * @param outboundResMsg Carbon message.
      * @param requestDataHolder Requested data holder.
      */
-    public static void setupTransferEncodingAndContentTypeForResponse(HTTPCarbonMessage outBoundResMsg
+    public static void setupTransferEncodingAndContentTypeForResponse(HTTPCarbonMessage outboundResMsg
             , RequestDataHolder requestDataHolder) {
 
         // 1. Remove Transfer-Encoding and Content-Length as per rfc7230#section-3.3.1
-        int statusCode = Util.getIntValue(outBoundResMsg, Constants.HTTP_STATUS_CODE, 200);
+        int statusCode = Util.getIntValue(outboundResMsg, Constants.HTTP_STATUS_CODE, 200);
         String httpMethod = requestDataHolder.getHttpMethod();
         if (statusCode == 204 ||
             statusCode >= 100 && statusCode < 200 ||
             (HttpMethod.CONNECT.name().equals(httpMethod) && statusCode >= 200 && statusCode < 300)) {
-            outBoundResMsg.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
-            outBoundResMsg.removeHeader(Constants.HTTP_CONTENT_LENGTH);
-            outBoundResMsg.removeHeader(Constants.HTTP_CONTENT_TYPE);
+            outboundResMsg.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
+            outboundResMsg.removeHeader(Constants.HTTP_CONTENT_LENGTH);
+            outboundResMsg.removeHeader(Constants.HTTP_CONTENT_TYPE);
             return;
         }
 
@@ -210,30 +210,30 @@ public class Util {
         String requestTransferEncodingHeader = requestDataHolder.getTransferEncodingHeader();
         if (requestTransferEncodingHeader != null &&
             !Constants.HTTP_TRANSFER_ENCODING_IDENTITY.equalsIgnoreCase(requestTransferEncodingHeader)) {
-            outBoundResMsg.setHeader(Constants.HTTP_TRANSFER_ENCODING, requestTransferEncodingHeader);
-            outBoundResMsg.removeHeader(Constants.HTTP_CONTENT_LENGTH);
+            outboundResMsg.setHeader(Constants.HTTP_TRANSFER_ENCODING, requestTransferEncodingHeader);
+            outboundResMsg.removeHeader(Constants.HTTP_CONTENT_LENGTH);
             return;
         }
 
         // 3. Check for request Content-Length header
         String requestContentLength = requestDataHolder.getContentLengthHeader();
         if (requestContentLength != null &&
-            (outBoundResMsg.isAlreadyRead() || (outBoundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null))) {
-            int contentLength = outBoundResMsg.getFullMessageLength();
+            (outboundResMsg.isAlreadyRead() || (outboundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null))) {
+            int contentLength = outboundResMsg.getFullMessageLength();
             if (contentLength > 0) {
-                outBoundResMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
+                outboundResMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
             }
-            outBoundResMsg.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
+            outboundResMsg.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
             return;
         }
 
         // 4. If request doesn't have Transfer-Encoding or Content-Length header look for response properties
-        if (outBoundResMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) != null) {
-            outBoundResMsg.getHeaders().remove(Constants.HTTP_CONTENT_LENGTH);  // remove Content-Length if present
-        } else if (outBoundResMsg.isAlreadyRead() ||
-                (outBoundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null)) {
-            int contentLength = outBoundResMsg.getFullMessageLength();
-            outBoundResMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
+        if (outboundResMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) != null) {
+            outboundResMsg.getHeaders().remove(Constants.HTTP_CONTENT_LENGTH);  // remove Content-Length if present
+        } else if (outboundResMsg.isAlreadyRead() ||
+                (outboundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null)) {
+            int contentLength = outboundResMsg.getFullMessageLength();
+            outboundResMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -78,7 +78,6 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
 
         try {
             final HttpRoute route = getTargetRoute(httpCarbonRequest);
-            Util.setupTransferEncodingForRequest(httpCarbonRequest, chunkDisabled);
             TargetChannel targetChannel = connectionManager.borrowTargetChannel(route, srcHandler, senderConfiguration);
             targetChannel.getChannelFuture().addListener(new ChannelFutureListener() {
                 @Override
@@ -96,6 +95,7 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                         if (!keepAlive) {
                             httpCarbonRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_CLOSE);
                         }
+                        Util.setupTransferEncodingForRequest(httpCarbonRequest, chunkDisabled);
                         targetChannel.setRequestWritten(true);
                         targetChannel.writeContent(httpCarbonRequest);
                     } else {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutBoundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutBoundRespListener.java
@@ -34,14 +34,14 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 /**
  * Get executed when the response is available.
  */
-public class HttpResponseListener implements HttpConnectorListener {
+public class HttpOutBoundRespListener implements HttpConnectorListener {
 
     private ChannelHandlerContext sourceContext;
     private RequestDataHolder requestDataHolder;
     private HandlerExecutor handlerExecutor;
     private HTTPCarbonMessage inboundRequestMsg;
 
-    public HttpResponseListener(ChannelHandlerContext channelHandlerContext, HTTPCarbonMessage requestMsg) {
+    public HttpOutBoundRespListener(ChannelHandlerContext channelHandlerContext, HTTPCarbonMessage requestMsg) {
         this.sourceContext = channelHandlerContext;
         this.requestDataHolder = new RequestDataHolder(requestMsg);
         this.handlerExecutor = HTTPTransportContextHolder.getInstance().getHandlerExecutor();
@@ -50,8 +50,6 @@ public class HttpResponseListener implements HttpConnectorListener {
 
     @Override
     public void onMessage(HTTPCarbonMessage httpResponseMessage) {
-        Util.setupTransferEncodingAndContentTypeForResponse(httpResponseMessage, requestDataHolder);
-
         sourceContext.channel().eventLoop().execute(() -> {
             boolean keepAlive = isKeepAlive(httpResponseMessage);
 
@@ -59,6 +57,7 @@ public class HttpResponseListener implements HttpConnectorListener {
                 handlerExecutor.executeAtSourceResponseReceiving(httpResponseMessage);
             }
 
+            Util.setupTransferEncodingAndContentTypeForResponse(httpResponseMessage, requestDataHolder);
             final HttpResponse response = Util.createHttpResponse(httpResponseMessage, keepAlive);
             sourceContext.write(response);
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -34,14 +34,14 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 /**
  * Get executed when the response is available.
  */
-public class HttpOutBoundRespListener implements HttpConnectorListener {
+public class HttpOutboundRespListener implements HttpConnectorListener {
 
     private ChannelHandlerContext sourceContext;
     private RequestDataHolder requestDataHolder;
     private HandlerExecutor handlerExecutor;
     private HTTPCarbonMessage inboundRequestMsg;
 
-    public HttpOutBoundRespListener(ChannelHandlerContext channelHandlerContext, HTTPCarbonMessage requestMsg) {
+    public HttpOutboundRespListener(ChannelHandlerContext channelHandlerContext, HTTPCarbonMessage requestMsg) {
         this.sourceContext = channelHandlerContext;
         this.requestDataHolder = new RequestDataHolder(requestMsg);
         this.handlerExecutor = HTTPTransportContextHolder.getInstance().getHandlerExecutor();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
-import org.wso2.transport.http.netty.contractimpl.HttpOutBoundRespListener;
+import org.wso2.transport.http.netty.contractimpl.HttpOutboundRespListener;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -138,8 +138,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         if (continueRequest) {
             if (serverConnectorFuture != null) {
                 try {
-                    ServerConnectorFuture outBoundRespFuture = httpRequestMsg.getHttpResponseFuture();
-                    outBoundRespFuture.setHttpConnectorListener(new HttpOutBoundRespListener(ctx, httpRequestMsg));
+                    ServerConnectorFuture outboundRespFuture = httpRequestMsg.getHttpResponseFuture();
+                    outboundRespFuture.setHttpConnectorListener(new HttpOutboundRespListener(ctx, httpRequestMsg));
                     this.serverConnectorFuture.notifyHttpListener(httpRequestMsg);
                 } catch (Exception e) {
                     log.error("Error while notifying listeners", e);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
-import org.wso2.transport.http.netty.contractimpl.HttpResponseListener;
+import org.wso2.transport.http.netty.contractimpl.HttpOutBoundRespListener;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -138,8 +138,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         if (continueRequest) {
             if (serverConnectorFuture != null) {
                 try {
-                    ServerConnectorFuture serverConnectorFuture = httpRequestMsg.getHttpResponseFuture();
-                    serverConnectorFuture.setHttpConnectorListener(new HttpResponseListener(ctx, httpRequestMsg));
+                    ServerConnectorFuture outBoundRespFuture = httpRequestMsg.getHttpResponseFuture();
+                    outBoundRespFuture.setHttpConnectorListener(new HttpOutBoundRespListener(ctx, httpRequestMsg));
                     this.serverConnectorFuture.notifyHttpListener(httpRequestMsg);
                 } catch (Exception e) {
                     log.error("Error while notifying listeners", e);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -95,7 +95,7 @@ public class ConnectionManager {
         if (sourceHandler != null) {
             EventLoopGroup group;
             ChannelHandlerContext ctx = sourceHandler.getInboundChannelContext();
-            group = ctx.channel().eventLoop();
+            group = targetEventLoopGroup;
             Class cl = ctx.channel().getClass();
 
             if (poolManagementPolicy == PoolManagementPolicy.LOCK_DEFAULT_POOLING) {


### PR DESCRIPTION
## Purpose
> Removing DataSource implementations from the transport implementation. 

DataSource was inherited by the carbon-messaging repository. Now that we are going away from it we need to remove its implementations as well. This is part of that effort.

## Goals
> Remove the dependency from carbon-messaging implementation. 

## Approach
> Move DataSource to thin layer of each product.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Covered by existing ones.

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A