### PR TITLE
Fix transfer-encoding and test resource issue

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -137,46 +137,46 @@ public class Util {
         return outgoingRequest;
     }
 
+    public static void setupTransferEncodingForEmptyRequest(HTTPCarbonMessage httpOutboundRequest,
+            boolean chunkDisabled) {
+        if (chunkDisabled) {
+            httpOutboundRequest.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
+            httpOutboundRequest.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(0));
+        } else {
+            httpOutboundRequest.removeHeader(Constants.HTTP_CONTENT_LENGTH);
+            httpOutboundRequest.setHeader(Constants.HTTP_TRANSFER_ENCODING, Constants.CHUNKED);
+        }
+    }
+
     /**
      * Prepare request message with Transfer-Encoding/Content-Length
      *
-     * @param cMsg HTTPCarbonMessage
+     * @param httpOutboundRequest HTTPCarbonMessage
      */
-    public static void setupTransferEncodingForRequest(HTTPCarbonMessage cMsg, boolean chunkDisabled) {
+    public static void setupTransferEncodingForRequest(HTTPCarbonMessage httpOutboundRequest, boolean chunkDisabled) {
         if (chunkDisabled) {
-            cMsg.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
-            setContentLength(cMsg);
+            httpOutboundRequest.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
+            setContentLength(httpOutboundRequest);
         } else {
-            cMsg.removeHeader(Constants.HTTP_CONTENT_LENGTH);
-            setTransferEncodingHeader(cMsg);
+            httpOutboundRequest.removeHeader(Constants.HTTP_CONTENT_LENGTH);
+            setTransferEncodingHeader(httpOutboundRequest);
         }
     }
 
-    private static void setContentLength(HTTPCarbonMessage cMsg) {
-        if (cMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null && !cMsg.isEmpty()) {
-            int contentLength = cMsg.getFullMessageLength();
-            if (contentLength > 0) {
-                cMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
-            } else if (isEntityBodyAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
-                cMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(0));
-            }
+    private static void setContentLength(HTTPCarbonMessage httpOutboundRequest) {
+        if (httpOutboundRequest.getHeader(Constants.HTTP_CONTENT_LENGTH) == null) {
+            int contentLength = httpOutboundRequest.getFullMessageLength();
+            httpOutboundRequest.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
         }
     }
 
-    private static void setTransferEncodingHeader(HTTPCarbonMessage cMsg) {
-        if (cMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null && !cMsg.isEmpty()) {
-            HttpContent httpContent = cMsg.peek();
-            if (httpContent instanceof LastHttpContent) {
-                if (httpContent.content().readableBytes() == 0 &&
-                        !isEntityBodyAllowed(cMsg.getProperty(Constants.HTTP_METHOD).toString())) {
-                    return;
-                }
-            }
-            cMsg.setHeader(Constants.HTTP_TRANSFER_ENCODING, Constants.CHUNKED);
+    private static void setTransferEncodingHeader(HTTPCarbonMessage httpOutboundRequest) {
+        if (httpOutboundRequest.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {
+            httpOutboundRequest.setHeader(Constants.HTTP_TRANSFER_ENCODING, Constants.CHUNKED);
         }
     }
 
-    private static boolean isEntityBodyAllowed(String method) {
+    public static boolean isEntityBodyAllowed(String method) {
         return method.equals(Constants.HTTP_POST_METHOD) || method.equals(Constants.HTTP_PUT_METHOD)
                 || method.equals(Constants.HTTP_PATCH_METHOD);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannelListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannelListener.java
@@ -20,8 +20,6 @@ package org.wso2.transport.http.netty.sender.channel;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
@@ -33,8 +31,6 @@ import java.net.ConnectException;
  * A class that get executed when the connection is created.
  */
 public class TargetChannelListener implements ChannelFutureListener {
-
-    private static final Logger log = LoggerFactory.getLogger(TargetChannelListener.class);
 
     private TargetChannel targetChannel;
     private HTTPCarbonMessage httpCarbonRequest;
@@ -71,9 +67,9 @@ public class TargetChannelListener implements ChannelFutureListener {
 
     private boolean isValidateChannel(ChannelFuture channelFuture) throws Exception {
         if (channelFuture.isDone() && channelFuture.isSuccess()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Created the connection to address: {}", httpRoute.toString());
-            }
+//            if (log.isDebugEnabled()) {
+//                log.debug("Created the connection to address: {}", httpRoute.toString());
+//            }
             return true;
         }
         return false;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -61,7 +61,6 @@ public class CipherSuitesTest {
 
     private static HttpClientConnector httpClientConnector;
     private static String testValue = "successful";
-    private String scheme = "https";
     private String verifyClient = "require";
 
     @DataProvider(name = "ciphers")
@@ -103,7 +102,7 @@ public class CipherSuitesTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -119,7 +118,7 @@ public class CipherSuitesTest {
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(scheme);
+        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
         listenerConfiguration.setParameters(serverParams);
 
         ServerConnector serverConnector = factory

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -18,11 +18,6 @@
 
 package org.wso2.transport.http.netty.https;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -66,9 +61,6 @@ public class CipherSuitesTest {
 
     private static HttpClientConnector httpClientConnector;
     private static String testValue = "successful";
-    private String keyStoreFile = "src/test/resources/simple-test-config/wso2carbon.jks";
-    private String trustStoreFile = "src/test/resources/simple-test-config/client-truststore.jks";
-    private String password = "wso2carbon";
     private String scheme = "https";
     private String verifyClient = "require";
 
@@ -111,19 +103,22 @@ public class CipherSuitesTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            config.setKeyStoreFile(keyStoreFile);
-            config.setKeyStorePassword(password);
-            config.setParameters(clientParams);
+            if (config.getId().contains("https")) {
+                config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+                config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
+                config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
+                config.setParameters(clientParams);
+            }
         });
 
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
         listenerConfiguration.setVerifyClient(verifyClient);
-        listenerConfiguration.setTrustStoreFile(trustStoreFile);
-        listenerConfiguration.setKeyStoreFile(keyStoreFile);
-        listenerConfiguration.setTrustStorePass(password);
-        listenerConfiguration.setKeyStorePass(password);
+        listenerConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
+        listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+        listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
+        listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setScheme(scheme);
         listenerConfiguration.setParameters(serverParams);
 
@@ -145,13 +140,7 @@ public class CipherSuitesTest {
     public void testCiphersuites(boolean hasException, int serverPort) {
         try {
             ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(
-                    new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
-            msg.setProperty("PORT", serverPort);
-            msg.setProperty("PROTOCOL", scheme);
-            msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
 
             CountDownLatch latch = new CountDownLatch(1);
             SSLConnectorListener listener = new SSLConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -100,7 +100,7 @@ public class HTTPSClientTestCase {
             HttpResponseFuture responseFuture = httpClientConnector.send(msg);
             responseFuture.setHttpConnectorListener(listener);
 
-            latch.await(120, TimeUnit.SECONDS);
+            latch.await(5, TimeUnit.SECONDS);
 
             HTTPCarbonMessage response = listener.getHttpResponseMessage();
             assertNotNull(response);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -71,7 +71,7 @@ public class HTTPSClientTestCase {
                 TestUtil.getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
             }
         });
@@ -90,7 +90,7 @@ public class HTTPSClientTestCase {
             HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                                                                                  HttpMethod.GET, ""));
             msg.setProperty("PORT", TestUtil.TEST_HTTPS_SERVER_PORT);
-            msg.setProperty("PROTOCOL", "https");
+            msg.setProperty("PROTOCOL", TestUtil.HTTPS_SCHEME);
             msg.setProperty("HOST", "localhost");
             msg.setProperty("HTTP_METHOD", "GET");
             msg.setEndOfMsgAdded(true);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -59,7 +59,6 @@ public class MutualSSLTestCase {
 
     private static HttpClientConnector httpClientConnector;
     private static String testValue = "Test";
-    private String scheme = "https";
     private String verifyClient = "require";
     private static int serverPort = 9095;
 
@@ -69,7 +68,7 @@ public class MutualSSLTestCase {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -86,7 +85,7 @@ public class MutualSSLTestCase {
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setCertPass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(scheme);
+        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
 
         ServerConnector connector = factory
                 .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -18,11 +18,6 @@
 
 package org.wso2.transport.http.netty.https;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -64,9 +59,6 @@ public class MutualSSLTestCase {
 
     private static HttpClientConnector httpClientConnector;
     private static String testValue = "Test";
-    private String keyStoreFile = "src/test/resources/simple-test-config/wso2carbon.jks";
-    private String trustStoreFile = "src/test/resources/simple-test-config/client-truststore.jks";
-    private String password = "wso2carbon";
     private String scheme = "https";
     private String verifyClient = "require";
     private static int serverPort = 9095;
@@ -77,8 +69,11 @@ public class MutualSSLTestCase {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            config.setKeyStoreFile(keyStoreFile);
-            config.setKeyStorePassword(password);
+            if (config.getId().contains("https")) {
+                config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+                config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
+                config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
+            }
         });
 
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
@@ -86,11 +81,11 @@ public class MutualSSLTestCase {
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
         listenerConfiguration.setVerifyClient(verifyClient);
-        listenerConfiguration.setTrustStoreFile(trustStoreFile);
-        listenerConfiguration.setKeyStoreFile(keyStoreFile);
-        listenerConfiguration.setTrustStorePass(password);
-        listenerConfiguration.setKeyStorePass(password);
-        listenerConfiguration.setCertPass(password);
+        listenerConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
+        listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+        listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
+        listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
+        listenerConfiguration.setCertPass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setScheme(scheme);
 
         ServerConnector connector = factory
@@ -105,16 +100,10 @@ public class MutualSSLTestCase {
     }
 
     @Test
-    public void testHttpsGet() {
+    public void testHttpsPost() {
         try {
             ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, ""));
-            msg.setProperty("PORT", serverPort);
-            msg.setProperty("PROTOCOL", scheme);
-            msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -62,7 +62,6 @@ public class SSLProtocolsTest {
     private static HttpClientConnector httpClientConnector;
     private static ServerConnector serverConnector;
     private static String testValue = "Test";
-    private String scheme = "https";
     private String verifyClient = "require";
 
     @DataProvider(name = "protocols")
@@ -98,7 +97,7 @@ public class SSLProtocolsTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -114,7 +113,7 @@ public class SSLProtocolsTest {
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(scheme);
+        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
         listenerConfiguration.setParameters(severParams);
         serverConnector = factory
                 .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -18,11 +18,6 @@
 
 package org.wso2.transport.http.netty.https;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -67,9 +62,6 @@ public class SSLProtocolsTest {
     private static HttpClientConnector httpClientConnector;
     private static ServerConnector serverConnector;
     private static String testValue = "Test";
-    private String keyStoreFile = "src/test/resources/simple-test-config/wso2carbon.jks";
-    private String trustStoreFile = "src/test/resources/simple-test-config/client-truststore.jks";
-    private String password = "wso2carbon";
     private String scheme = "https";
     private String verifyClient = "require";
 
@@ -106,19 +98,22 @@ public class SSLProtocolsTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            config.setKeyStoreFile(keyStoreFile);
-            config.setKeyStorePassword(password);
-            config.setParameters(clientParams);
+            if (config.getId().contains("https")) {
+                config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+                config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
+                config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
+                config.setParameters(clientParams);
+            }
         });
 
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
         listenerConfiguration.setVerifyClient(verifyClient);
-        listenerConfiguration.setTrustStoreFile(trustStoreFile);
-        listenerConfiguration.setKeyStoreFile(keyStoreFile);
-        listenerConfiguration.setTrustStorePass(password);
-        listenerConfiguration.setKeyStorePass(password);
+        listenerConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
+        listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
+        listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
+        listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setScheme(scheme);
         listenerConfiguration.setParameters(severParams);
         serverConnector = factory
@@ -126,22 +121,18 @@ public class SSLProtocolsTest {
         ServerConnectorFuture future = serverConnector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
+
         httpClientConnector = factory
                 .createHttpClientConnector(HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
                         HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME));
+
         testSSLProtocols(hasException, serverPort);
     }
 
     public void testSSLProtocols(boolean hasException, int serverPort) {
         try {
             ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(
-                    new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
-            msg.setProperty("PORT", serverPort);
-            msg.setProperty("PROTOCOL", scheme);
-            msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
 
             CountDownLatch latch = new CountDownLatch(1);
             SSLConnectorListener listener = new SSLConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
@@ -52,7 +52,7 @@ public class PassThroughHttpTestCase {
     @BeforeClass
     public void setUp() {
         TransportsConfiguration configuration = YAMLTransportConfigurationBuilder
-                .build("src/test/resources/simple-test-config/netty-transports.yml");
+                .build(TestUtil.getAbsolutePath("/simple-test-config/netty-transports.yml"));
         serverConnectors = TestUtil.startConnectors(
                 configuration, new PassthroughMessageProcessorListener(configuration));
         httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTP_SERVER_PORT,

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -60,8 +60,8 @@ public class PKCSTest {
 
     private static HttpClientConnector httpClientConnector;
     private static String testValue = "Test";
-    private String keyStoreFile = "src/test/resources/simple-test-config/wso2carbon.p12";
-    private String trustStoreFile = "src/test/resources/simple-test-config/client-truststore.p12";
+    private String keyStoreFile = "/simple-test-config/wso2carbon.p12";
+    private String trustStoreFile = "/simple-test-config/client-truststore.p12";
     private String password = "ballerina";
     private String scheme = "https";
     private String tlsStoreType = "PKCS12";
@@ -76,9 +76,11 @@ public class PKCSTest {
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         //set PKCS12 truststore to ballerina client.
         senderConfig.forEach(config -> {
-            config.setTrustStoreFile(trustStoreFile);
-            config.setTrustStorePass(password);
-            config.setTlsStoreType(tlsStoreType);
+            if (config.getId().contains("https")) {
+                config.setTrustStoreFile(TestUtil.getAbsolutePath(trustStoreFile));
+                config.setTrustStorePass(password);
+                config.setTlsStoreType(tlsStoreType);
+            }
         });
 
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
@@ -86,7 +88,7 @@ public class PKCSTest {
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
         //set PKCS12 keystore to ballerina server.
-        listenerConfiguration.setKeyStoreFile(keyStoreFile);
+        listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(keyStoreFile));
         listenerConfiguration.setKeyStorePass(password);
         listenerConfiguration.setCertPass(password);
         listenerConfiguration.setScheme(scheme);
@@ -112,7 +114,7 @@ public class PKCSTest {
             msg.setProperty("PORT", serverPort);
             msg.setProperty("PROTOCOL", scheme);
             msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", "GET");
+            msg.setProperty("HTTP_METHOD", "POST");
             msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
 
             CountDownLatch latch = new CountDownLatch(1);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -114,7 +114,7 @@ public class PKCSTest {
             msg.setProperty("PORT", serverPort);
             msg.setProperty("PROTOCOL", scheme);
             msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", "POST");
+            msg.setProperty("HTTP_METHOD", Constants.HTTP_POST_METHOD);
             msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
 
             CountDownLatch latch = new CountDownLatch(1);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -76,7 +76,7 @@ public class PKCSTest {
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         //set PKCS12 truststore to ballerina client.
         senderConfig.forEach(config -> {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(trustStoreFile));
                 config.setTrustStorePass(password);
                 config.setTlsStoreType(tlsStoreType);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
@@ -93,7 +93,7 @@ public class ProxyServerTestCase {
         //set proxy server configuration to client connector.
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         for (SenderConfiguration config : senderConfig) {
-            if (config.getId().contains("https")) {
+            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
             }
             config.setProxyServerConfiguration(proxyServerConfiguration);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
@@ -70,7 +70,6 @@ public class ProxyServerTestCase {
     private static HttpClientConnector httpClientConnector;
     private static ServerConnector serverConnector;
     private static String testValue = "Test";
-    private String scheme = "https";
     private static int serverPort = 8081;
     private ClientAndProxy proxy;
     private String password = "wso2carbon";
@@ -103,7 +102,7 @@ public class ProxyServerTestCase {
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
-        listenerConfiguration.setScheme(scheme);
+        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(password);
         serverConnector = factory
@@ -114,7 +113,7 @@ public class ProxyServerTestCase {
 
         httpClientConnector = factory
                 .createHttpClientConnector(HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
-                        HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, scheme));
+                        HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, TestUtil.HTTPS_SCHEME));
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -19,9 +19,13 @@
 package org.wso2.transport.http.netty.util;
 
 import com.google.common.io.ByteStreams;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.apache.commons.io.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +40,7 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.HttpsServer;
@@ -52,6 +57,7 @@ import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,6 +85,9 @@ public class TestUtil {
     public static final String TEST_HOST = "localhost";
     public static final long HTTP2_RESPONSE_TIME_OUT = 30;
     public static final TimeUnit HTTP2_RESPONSE_TIME_UNIT = TimeUnit.SECONDS;
+    public static final String KEY_STORE_FILE_PATH = "/simple-test-config/wso2carbon.jks";
+    public static final String TRUST_STORE_FILE_PATH = "/simple-test-config/client-truststore.jks";
+    public static final String KEY_STORE_PASSWORD = "wso2carbon";
     private static List<ServerConnector> connectors;
     private static List<ServerConnectorFuture> futures;
 
@@ -235,6 +244,21 @@ public class TestUtil {
         }
 
         return transportsConfiguration;
+    }
+
+    public static String getAbsolutePath(String relativePath) {
+        return TestUtil.class.getResource(relativePath).getFile();
+    }
+
+    public static HTTPCarbonMessage createHttpsRequest(int serverPort, ByteBuffer byteBuffer) {
+        HTTPCarbonMessage msg = new HTTPCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
+        msg.setProperty("PORT", serverPort);
+        msg.setProperty("PROTOCOL", "https");
+        msg.setProperty("HOST", TestUtil.TEST_HOST);
+        msg.setProperty("HTTP_METHOD", "POST");
+        msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+        return msg;
     }
 }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.Charsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.config.TransportProperty;
 import org.wso2.transport.http.netty.config.TransportsConfiguration;
@@ -88,6 +89,7 @@ public class TestUtil {
     public static final String KEY_STORE_FILE_PATH = "/simple-test-config/wso2carbon.jks";
     public static final String TRUST_STORE_FILE_PATH = "/simple-test-config/client-truststore.jks";
     public static final String KEY_STORE_PASSWORD = "wso2carbon";
+    public static final String HTTPS_SCHEME = "https";
     private static List<ServerConnector> connectors;
     private static List<ServerConnectorFuture> futures;
 
@@ -254,9 +256,9 @@ public class TestUtil {
         HTTPCarbonMessage msg = new HTTPCarbonMessage(
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
         msg.setProperty("PORT", serverPort);
-        msg.setProperty("PROTOCOL", "https");
+        msg.setProperty("PROTOCOL", TestUtil.HTTPS_SCHEME);
         msg.setProperty("HOST", TestUtil.TEST_HOST);
-        msg.setProperty("HTTP_METHOD", "POST");
+        msg.setProperty("HTTP_METHOD", Constants.HTTP_POST_METHOD);
         msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
         return msg;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpsServer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpsServer.java
@@ -51,7 +51,6 @@ public class HttpsServer implements TestServer {
     private SSLContext sslContext;
     private ChannelInitializer channelInitializer;
 
-    String ksName = "src/test/resources/simple-test-config/wso2carbon.jks";
     char ksPass[] = "wso2carbon".toCharArray();
     char ctPass[] = "wso2carbon".toCharArray();
 
@@ -73,7 +72,7 @@ public class HttpsServer implements TestServer {
             b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 15000);
 
             KeyStore ks = KeyStore.getInstance("JKS");
-            ks.load(new FileInputStream(ksName), ksPass);
+            ks.load(new FileInputStream(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH)), ksPass);
             KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
             kmf.init(ks, ctPass);
 

--- a/components/org.wso2.transport.http.netty/src/test/resources/simple-test-config/netty-transports.yml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/simple-test-config/netty-transports.yml
@@ -122,7 +122,7 @@ senderConfigurations:
  -
   id: "https-sender"
   scheme: "https"
-  trustStoreFile: "src/test/resources/simple-test-config/wso2carbon.jks"
+  trustStoreFile: "/simple-test-config/wso2carbon.jks"
   trustStorePass: "wso2carbon"
   socketIdleTimeout: 120000
   parameters:


### PR DESCRIPTION
## Purpose
> There was an issue identified while removing DataSource. It is been fixed with this PR. Basically, when we check the condition for transfer-encoding we also check for the message payload. This logic had some issues when it comes to multi threading. 

## Goals
> Improve the code to handle multi-threading scenarios. 

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Covered by existing ones.

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A