### PR TITLE
Remove message future after a finishing the writing of a response

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -80,6 +80,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                     if (handlerExecutor != null) {
                         handlerExecutor.executeAtSourceResponseSending(httpResponseMessage);
                     }
+                    httpResponseMessage.removeHttpContentAsyncFuture();
                 } else {
                     sourceContext.write(httpContent);
                 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BlockingEntityCollector.java
@@ -136,7 +136,6 @@ public class BlockingEntityCollector implements EntityCollector {
                     if (httpContent instanceof LastHttpContent) {
                         isEndOfMessageProcessed = true;
                         isConsumed.set(true);
-                        isExpectingEntity.set(true);
                     }
                     httpContent.release();
                 } catch (InterruptedException e) {
@@ -144,6 +143,7 @@ public class BlockingEntityCollector implements EntityCollector {
                 }
             }
         }
+        isExpectingEntity.set(true);
     }
 
     @Deprecated


### PR DESCRIPTION
## Purpose
> Currently, the message future is not removed from the response message after sending the response. Also, when releasing the entities, the `expectingEntity` property was placed in the wrong section in the `waitAndReleaseAllEntities()` method. This caused issues when using the same response message in the 100 continue scenario, with the client not receiving a content length header which in turn resulted in the client hanging.

## Goals
> * Remove the message future after the response is sent.
> * Set the `isExpectingEntity` property outside of the check to verify whether the message has already been consumed.
