### PR TITLE
Remove all the data-source related code from transport

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -137,7 +137,6 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                     httpResponseFuture.notifyHttpListener(cause);
                 }
             });
-            Util.prepareBuiltMessageForTransfer(httpCarbonRequest);
         } catch (Exception failedCause) {
             httpResponseFuture.notifyHttpListener(failedCause);
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -85,7 +85,6 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                 }
             }));
         });
-        Util.prepareBuiltMessageForTransfer(httpResponseMessage);
     }
 
     // Decides whether to close the connection after sending the response

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
@@ -43,15 +43,15 @@ public class BlockingEntityCollector implements EntityCollector {
     private static final Logger LOG = LoggerFactory.getLogger(BlockingEntityCollector.class);
 
     private int soTimeOut;
-    private AtomicBoolean alreadyRead;
     private AtomicBoolean endOfMsgAdded;
+    private AtomicBoolean isExpectingEntity;
     private AtomicBoolean isConsumed;
     private BlockingQueue<HttpContent> httpContentQueue;
 
     public BlockingEntityCollector(int soTimeOut) {
         this.soTimeOut = soTimeOut;
-        this.alreadyRead = new AtomicBoolean(false);
         this.endOfMsgAdded = new AtomicBoolean(false);
+        this.isExpectingEntity = new AtomicBoolean(false);
         this.isConsumed = new AtomicBoolean(false);
         this.httpContentQueue = new LinkedBlockingQueue<>();
     }
@@ -59,20 +59,33 @@ public class BlockingEntityCollector implements EntityCollector {
     public void addHttpContent(HttpContent httpContent) {
         try {
             isConsumed.set(false);
+            isExpectingEntity.set(false);
             httpContentQueue.add(httpContent);
         } catch (Exception e) {
             LOG.error("Cannot put content to queue", e);
         }
     }
 
+    public void addMessageBody(ByteBuffer msgBody) {
+        addHttpContent(new DefaultHttpContent(Unpooled.copiedBuffer(msgBody)));
+    }
+
+    public ByteBuf getMessageBody() {
+        HttpContent httpContent = getHttpContent();
+        if (httpContent != null) {
+            return httpContent.content();
+        }
+        return null;
+    }
+
     public HttpContent getHttpContent() {
         try {
-            if (!isConsumed.get() || !alreadyRead.get()) {
+            // Consumed but expecting entity.
+            if (!isConsumed.get() || isExpectingEntity.get()) {
                 HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
 
                 if (httpContent instanceof LastHttpContent) {
                     isConsumed.set(true);
-                    alreadyRead.set(false);
                     httpContentQueue.clear();
                 }
 
@@ -84,17 +97,53 @@ public class BlockingEntityCollector implements EntityCollector {
         return null;
     }
 
-    public void addMessageBody(ByteBuffer msgBody) {
-        isConsumed.set(false);
-        httpContentQueue.add(new DefaultHttpContent(Unpooled.copiedBuffer(msgBody)));
+    public int getFullMessageLength() {
+        List<HttpContent> contentList = new ArrayList<>();
+        boolean isEndOfMessageProcessed = false;
+        while (isExpectingEntity.get() || (!isConsumed.get() && !isEndOfMessageProcessed)) {
+            try {
+                HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
+                if ((httpContent instanceof LastHttpContent)) {
+                    isEndOfMessageProcessed = true;
+                }
+                contentList.add(httpContent);
+
+            } catch (InterruptedException e) {
+                LOG.error("Error while getting full message length", e);
+            }
+        }
+        int size = 0;
+        for (HttpContent httpContent : contentList) {
+            size += httpContent.content().readableBytes();
+            httpContentQueue.add(httpContent);
+        }
+
+        return size;
     }
 
-    public ByteBuf getMessageBody() {
-        HttpContent httpContent = getHttpContent();
-        if (httpContent != null) {
-            return httpContent.content();
+    public void waitAndReleaseAllEntities() {
+        if (!isConsumed.get()) {
+            boolean isEndOfMessageProcessed = false;
+            while (!isEndOfMessageProcessed) {
+                try {
+                    HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
+                    // This check is to make sure we add the last http content after getClone and avoid adding
+                    // empty content to bytebuf list again and again
+                    if (httpContent instanceof EmptyLastHttpContent) {
+                        break;
+                    }
+
+                    if (httpContent instanceof LastHttpContent) {
+                        isEndOfMessageProcessed = true;
+                        isConsumed.set(true);
+                        isExpectingEntity.set(true);
+                    }
+                    httpContent.release();
+                } catch (InterruptedException e) {
+                    LOG.error("Error while getting full message body", e);
+                }
+            }
         }
-        return null;
     }
 
     @Deprecated
@@ -128,54 +177,6 @@ public class BlockingEntityCollector implements EntityCollector {
         return byteBufferList;
     }
 
-    public void waitAndReleaseAllEntities() {
-        if (!isConsumed.get() && !alreadyRead.get()) {
-            boolean isEndOfMessageProcessed = false;
-            while (!isEndOfMessageProcessed) {
-                try {
-                    HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
-                    // This check is to make sure we add the last http content after getClone and avoid adding
-                    // empty content to bytebuf list again and again
-                    if (httpContent instanceof EmptyLastHttpContent) {
-                        break;
-                    }
-
-                    if (httpContent instanceof LastHttpContent) {
-                        isEndOfMessageProcessed = true;
-                        isConsumed.set(true);
-                    }
-                    httpContent.release();
-                } catch (InterruptedException e) {
-                    LOG.error("Error while getting full message body", e);
-                }
-            }
-        }
-    }
-
-    public int getFullMessageLength() {
-        List<HttpContent> contentList = new ArrayList<>();
-        boolean isEndOfMessageProcessed = false;
-        while (!isEndOfMessageProcessed) {
-            try {
-                HttpContent httpContent = httpContentQueue.poll(soTimeOut, TimeUnit.SECONDS);
-                if ((httpContent instanceof LastHttpContent)) {
-                    isEndOfMessageProcessed = true;
-                }
-                contentList.add(httpContent);
-
-            } catch (InterruptedException e) {
-                LOG.error("Error while getting full message length", e);
-            }
-        }
-        int size = 0;
-        for (HttpContent httpContent : contentList) {
-            size += httpContent.content().readableBytes();
-            httpContentQueue.add(httpContent);
-        }
-
-        return size;
-    }
-
     public boolean isEmpty() {
         return this.httpContentQueue.isEmpty();
     }
@@ -199,14 +200,5 @@ public class BlockingEntityCollector implements EntityCollector {
 
     @Deprecated
     public synchronized void release() {
-    }
-
-    // TODO: Need to move below two to ballerina code
-    public boolean isAlreadyRead() {
-        return alreadyRead.get();
-    }
-
-    public void setAlreadyRead(boolean alreadyRead) {
-        this.alreadyRead.set(alreadyRead);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
@@ -109,7 +109,7 @@ public class BlockingEntityCollector implements EntityCollector {
                 contentList.add(httpContent);
 
             } catch (InterruptedException e) {
-                LOG.error("Error while getting full message length", e);
+                LOG.warn("Error while getting full message length", e);
             }
         }
         int size = 0;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
@@ -94,18 +94,6 @@ public interface EntityCollector {
     void release();
 
     /**
-     * Allows check if the stream is consumed or not.
-     * @return true or false
-     */
-    boolean isAlreadyRead();
-
-    /**
-     * Update the state if already read.
-     * @param alreadyRead indicated using true or false
-     */
-    void setAlreadyRead(boolean alreadyRead);
-
-    /**
      * This is need to release content before GC
      */
     void waitAndReleaseAllEntities();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -150,14 +150,6 @@ public class HTTPCarbonMessage {
         blockingEntityCollector.setEndOfMsgAdded(endOfMsgAdded);
     }
 
-    public boolean isAlreadyRead() {
-        return blockingEntityCollector.isAlreadyRead();
-    }
-
-    public void setAlreadyRead(boolean alreadyRead) {
-        blockingEntityCollector.setAlreadyRead(alreadyRead);
-    }
-
     /**
      * Returns the header map of the request.
      *

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -66,7 +66,6 @@ public class HttpMessageDataStreamer {
 
         @Override
         public int read() throws IOException {
-            httpCarbonMessage.setAlreadyRead(true); // TODO: No need to set this again and again
             if ((httpContent instanceof LastHttpContent) && chunkFinished) {
                 return -1;
             } else if (chunkFinished) {


### PR DESCRIPTION
## Purpose
> Finally, we were able to completed the subject. If you think of separation of concerns DataSource implementations are not really part of the transport but instead a part of the respective products that uses the transport. 

Hence, we have removed it from the transport.

## Goals
> Make the code more readable and manageable.

## Approach
> Moving the implementation to respective products.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Covered by existing ones.

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A