### PR TITLE
Remove blocking calculation of Content-Length

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -272,21 +272,21 @@ public final class Constants {
     public static final String HTTP_TRACE_LOG_HANDLER = "http-trace-logger";
     public static final String WEBSOCKET_SERVER_HANDSHAKE_HANDLER = "websocket-server-handshake-handler";
 
-    public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.<Integer>valueOf
+    public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf
             ("REDIRECT_COUNT");
-    public static final AttributeKey<HTTPCarbonMessage> ORIGINAL_REQUEST = AttributeKey.<HTTPCarbonMessage>valueOf
+    public static final AttributeKey<HTTPCarbonMessage> ORIGINAL_REQUEST = AttributeKey.valueOf
             ("ORIGINAL_REQUEST");
     public static final AttributeKey<HttpResponseFuture> RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL = AttributeKey
-            .<HttpResponseFuture>valueOf
+            .valueOf
             ("RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL");
     public static final AttributeKey<Long> ORIGINAL_CHANNEL_START_TIME = AttributeKey
-            .<Long>valueOf
+            .valueOf
                     ("ORIGINAL_CHANNEL_START_TIME");
     public static final AttributeKey<Integer> ORIGINAL_CHANNEL_TIMEOUT = AttributeKey
-            .<Integer>valueOf
+            .valueOf
                     ("ORIGINAL_CHANNEL_TIMEOUT");
     public static final AttributeKey<TargetChannel> TARGET_CHANNEL_REFERENCE = AttributeKey
-            .<TargetChannel>valueOf
+            .valueOf
                     ("TARGET_CHANNEL_REFERENCE");
 
     public static final String UTF8 = "UTF-8";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -19,23 +19,18 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
-import org.wso2.carbon.messaging.Header;
-import org.wso2.carbon.messaging.Headers;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.config.Parameter;
 import org.wso2.transport.http.netty.listener.RequestDataHolder;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.io.File;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -50,23 +45,6 @@ public class Util {
 
     private static final String DEFAULT_HTTP_METHOD_POST = "POST";
     private static final String DEFAULT_VERSION_HTTP_1_1 = "HTTP/1.1";
-
-    public static Headers getHeaders(HttpMessage message) {
-        List<Header> headers = new LinkedList<>();
-        if (message.headers() != null) {
-            for (Map.Entry<String, String> k : message.headers().entries()) {
-                headers.add(new Header(k.getKey(), k.getValue()));
-            }
-        }
-        return new Headers(headers);
-    }
-
-    public static void setHeaders(HttpMessage message, Headers headers) {
-        HttpHeaders httpHeaders = message.headers();
-        for (Header header : headers.getAll()) {
-            httpHeaders.add(header.getName(), header.getValue());
-        }
-    }
 
     private static String getStringValue(HTTPCarbonMessage msg, String key, String defaultValue) {
         String value = (String) msg.getProperty(key);
@@ -86,55 +64,74 @@ public class Util {
         return value;
     }
 
-    public static HttpResponse createHttpResponse(HTTPCarbonMessage msg) {
-        return createHttpResponse(msg, false);
-    }
-
     @SuppressWarnings("unchecked")
-    public static HttpResponse createHttpResponse(HTTPCarbonMessage msg, boolean keepAlive) {
-        HttpVersion httpVersion = new HttpVersion(Util.getStringValue(msg, Constants.HTTP_VERSION, HTTP_1_1.text()),
-                true);
+    public static HttpResponse createHttpResponse(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive) {
+        HttpVersion httpVersion = new HttpVersion(Util
+                .getStringValue(outboundResponseMsg, Constants.HTTP_VERSION, HTTP_1_1.text()), true);
+        HttpResponseStatus httpResponseStatus = getHttpResponseStatus(outboundResponseMsg);
 
-        int statusCode = Util.getIntValue(msg, Constants.HTTP_STATUS_CODE, 200);
-
-        String reasonPhrase = Util.getStringValue(msg, Constants.HTTP_REASON_PHRASE,
-                HttpResponseStatus.valueOf(statusCode).reasonPhrase());
-
-        HttpResponseStatus httpResponseStatus = new HttpResponseStatus(statusCode, reasonPhrase);
-
-        DefaultHttpResponse outgoingResponse = new DefaultHttpResponse(httpVersion, httpResponseStatus, false);
+        HttpResponse outboundNettyResponse = new DefaultHttpResponse(httpVersion, httpResponseStatus, false);
+        outboundNettyResponse.setProtocolVersion(httpVersion);
+        outboundNettyResponse.setStatus(httpResponseStatus);
 
         if (!keepAlive) {
-            msg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
+            outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
         }
 
-        outgoingResponse.headers().setAll(msg.getHeaders());
+        outboundNettyResponse.headers().setAll(outboundResponseMsg.getHeaders());
 
-        return outgoingResponse;
+        return outboundNettyResponse;
+    }
+
+    private static HttpResponseStatus getHttpResponseStatus(HTTPCarbonMessage msg) {
+        int statusCode = Util.getIntValue(msg, Constants.HTTP_STATUS_CODE, 200);
+        String reasonPhrase = Util.getStringValue(msg, Constants.HTTP_REASON_PHRASE,
+                HttpResponseStatus.valueOf(statusCode).reasonPhrase());
+        return new HttpResponseStatus(statusCode, reasonPhrase);
     }
 
     @SuppressWarnings("unchecked")
-    public static HttpRequest createHttpRequest(HTTPCarbonMessage msg) {
-        HttpMethod httpMethod;
-        if (null != msg.getProperty(Constants.HTTP_METHOD)) {
-            httpMethod = new HttpMethod((String) msg.getProperty(Constants.HTTP_METHOD));
-        } else {
-            httpMethod = new HttpMethod(DEFAULT_HTTP_METHOD_POST);
+    public static HttpRequest createHttpRequest(HTTPCarbonMessage outboundRequestMsg) {
+        HttpMethod httpMethod = getHttpMethod(outboundRequestMsg);
+        HttpVersion httpVersion = getHttpVersion(outboundRequestMsg);
+        String requestPath = getRequestPath(outboundRequestMsg);
+
+        HttpRequest outboundNettyRequest = new DefaultHttpRequest(httpVersion, httpMethod,
+                (String) outboundRequestMsg.getProperty(Constants.TO), false);
+        outboundNettyRequest.setMethod(httpMethod);
+        outboundNettyRequest.setProtocolVersion(httpVersion);
+        outboundNettyRequest.setUri(requestPath);
+
+        outboundNettyRequest.headers().setAll(outboundRequestMsg.getHeaders());
+
+        return outboundNettyRequest;
+    }
+
+    private static String getRequestPath(HTTPCarbonMessage outboundRequestMsg) {
+        if (outboundRequestMsg.getProperty(Constants.TO) == null) {
+            outboundRequestMsg.setProperty(Constants.TO, "");
         }
+        return (String) outboundRequestMsg.getProperty(Constants.TO);
+    }
+
+    private static HttpVersion getHttpVersion(HTTPCarbonMessage outboundRequestMsg) {
         HttpVersion httpVersion;
-        if (null != msg.getProperty(Constants.HTTP_VERSION)) {
-            httpVersion = new HttpVersion((String) msg.getProperty(Constants.HTTP_VERSION), true);
+        if (null != outboundRequestMsg.getProperty(Constants.HTTP_VERSION)) {
+            httpVersion = new HttpVersion((String) outboundRequestMsg.getProperty(Constants.HTTP_VERSION), true);
         } else {
             httpVersion = new HttpVersion(DEFAULT_VERSION_HTTP_1_1, true);
         }
-        if ((String) msg.getProperty(Constants.TO) == null) {
-            msg.setProperty(Constants.TO, "/");
+        return httpVersion;
+    }
+
+    private static HttpMethod getHttpMethod(HTTPCarbonMessage outboundRequestMsg) {
+        HttpMethod httpMethod;
+        if (null != outboundRequestMsg.getProperty(Constants.HTTP_METHOD)) {
+            httpMethod = new HttpMethod((String) outboundRequestMsg.getProperty(Constants.HTTP_METHOD));
+        } else {
+            httpMethod = new HttpMethod(DEFAULT_HTTP_METHOD_POST);
         }
-        HttpRequest outgoingRequest = new DefaultHttpRequest(httpVersion, httpMethod,
-                (String) msg.getProperty(Constants.TO), false);
-        HttpHeaders headers = msg.getHeaders();
-        outgoingRequest.headers().setAll(headers);
-        return outgoingRequest;
+        return httpMethod;
     }
 
     public static void setupTransferEncodingForEmptyRequest(HTTPCarbonMessage httpOutboundRequest,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -203,7 +203,7 @@ public class Util {
         // 2. Check for transfer encoding header is set in the request
         // As per RFC 2616, Section 4.4, Content-Length must be ignored if Transfer-Encoding header
         // is present and its value not equal to 'identity'
-        String requestTransferEncodingHeader = requestDataHolder.getTransferEncodingHeader();
+        String requestTransferEncodingHeader = requestDataHolder.getTransferEncodingHeaderValue();
         if (requestTransferEncodingHeader != null &&
             !Constants.HTTP_TRANSFER_ENCODING_IDENTITY.equalsIgnoreCase(requestTransferEncodingHeader)) {
             outboundResMsg.setHeader(Constants.HTTP_TRANSFER_ENCODING, requestTransferEncodingHeader);
@@ -212,7 +212,7 @@ public class Util {
         }
 
         // 3. Check for request Content-Length header
-        String requestContentLength = requestDataHolder.getContentLengthHeader();
+        String requestContentLength = requestDataHolder.getContentLengthHeaderValue();
         if (requestContentLength != null &&
             (outboundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null)) {
             int contentLength = outboundResMsg.getFullMessageLength();
@@ -237,25 +237,20 @@ public class Util {
         // 2. Check for transfer encoding header is set in the request
         // As per RFC 2616, Section 4.4, Content-Length must be ignored if Transfer-Encoding header
         // is present and its value not equal to 'identity'
-        String requestTransferEncodingHeader = requestDataHolder.getTransferEncodingHeader();
-        if (requestTransferEncodingHeader != null &&
-                !Constants.HTTP_TRANSFER_ENCODING_IDENTITY.equalsIgnoreCase(requestTransferEncodingHeader)) {
+        String inboundReqTransferEncodingHeaderValue = requestDataHolder.getTransferEncodingHeaderValue();
+        if (inboundReqTransferEncodingHeaderValue != null &&
+                !Constants.HTTP_TRANSFER_ENCODING_IDENTITY.equalsIgnoreCase(inboundReqTransferEncodingHeaderValue)) {
             return true;
         }
 
         // 3. Check for request Content-Length header
-        String requestContentLength = requestDataHolder.getContentLengthHeader();
-        if (requestContentLength != null &&
-                (outboundResMsg.getHeader(Constants.HTTP_CONTENT_LENGTH) == null)) {
+        String requestContentLength = requestDataHolder.getContentLengthHeaderValue();
+        if (requestContentLength != null) {
             return false;
         }
 
         // 4. If request doesn't have Transfer-Encoding or Content-Length header look for response properties
-        if (outboundResMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) != null) {
-            return true;
-        } else {
-            return true;
-        }
+        return outboundResMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) != null;
     }
 
     public static SSLConfig getSSLConfigForListener(String certPass, String keyStorePass, String keyStoreFilePath,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -22,6 +22,7 @@ package org.wso2.transport.http.netty.contractimpl;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
@@ -30,6 +31,9 @@ import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.listener.RequestDataHolder;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Get executed when the response is available.
@@ -40,6 +44,10 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     private RequestDataHolder requestDataHolder;
     private HandlerExecutor handlerExecutor;
     private HTTPCarbonMessage inboundRequestMsg;
+    private boolean isChunked;
+    private boolean isHeadersWritten = false;
+    private int contentLength = 0;
+    private List<HttpContent> contentList = new ArrayList<>();
 
     public HttpOutboundRespListener(ChannelHandlerContext channelHandlerContext, HTTPCarbonMessage requestMsg) {
         this.sourceContext = channelHandlerContext;
@@ -49,21 +57,34 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     }
 
     @Override
-    public void onMessage(HTTPCarbonMessage httpResponseMessage) {
+    public void onMessage(HTTPCarbonMessage outboundResponseMsg) {
         sourceContext.channel().eventLoop().execute(() -> {
-            boolean keepAlive = isKeepAlive(httpResponseMessage);
 
             if (handlerExecutor != null) {
-                handlerExecutor.executeAtSourceResponseReceiving(httpResponseMessage);
+                handlerExecutor.executeAtSourceResponseReceiving(outboundResponseMsg);
             }
 
-            Util.setupTransferEncodingAndContentTypeForResponse(httpResponseMessage, requestDataHolder);
-            final HttpResponse response = Util.createHttpResponse(httpResponseMessage, keepAlive);
-            sourceContext.write(response);
+            boolean keepAlive = isKeepAlive(outboundResponseMsg);
+            isChunked = Util.isChunkedOutboundResponse(outboundResponseMsg, requestDataHolder);
 
-            httpResponseMessage.getHttpContentAsync().setMessageListener(httpContent ->
+            outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent ->
                     this.sourceContext.channel().eventLoop().execute(() -> {
                 if (Util.isLastHttpContent(httpContent)) {
+                    if (!isHeadersWritten) {
+                        if (isChunked) {
+                            Util.setupChunkedRequest(outboundResponseMsg);
+                        } else {
+                            contentLength += httpContent.content().readableBytes();
+                            Util.setupContentLengthRequest(outboundResponseMsg, contentLength);
+                        }
+                        writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+                    }
+
+                    if (!isChunked) {
+                        for (HttpContent cachedHttpContent : contentList) {
+                            sourceContext.writeAndFlush(cachedHttpContent);
+                        }
+                    }
                     ChannelFuture outboundChannelFuture = sourceContext.writeAndFlush(httpContent);
                     HttpResponseStatusFuture outboundRespStatusFuture =
                             inboundRequestMsg.getHttpOutboundRespStatusFuture();
@@ -74,15 +95,27 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                             outboundRespStatusFuture.notifyHttpListener(inboundRequestMsg);
                         }
                     });
+
                     if (!keepAlive) {
                         outboundChannelFuture.addListener(ChannelFutureListener.CLOSE);
                     }
                     if (handlerExecutor != null) {
-                        handlerExecutor.executeAtSourceResponseSending(httpResponseMessage);
+                        handlerExecutor.executeAtSourceResponseSending(outboundResponseMsg);
                     }
-                    httpResponseMessage.removeHttpContentAsyncFuture();
+                    outboundResponseMsg.removeHttpContentAsyncFuture();
+                    contentList.clear();
+                    contentLength = 0;
                 } else {
-                    sourceContext.writeAndFlush(httpContent);
+                    if (isChunked) {
+                        if (!isHeadersWritten) {
+                            Util.setupChunkedRequest(outboundResponseMsg);
+                            writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+                        }
+                        sourceContext.writeAndFlush(httpContent);
+                    } else {
+                        this.contentList.add(httpContent);
+                        contentLength += httpContent.content().readableBytes();
+                    }
                 }
             }));
         });
@@ -104,5 +137,11 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     @Override
     public void onError(Throwable throwable) {
 
+    }
+
+    private void writeOutboundResponseHeaders(HTTPCarbonMessage httpOutboundRequest, boolean keepAlive) {
+        HttpResponse response = Util.createHttpResponse(httpOutboundRequest, keepAlive);
+        isHeadersWritten = true;
+        sourceContext.write(response);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -124,7 +124,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     // Decides whether to close the connection after sending the response
     private boolean isKeepAlive(HTTPCarbonMessage responseMsg) {
         String responseConnectionHeader = responseMsg.getHeader(Constants.HTTP_CONNECTION);
-        String requestConnectionHeader = requestDataHolder.getConnectionHeader();
+        String requestConnectionHeader = requestDataHolder.getConnectionHeaderValue();
         if ((responseConnectionHeader != null &&
                 Constants.CONNECTION_CLOSE.equalsIgnoreCase(responseConnectionHeader))
                 || (requestConnectionHeader != null &&

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -45,7 +45,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     private HandlerExecutor handlerExecutor;
     private HTTPCarbonMessage inboundRequestMsg;
     private boolean isChunked;
-    private boolean isHeadersWritten = false;
+    private boolean isHeaderWritten = false;
     private int contentLength = 0;
     private List<HttpContent> contentList = new ArrayList<>();
 
@@ -70,7 +70,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
             outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent ->
                     this.sourceContext.channel().eventLoop().execute(() -> {
                 if (Util.isLastHttpContent(httpContent)) {
-                    if (!isHeadersWritten) {
+                    if (!isHeaderWritten) {
                         if (isChunked) {
                             Util.setupChunkedRequest(outboundResponseMsg);
                         } else {
@@ -107,7 +107,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                     contentLength = 0;
                 } else {
                     if (isChunked) {
-                        if (!isHeadersWritten) {
+                        if (!isHeaderWritten) {
                             Util.setupChunkedRequest(outboundResponseMsg);
                             writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
                         }
@@ -141,7 +141,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
 
     private void writeOutboundResponseHeaders(HTTPCarbonMessage httpOutboundRequest, boolean keepAlive) {
         HttpResponse response = Util.createHttpResponse(httpOutboundRequest, keepAlive);
-        isHeadersWritten = true;
+        isHeaderWritten = true;
         sourceContext.write(response);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/RequestDataHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/RequestDataHolder.java
@@ -27,19 +27,19 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
  */
 public class RequestDataHolder {
 
-    private String acceptEncodingHeader;
-    private String connectionHeader;
-    private String contentTypeHeader;
-    private String transferEncodingHeader;
-    private String contentLengthHeader;
+    private String acceptEncodingHeaderValue;
+    private String connectionHeaderValue;
+    private String contentTypeHeaderValue;
+    private String transferEncodingHeaderValue;
+    private String contentLengthHeaderValue;
     private String httpMethod;
 
     public RequestDataHolder(HTTPCarbonMessage requestMessage) {
-        acceptEncodingHeader = requestMessage.getHeader(Constants.ACCEPT_ENCODING);
-        connectionHeader = requestMessage.getHeader(Constants.HTTP_CONNECTION);
-        contentTypeHeader = requestMessage.getHeader(Constants.HTTP_CONTENT_TYPE);
-        transferEncodingHeader = requestMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING);
-        contentLengthHeader = requestMessage.getHeader(Constants.HTTP_CONTENT_LENGTH);
+        acceptEncodingHeaderValue = requestMessage.getHeader(Constants.ACCEPT_ENCODING);
+        connectionHeaderValue = requestMessage.getHeader(Constants.HTTP_CONNECTION);
+        contentTypeHeaderValue = requestMessage.getHeader(Constants.HTTP_CONTENT_TYPE);
+        transferEncodingHeaderValue = requestMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING);
+        contentLengthHeaderValue = requestMessage.getHeader(Constants.HTTP_CONTENT_LENGTH);
         httpMethod = (String) requestMessage.getProperty(Constants.HTTP_METHOD);
     }
 
@@ -48,8 +48,8 @@ public class RequestDataHolder {
      *
      * @return value of the Accept-Encoding header
      */
-    public String getAcceptEncodingHeader() {
-        return acceptEncodingHeader;
+    public String getAcceptEncodingHeaderValue() {
+        return acceptEncodingHeaderValue;
     }
 
     /**
@@ -57,8 +57,8 @@ public class RequestDataHolder {
      *
      * @return value of the Connection header
      */
-    public String getConnectionHeader() {
-        return connectionHeader;
+    public String getConnectionHeaderValue() {
+        return connectionHeaderValue;
     }
 
     /**
@@ -66,8 +66,8 @@ public class RequestDataHolder {
      *
      * @return value of the Content-Type header
      */
-    public String getContentTypeHeader() {
-        return contentTypeHeader;
+    public String getContentTypeHeaderValue() {
+        return contentTypeHeaderValue;
     }
 
     /**
@@ -75,8 +75,8 @@ public class RequestDataHolder {
      *
      * @return  value of the Transfer-Encoding header
      */
-    public String getTransferEncodingHeader() {
-        return transferEncodingHeader;
+    public String getTransferEncodingHeaderValue() {
+        return transferEncodingHeaderValue;
     }
 
     /**
@@ -84,8 +84,8 @@ public class RequestDataHolder {
      *
      * @return value of the Content-Length header
      */
-    public String getContentLengthHeader() {
-        return contentLengthHeader;
+    public String getContentLengthHeaderValue() {
+        return contentLengthHeaderValue;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -359,14 +359,23 @@ public class HTTPCarbonMessage {
         return blockingEntityCollector;
     }
 
-    /**
-     * Peek the head of the queue
-     */
-    public HttpContent peek() {
-        return this.blockingEntityCollector.peek();
-    }
-
     public synchronized void removeHttpContentAsyncFuture() {
         this.messageFuture = null;
+    }
+
+    /**
+     * Gives the underling netty request message
+     * @return netty request message
+     */
+    public HttpRequest getNettyHttpRequest() {
+        return (HttpRequest) this.httpMessage;
+    }
+
+    /**
+     * Gives the underling netty response message
+     * @return netty response message
+     */
+    public HttpResponse getNettyHttpResponse() {
+        return (HttpResponse) this.httpMessage;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.messaging.exceptions.MessagingException;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.common.Util;
@@ -179,22 +178,20 @@ public class TargetChannel {
                     this.getChannel().writeAndFlush(httpContent);
                 }
             }));
-        } catch (Exception e) {
-            String msg;
-            if (e instanceof NullPointerException) {
-                msg = "Failed to send the request";
+        } catch (Exception exception) {
+            String errorMsg;
+            if (exception instanceof NullPointerException) {
+                errorMsg = "Failed to send the request";
             } else {
-                msg = "Failed to send the request : " + e.getMessage().toLowerCase(Locale.ENGLISH);
+                errorMsg = "Failed to send the request : " + exception.getMessage().toLowerCase(Locale.ENGLISH);
             }
 
-            log.error(msg, e);
-            MessagingException messagingException = new MessagingException(msg, e, 101500);
-            httpOutboundRequest.setMessagingException(messagingException);
-            this.targetHandler.getHttpResponseFuture().notifyHttpListener(httpOutboundRequest);
+            log.error(errorMsg, exception);
+            this.targetHandler.getHttpResponseFuture().notifyHttpListener(exception);
         }
     }
 
-    public void writeOutboundRequestHeaders(HTTPCarbonMessage httpOutboundRequest) {
+    private void writeOutboundRequestHeaders(HTTPCarbonMessage httpOutboundRequest) {
         HttpRequest httpRequest = Util.createHttpRequest(httpOutboundRequest);
         this.setRequestWritten(true);
         this.getChannel().write(httpRequest);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -95,7 +95,7 @@ public class ConnectionManager {
         if (sourceHandler != null) {
             EventLoopGroup group;
             ChannelHandlerContext ctx = sourceHandler.getInboundChannelContext();
-            group = targetEventLoopGroup;
+            group = ctx.channel().eventLoop();
             Class cl = ctx.channel().getClass();
 
             if (poolManagementPolicy == PoolManagementPolicy.LOCK_DEFAULT_POOLING) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorConnectionRefusedTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorConnectionRefusedTestCase.java
@@ -18,9 +18,6 @@
 
 package org.wso2.transport.http.netty;
 
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -67,17 +64,11 @@ public class ClientConnectorConnectionRefusedTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, ""));
-            msg.setProperty("PORT", TestUtil.TEST_HTTPS_SERVER_PORT);
-            msg.setProperty("PROTOCOL", "https");
-            msg.setProperty("HOST", "localhost");
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.setEndOfMsgAdded(true);
+            HTTPCarbonMessage httpsRequest = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);
-            HttpResponseFuture responseFuture = httpClientConnector.send(msg);
+            HttpResponseFuture responseFuture = httpClientConnector.send(httpsRequest);
             responseFuture.setHttpConnectorListener(listener);
 
             latch.await(6, TimeUnit.SECONDS);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
@@ -18,10 +18,7 @@
 
 package org.wso2.transport.http.netty;
 
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -78,13 +75,7 @@ public class ClientConnectorTimeoutTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, ""));
-            msg.setProperty("PORT", TestUtil.TEST_HTTPS_SERVER_PORT);
-            msg.setProperty("PROTOCOL", "https");
-            msg.setProperty("HOST", "localhost");
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.setEndOfMsgAdded(true);
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
@@ -111,29 +111,25 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
                             ByteBuffer byteBuffer = ByteBuffer.allocate(length);
                             byteBufferList.forEach(byteBuffer::put);
 
-                            String responseValue = new String(byteBuffer.array()) + ":" + requestValue;
+                            String responseStringValue = new String(byteBuffer.array()) + ":" + requestValue;
 
-                            byte[] array = null;
+                            byte[] responseByteValues = null;
                             try {
-                                array = responseValue.getBytes("UTF-8");
+                                responseByteValues = responseStringValue.getBytes("UTF-8");
                             } catch (UnsupportedEncodingException e) {
                                 logger.error("Failed to get the byte array from responseValue", e);
                             }
 
-//                            ByteBuffer byteBuff = ByteBuffer.allocate(array.length);
-//                            byteBuff.put(array);
-//                            byteBuff.flip();
-
-                            ByteBuffer byteBuff = ByteBuffer.wrap(array);
+                            ByteBuffer responseValueByteBuffer = ByteBuffer.wrap(responseByteValues);
 
                             HTTPCarbonMessage httpCarbonMessage = httpResponse
                                     .cloneCarbonMessageWithOutData();
                             if (httpCarbonMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {
                                 httpCarbonMessage.setHeader(Constants.HTTP_CONTENT_LENGTH,
-                                        String.valueOf(array.length));
+                                        String.valueOf(responseByteValues.length));
                             }
                             httpCarbonMessage.addHttpContent(
-                                    new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuff)));
+                                    new DefaultLastHttpContent(Unpooled.wrappedBuffer(responseValueByteBuffer)));
 
                             try {
                                 httpRequest.respond(httpCarbonMessage);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
@@ -110,7 +110,9 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
 
                             ByteBuffer byteBuffer = ByteBuffer.allocate(length);
                             byteBufferList.forEach(byteBuffer::put);
+
                             String responseValue = new String(byteBuffer.array()) + ":" + requestValue;
+
                             byte[] array = null;
                             try {
                                 array = responseValue.getBytes("UTF-8");
@@ -118,9 +120,12 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
                                 logger.error("Failed to get the byte array from responseValue", e);
                             }
 
-                            ByteBuffer byteBuff = ByteBuffer.allocate(array.length);
-                            byteBuff.put(array);
-                            byteBuff.flip();
+//                            ByteBuffer byteBuff = ByteBuffer.allocate(array.length);
+//                            byteBuff.put(array);
+//                            byteBuff.flip();
+
+                            ByteBuffer byteBuff = ByteBuffer.wrap(array);
+
                             HTTPCarbonMessage httpCarbonMessage = httpResponse
                                     .cloneCarbonMessageWithOutData();
                             if (httpCarbonMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -41,8 +41,6 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -102,7 +100,7 @@ public class CipherSuitesTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -118,7 +116,7 @@ public class CipherSuitesTest {
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
+        listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
         listenerConfiguration.setParameters(serverParams);
 
         ServerConnector serverConnector = factory
@@ -138,8 +136,7 @@ public class CipherSuitesTest {
 
     public void testCiphersuites(boolean hasException, int serverPort) {
         try {
-            ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(serverPort, testValue, "");
 
             CountDownLatch latch = new CountDownLatch(1);
             SSLConnectorListener listener = new SSLConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -18,9 +18,6 @@
 
 package org.wso2.transport.http.netty.https;
 
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -71,7 +68,7 @@ public class HTTPSClientTestCase {
                 TestUtil.getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
             }
         });
@@ -87,13 +84,7 @@ public class HTTPSClientTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                                                                                 HttpMethod.GET, ""));
-            msg.setProperty("PORT", TestUtil.TEST_HTTPS_SERVER_PORT);
-            msg.setProperty("PROTOCOL", TestUtil.HTTPS_SCHEME);
-            msg.setProperty("HOST", "localhost");
-            msg.setProperty("HTTP_METHOD", "GET");
-            msg.setEndOfMsgAdded(true);
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -41,8 +41,6 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -68,7 +66,7 @@ public class MutualSSLTestCase {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -85,7 +83,7 @@ public class MutualSSLTestCase {
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setCertPass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
+        listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
 
         ServerConnector connector = factory
                 .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
@@ -101,8 +99,7 @@ public class MutualSSLTestCase {
     @Test
     public void testHttpsPost() {
         try {
-            ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(serverPort, testValue, "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -41,8 +41,6 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -97,7 +95,7 @@ public class SSLProtocolsTest {
                 .getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         senderConfig.forEach(config -> {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
                 config.setKeyStorePassword(TestUtil.KEY_STORE_PASSWORD);
@@ -113,7 +111,7 @@ public class SSLProtocolsTest {
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
-        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
+        listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
         listenerConfiguration.setParameters(severParams);
         serverConnector = factory
                 .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
@@ -130,8 +128,7 @@ public class SSLProtocolsTest {
 
     public void testSSLProtocols(boolean hasException, int serverPort) {
         try {
-            ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = TestUtil.createHttpsRequest(serverPort, byteBuffer);
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(serverPort, testValue, "");
 
             CountDownLatch latch = new CountDownLatch(1);
             SSLConnectorListener listener = new SSLConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -15,11 +15,6 @@
 
 package org.wso2.transport.http.netty.pkcs;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -43,8 +38,6 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -76,7 +69,7 @@ public class PKCSTest {
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         //set PKCS12 truststore to ballerina client.
         senderConfig.forEach(config -> {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(trustStoreFile));
                 config.setTrustStorePass(password);
                 config.setTlsStoreType(tlsStoreType);
@@ -108,14 +101,7 @@ public class PKCSTest {
     @Test
     public void testPKCS12() {
         try {
-            ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-            HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, ""));
-            msg.setProperty("PORT", serverPort);
-            msg.setProperty("PROTOCOL", scheme);
-            msg.setProperty("HOST", TestUtil.TEST_HOST);
-            msg.setProperty("HTTP_METHOD", Constants.HTTP_POST_METHOD);
-            msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(serverPort, testValue, "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
@@ -93,7 +93,7 @@ public class ProxyServerTestCase {
         //set proxy server configuration to client connector.
         Set<SenderConfiguration> senderConfig = transportsConfiguration.getSenderConfigurations();
         for (SenderConfiguration config : senderConfig) {
-            if (config.getId().contains(TestUtil.HTTPS_SCHEME)) {
+            if (config.getId().contains(Constants.HTTPS_SCHEME)) {
                 config.setTrustStoreFile(TestUtil.getAbsolutePath(config.getTrustStoreFile()));
             }
             config.setProxyServerConfiguration(proxyServerConfiguration);
@@ -102,7 +102,7 @@ public class ProxyServerTestCase {
         HttpWsConnectorFactory factory = new HttpWsConnectorFactoryImpl();
         ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
         listenerConfiguration.setPort(serverPort);
-        listenerConfiguration.setScheme(TestUtil.HTTPS_SCHEME);
+        listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(password);
         serverConnector = factory
@@ -113,7 +113,7 @@ public class ProxyServerTestCase {
 
         httpClientConnector = factory
                 .createHttpClientConnector(HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
-                        HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, TestUtil.HTTPS_SCHEME));
+                        HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME));
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -84,12 +84,13 @@ public class TestUtil {
     public static final int TEST_DEFAULT_INTERFACE_PORT = 8490;
     public static final int TEST_ALTER_INTERFACE_PORT = 8590;
     public static final int TEST_REMOTE_WS_SERVER_PORT = 9010;
-    public static final String TEST_HOST = "localhost";
     public static final long HTTP2_RESPONSE_TIME_OUT = 30;
-    public static final TimeUnit HTTP2_RESPONSE_TIME_UNIT = TimeUnit.SECONDS;
+    public static final String TEST_HOST = "localhost";
     public static final String KEY_STORE_FILE_PATH = "/simple-test-config/wso2carbon.jks";
     public static final String TRUST_STORE_FILE_PATH = "/simple-test-config/client-truststore.jks";
     public static final String KEY_STORE_PASSWORD = "wso2carbon";
+    public static final TimeUnit HTTP2_RESPONSE_TIME_UNIT = TimeUnit.SECONDS;
+
     private static List<ServerConnector> connectors;
     private static List<ServerConnectorFuture> futures;
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -59,6 +59,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -89,7 +90,6 @@ public class TestUtil {
     public static final String KEY_STORE_FILE_PATH = "/simple-test-config/wso2carbon.jks";
     public static final String TRUST_STORE_FILE_PATH = "/simple-test-config/client-truststore.jks";
     public static final String KEY_STORE_PASSWORD = "wso2carbon";
-    public static final String HTTPS_SCHEME = "https";
     private static List<ServerConnector> connectors;
     private static List<ServerConnectorFuture> futures;
 
@@ -252,14 +252,17 @@ public class TestUtil {
         return TestUtil.class.getResource(relativePath).getFile();
     }
 
-    public static HTTPCarbonMessage createHttpsRequest(int serverPort, ByteBuffer byteBuffer) {
+    public static HTTPCarbonMessage createHttpsPostReq(int serverPort, String payload, String path) {
         HTTPCarbonMessage msg = new HTTPCarbonMessage(
-                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
-        msg.setProperty("PORT", serverPort);
-        msg.setProperty("PROTOCOL", TestUtil.HTTPS_SCHEME);
-        msg.setProperty("HOST", TestUtil.TEST_HOST);
-        msg.setProperty("HTTP_METHOD", Constants.HTTP_POST_METHOD);
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path));
+        msg.setProperty(Constants.PORT, serverPort);
+        msg.setProperty(Constants.PROTOCOL, Constants.HTTPS_SCHEME);
+        msg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        msg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(payload.getBytes(Charset.forName("UTF-8")));
         msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+
         return msg;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -254,17 +254,17 @@ public class TestUtil {
     }
 
     public static HTTPCarbonMessage createHttpsPostReq(int serverPort, String payload, String path) {
-        HTTPCarbonMessage msg = new HTTPCarbonMessage(
+        HTTPCarbonMessage httpPostRequest = new HTTPCarbonMessage(
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path));
-        msg.setProperty(Constants.PORT, serverPort);
-        msg.setProperty(Constants.PROTOCOL, Constants.HTTPS_SCHEME);
-        msg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-        msg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
+        httpPostRequest.setProperty(Constants.PORT, serverPort);
+        httpPostRequest.setProperty(Constants.PROTOCOL, Constants.HTTPS_SCHEME);
+        httpPostRequest.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        httpPostRequest.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
 
         ByteBuffer byteBuffer = ByteBuffer.wrap(payload.getBytes(Charset.forName("UTF-8")));
-        msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+        httpPostRequest.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
 
-        return msg;
+        return httpPostRequest;
     }
 }
 


### PR DESCRIPTION
## Purpose
> Current code blocks when we calculate the content-length of a given request. This mandates us to use two threads in order to get it working. With this PR I have removed the blocking operation such that the calculation happens in async way. 

In addition to that I have done some refactoring of the code as well. 

## Goals
> Remove unnecessary thread pools from http transport. 

## Approach
> Using reactive style of coding.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Covered by the existing ones.

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A

## Learning
> N/A