### PR TITLE
Remove Carbon Component header from pom.xml of org.wso2.transport.http.netty

### DIFF
--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -208,11 +208,5 @@
             org.wso2.carbon.messaging.*;version="${carbon.messaging.package.import.version.range}",
             org.apache.commons.pool.*;version="${commons.pool.package.import.version.range}",
         </import.package>
-        <carbon.component>
-            startup.connectorListener;componentName="netty-transports-mgt";
-            requiredService="org.wso2.carbon.messaging.CarbonTransportInitializer,
-            org.wso2.carbon.messaging.CarbonMessageProcessor",
-            osgi.service; objectClass="org.wso2.carbon.messaging.ServerConnectorProvider"
-        </carbon.component>
     </properties>
 </project>

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportServiceComponent.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/HTTPTransportServiceComponent.java
@@ -26,7 +26,6 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.kernel.startupresolver.RequiredCapabilityListener;
 import org.wso2.carbon.messaging.CarbonMessageProcessor;
 
 /**
@@ -35,12 +34,9 @@ import org.wso2.carbon.messaging.CarbonMessageProcessor;
  */
 @Component(
         name = "org.wso2.carbon.transport.http.netty.internal.HTTPTransportServiceComponent",
-        immediate = true,
-        property = {
-                "componentName=netty-transports-mgt"
-        })
-@SuppressWarnings("unused")
-public class HTTPTransportServiceComponent implements RequiredCapabilityListener {
+        immediate = true)
+@Deprecated
+public class HTTPTransportServiceComponent {
 
     private static final Logger log = LoggerFactory.getLogger(HTTPTransportServiceComponent.class);
 
@@ -79,12 +75,5 @@ public class HTTPTransportServiceComponent implements RequiredCapabilityListener
 
     protected void removeNettyStatHandler(MessagingHandler messagingHandler) {
         HTTPTransportContextHolder.getInstance().getHandlerExecutor().removeHandler(messagingHandler);
-    }
-
-    @Override
-    public void onAllRequiredCapabilitiesAvailable() {
-        HTTPTransportContextHolder.getInstance().getBundleContext().
-                registerService(HTTPTransportServiceComponent.class, this, null);
-        log.info("All CarbonHTTPServerInitializers are available");
     }
 }


### PR DESCRIPTION
## Purpose
`Carbon-Component` header in the `pom.xml` file of `org.wso2.transport.http.netty` module cases to generate following WARN log from Carbon Startup Resolver.
```
WARN {org.wso2.carbon.kernel.internal.startupresolver.StartupComponentManager} - Adding a RequiredCapabilityListener from bundle(org.wso2.transport.http.netty:6.0.63), but specified startup component is not available, component-name: netty-transports-mgt
```
Fixes https://github.com/wso2/product-sp/issues/331

## Goals
- Not causing WARN log

## Approach
- Remove `<carbon.component>` property from `pom.xml` file of `org.wso2.transport.http.netty` module
- Remove `componentName` property from OSGi `@Component` annotation in `HTTPTransportServiceComponent` class

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
