### PR TITLE
Pass the channel promise to write() in trace log handler

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HTTPTraceLoggingHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HTTPTraceLoggingHandler.java
@@ -88,7 +88,7 @@ public class HTTPTraceLoggingHandler extends LoggingHandler {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, EVENT_OUTBOUND, msg));
         }
-        ctx.write(msg);
+        ctx.write(msg, promise);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Fix the issue with the call to write() in trace logging handler not being passed the channel promise.

## Goals
> Pass the channel promise to write()

