### PR TITLE
Adding every headers instead of setAll in out going message

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -108,7 +108,9 @@ public class Util {
             msg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
         }
 
-        outgoingResponse.headers().setAll(msg.getHeaders());
+        for (Map.Entry<String, String> entry : msg.getHeaders()) {
+            outgoingResponse.headers().add(entry.getKey(), entry.getValue());
+        }
 
         return outgoingResponse;
     }


### PR DESCRIPTION
## Purpose
When headers are added to the outgoing message using setAll, if a header string is already present, this is removed and the new value is set. Since some http headers can be in multiple numbers such as Set-Cookie header, this behavior is not optimal.

## Goals
Stop removal of headers when headers with same key is present.

## Approach
Iterated through the headers and called add method, which does not remove headers if present.

## User stories
N/A

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests N/A
 - Integration tests N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK1.8
 
## Learning
N/A