### PR TITLE
Add testcase for connection re-use in connection-pool

### DIFF
--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorConnectionRefusedTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorConnectionRefusedTestCase.java
@@ -64,7 +64,7 @@ public class ClientConnectorConnectionRefusedTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage httpsRequest = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
+            HTTPCarbonMessage httpsRequest = TestUtil.createHttpsPostReq(TestUtil.HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
@@ -59,7 +59,7 @@ public class ClientConnectorTimeoutTestCase {
 
     @BeforeClass
     public void setup() {
-        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTPS_SERVER_PORT, new DumbServerInitializer());
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTPS_SERVER_PORT, new DumbServerInitializer());
 
         TransportsConfiguration transportsConfiguration = TestUtil.getConfiguration(
                 "/simple-test-config" + File.separator + "netty-transports.yml");
@@ -75,7 +75,7 @@ public class ClientConnectorTimeoutTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkHeaderClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkHeaderClientTestCase.java
@@ -73,7 +73,7 @@ public class ChunkHeaderClientTestCase {
     public void setup() {
         transportsConfiguration =
                 TestUtil.getConfiguration("/simple-test-config" + File.separator + "netty-transports.yml");
-        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTP_SERVER_PORT,
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT,
                 new ChunkBasedServerInitializer(testValue, "text/plain", 200));
     }
 
@@ -116,7 +116,7 @@ public class ChunkHeaderClientTestCase {
                 HTTPConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
 
         ByteBuffer byteBuffer = ByteBuffer.wrap(testValue.getBytes(Charset.forName("UTF-8")));
-        msg.setProperty("PORT", TestUtil.TEST_HTTP_SERVER_PORT);
+        msg.setProperty("PORT", TestUtil.HTTP_SERVER_PORT);
         msg.setProperty("PROTOCOL", "http");
         msg.setProperty("HOST", "localhost");
         msg.setProperty("HTTP_METHOD", "GET");

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.connectionpool;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.passthrough.PassthroughMessageProcessorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+import org.wso2.transport.http.netty.util.server.initializers.SendChannelIDServerInitializer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * Tests for connection pool implementation.
+ */
+public class ConnectionPoolTestCase {
+
+    private static Logger logger = LoggerFactory.getLogger(ConnectionPoolTestCase.class);
+
+    private HttpServer httpServer;
+    private List<ServerConnector> serverConnectors;
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
+    private ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    @BeforeClass
+    public void setup() {
+        TransportsConfiguration transportsConfiguration = TestUtil.getConfiguration(
+                "/simple-test-config" + File.separator + "netty-transports.yml");
+
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new SendChannelIDServerInitializer());
+        serverConnectors = TestUtil.startConnectors(transportsConfiguration,
+                new PassthroughMessageProcessorListener(transportsConfiguration));
+    }
+
+    @Test
+    public void testConnectionReuseForProxy() {
+        try {
+            Future<String> requestOneResponse;
+            Future<String> requestThreeResponse;
+
+            ClientWorker clientWorkerOne = new ClientWorker();
+            ClientWorker clientWorkerTwo = new ClientWorker();
+            ClientWorker clientWorkerThree = new ClientWorker();
+
+            requestOneResponse = executor.submit(clientWorkerOne);
+
+            // While the fist request is being processed by the back-end,
+            // we send the second request which forces the client connector to
+            // create a new connection.
+            Thread.sleep(2500);
+            executor.submit(clientWorkerTwo);
+            assertNotNull(requestOneResponse.get());
+
+            requestThreeResponse = executor.submit(clientWorkerThree);
+
+            assertEquals(requestOneResponse.get(), requestThreeResponse.get());
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running passthroughPostTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(serverConnectors, httpServer);
+    }
+
+    private class ClientWorker implements Callable<String> {
+
+        String response;
+
+        @Override
+        public String call() throws Exception {
+            try {
+                HttpURLConnection urlConn = TestUtil
+                        .request(baseURI, "/", HttpMethod.POST.name(), true);
+                response = TestUtil.getContent(urlConn);
+            } catch (IOException e) {
+                logger.error("Couldn't get the response", e);
+            }
+
+            return response;
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolTestCase.java
@@ -101,7 +101,7 @@ public class ConnectionPoolTestCase {
 
     private class ClientWorker implements Callable<String> {
 
-        String response;
+        private String response;
 
         @Override
         public String call() throws Exception {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/ContentAwareMessageProcessorTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/ContentAwareMessageProcessorTestCase.java
@@ -54,7 +54,7 @@ public class ContentAwareMessageProcessorTestCase {
     private TransportsConfiguration configuration;
 
     private HttpServer httpServer;
-    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.TEST_DEFAULT_INTERFACE_PORT));
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
 
     @BeforeClass
     public void setUp() {
@@ -62,7 +62,7 @@ public class ContentAwareMessageProcessorTestCase {
                 .build("src/test/resources/simple-test-config/netty-transports.yml");
         serverConnectors = TestUtil.startConnectors(
                 configuration, new PassthroughMessageProcessorListener(configuration));
-        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTP_SERVER_PORT, new EchoServerInitializer());
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new EchoServerInitializer());
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
@@ -82,7 +82,7 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
                 byteBuffer1.flip();
                 newMsg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer1)));
                 newMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                newMsg.setProperty(Constants.PORT, TestUtil.TEST_HTTP_SERVER_PORT);
+                newMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationStreamingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationStreamingListener.java
@@ -75,7 +75,7 @@ public class RequestResponseCreationStreamingListener implements HttpConnectorLi
                 outputStream.flush();
                 outputStream.close();
                 newMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                newMsg.setProperty(Constants.PORT, TestUtil.TEST_HTTP_SERVER_PORT);
+                newMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformListener.java
@@ -76,7 +76,7 @@ public class RequestResponseTransformListener implements HttpConnectorListener {
                 requestValue = new String(byteBuff.array());
 
                 httpRequest.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                httpRequest.setProperty(Constants.PORT, TestUtil.TEST_HTTP_SERVER_PORT);
+                httpRequest.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
 
                 if (responseValue != null) {
                     byte[] array = responseValue.getBytes("UTF-8");

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformStreamingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformStreamingListener.java
@@ -70,7 +70,7 @@ public class RequestResponseTransformStreamingListener implements HttpConnectorL
                 outputStream.write(bytes);
                 outputStream.close();
                 httpRequestMessage.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                httpRequestMessage.setProperty(Constants.PORT, TestUtil.TEST_HTTP_SERVER_PORT);
+                httpRequestMessage.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/encoding/ContentEncodingTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/encoding/ContentEncodingTestCase.java
@@ -50,7 +50,7 @@ public class ContentEncodingTestCase {
     private TransportsConfiguration configuration;
 
     private HttpServer httpServer;
-    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.TEST_DEFAULT_INTERFACE_PORT));
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
 
     private static final Logger log = LoggerFactory.getLogger(ContentEncodingTestCase.class);
 
@@ -60,7 +60,7 @@ public class ContentEncodingTestCase {
                 .build("src/test/resources/simple-test-config/netty-transports.yml");
         serverConnectors = TestUtil.startConnectors(
                 configuration, new ContentReadingListener());
-        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTP_SERVER_PORT, new EchoServerInitializer());
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new EchoServerInitializer());
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -73,7 +73,7 @@ public class HTTPSClientTestCase {
             }
         });
 
-        httpsServer = TestUtil.startHttpsServer(TestUtil.TEST_HTTPS_SERVER_PORT,
+        httpsServer = TestUtil.startHttpsServer(TestUtil.HTTPS_SERVER_PORT,
                 new MockServerInitializer(testValue, "text/plain", 200));
         HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
         httpClientConnector = connectorFactory.createHttpClientConnector(
@@ -84,7 +84,7 @@ public class HTTPSClientTestCase {
     @Test
     public void testHttpsGet() {
         try {
-            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.TEST_HTTPS_SERVER_PORT, "", "");
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.HTTPS_SERVER_PORT, "", "");
 
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
@@ -47,7 +47,7 @@ public class PassThroughHttpTestCase {
     private static final String testValue = "Test Message";
     private HttpServer httpServer;
 
-    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.TEST_DEFAULT_INTERFACE_PORT));
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
 
     @BeforeClass
     public void setUp() {
@@ -55,7 +55,7 @@ public class PassThroughHttpTestCase {
                 .build(TestUtil.getAbsolutePath("/simple-test-config/netty-transports.yml"));
         serverConnectors = TestUtil.startConnectors(
                 configuration, new PassthroughMessageProcessorListener(configuration));
-        httpServer = TestUtil.startHTTPServer(TestUtil.TEST_HTTP_SERVER_PORT,
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT,
                 new MockServerInitializer(testValue, Constants.TEXT_PLAIN, 200));
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -79,11 +79,11 @@ public class TestUtil {
 
     private static final Logger log = LoggerFactory.getLogger(TestUtil.class);
 
-    public static final int TEST_HTTP_SERVER_PORT = 9000;
-    public static final int TEST_HTTPS_SERVER_PORT = 9004;
-    public static final int TEST_DEFAULT_INTERFACE_PORT = 8490;
-    public static final int TEST_ALTER_INTERFACE_PORT = 8590;
-    public static final int TEST_REMOTE_WS_SERVER_PORT = 9010;
+    public static final int HTTP_SERVER_PORT = 9000;
+    public static final int HTTPS_SERVER_PORT = 9004;
+    public static final int SERVER_CONNECTOR_PORT = 8490;
+    public static final int ALTER_INTERFACE_PORT = 8590;
+    public static final int REMOTE_WS_SERVER_PORT = 9010;
     public static final long HTTP2_RESPONSE_TIME_OUT = 30;
     public static final String TEST_HOST = "localhost";
     public static final String KEY_STORE_FILE_PATH = "/simple-test-config/wso2carbon.jks";

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/websocket/WebSocketTestClient.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/websocket/WebSocketTestClient.java
@@ -63,7 +63,7 @@ public class WebSocketTestClient {
     private static final Logger logger = LoggerFactory.getLogger(WebSocketTestClient.class);
 
     private String url = System.getProperty("url", String.format("ws://%s:%d/%s",
-                                                  TestUtil.TEST_HOST, TestUtil.TEST_DEFAULT_INTERFACE_PORT, "test"));
+                                                  TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT, "test"));
     private final String subProtocol;
     private Map<String, String> customHeaders = new HashMap<>();
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpServer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpServer.java
@@ -38,7 +38,7 @@ public class HttpServer implements TestServer {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpServer.class);
 
-    private int port = TestUtil.TEST_HTTP_SERVER_PORT;
+    private int port = TestUtil.HTTP_SERVER_PORT;
     private int bossGroupSize = Runtime.getRuntime().availableProcessors();
     private int workerGroupSize = Runtime.getRuntime().availableProcessors() * 2;
     private EventLoopGroup bossGroup;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpsServer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/HttpsServer.java
@@ -43,7 +43,7 @@ public class HttpsServer implements TestServer {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpsServer.class);
 
-    private int port = TestUtil.TEST_HTTPS_SERVER_PORT;
+    private int port = TestUtil.HTTPS_SERVER_PORT;
     private int bossGroupSize = Runtime.getRuntime().availableProcessors();
     private int workerGroupSize = Runtime.getRuntime().availableProcessors() * 2;
     private EventLoopGroup bossGroup;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
@@ -42,7 +42,7 @@ import java.net.URL;
 public class HttpToWsProtocolSwitchTestCase {
 
     private HttpWsConnectorFactoryImpl httpConnectorFactory = new HttpWsConnectorFactoryImpl();
-    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.TEST_DEFAULT_INTERFACE_PORT));
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
     private ServerConnector serverConnector;
 
     @BeforeClass
@@ -50,7 +50,7 @@ public class HttpToWsProtocolSwitchTestCase {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
-        listenerConfiguration.setPort(TestUtil.TEST_DEFAULT_INTERFACE_PORT);
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
         serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketClientTestCase.java
@@ -52,12 +52,12 @@ public class WebSocketClientTestCase {
 
     private HttpWsConnectorFactoryImpl httpConnectorFactory = new HttpWsConnectorFactoryImpl();
     private final String url = String.format("ws://%s:%d/%s", "localhost",
-                                             TestUtil.TEST_REMOTE_WS_SERVER_PORT, "websocket");
+                                             TestUtil.REMOTE_WS_SERVER_PORT, "websocket");
     private static final String PING = "ping";
     private final int latchWaitTimeInSeconds = 10;
     private WsClientConnectorConfig configuration = new WsClientConnectorConfig(url);
     private WebSocketClientConnector clientConnector;
-    private WebSocketRemoteServer remoteServer = new WebSocketRemoteServer(TestUtil.TEST_REMOTE_WS_SERVER_PORT,
+    private WebSocketRemoteServer remoteServer = new WebSocketRemoteServer(TestUtil.REMOTE_WS_SERVER_PORT,
                                                                            "xml, json");
 
     @BeforeClass

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketMessagePropertiesTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketMessagePropertiesTestCase.java
@@ -54,7 +54,7 @@ public class WebSocketMessagePropertiesTestCase {
     public void setup() throws InterruptedException {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
-        listenerConfiguration.setPort(TestUtil.TEST_DEFAULT_INTERFACE_PORT);
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
         serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassThroughTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassThroughTestCase.java
@@ -52,7 +52,7 @@ public class WebSocketPassThroughTestCase {
     private final int latchCountDownInSecs = 10;
 
     private HttpWsConnectorFactoryImpl httpConnectorFactory = new HttpWsConnectorFactoryImpl();
-    private WebSocketRemoteServer remoteServer = new WebSocketRemoteServer(TestUtil.TEST_REMOTE_WS_SERVER_PORT);
+    private WebSocketRemoteServer remoteServer = new WebSocketRemoteServer(TestUtil.REMOTE_WS_SERVER_PORT);
 
     private ServerConnector serverConnector;
 
@@ -61,7 +61,7 @@ public class WebSocketPassThroughTestCase {
         remoteServer.run();
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
-        listenerConfiguration.setPort(TestUtil.TEST_DEFAULT_INTERFACE_PORT);
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
         serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
@@ -51,7 +51,7 @@ public class WebSocketPassthroughServerConnectorListener implements WebSocketCon
     @Override
     public void onMessage(WebSocketInitMessage initMessage) {
         String remoteUrl = String.format("ws://%s:%d/%s", "localhost",
-                                         TestUtil.TEST_REMOTE_WS_SERVER_PORT, "websocket");
+                                         TestUtil.REMOTE_WS_SERVER_PORT, "websocket");
         WsClientConnectorConfig configuration = new WsClientConnectorConfig(remoteUrl);
         configuration.setTarget("myService");
         WebSocketClientConnector clientConnector = connectorFactory.createWsClientConnector(configuration);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketServerTestCase.java
@@ -60,7 +60,7 @@ public class WebSocketServerTestCase {
     public void setup() throws InterruptedException {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
-        listenerConfiguration.setPort(TestUtil.TEST_DEFAULT_INTERFACE_PORT);
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
         serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
                 listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();
@@ -167,7 +167,7 @@ public class WebSocketServerTestCase {
     public void testIdleTimeout() throws InterruptedException, ProtocolException, SSLException, URISyntaxException {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
-        listenerConfiguration.setPort(TestUtil.TEST_ALTER_INTERFACE_PORT);
+        listenerConfiguration.setPort(TestUtil.ALTER_INTERFACE_PORT);
         ServerConnector alterServerConnector = httpConnectorFactory.createServerConnector(
                 ServerBootstrapConfiguration.getInstance(),
                 listenerConfiguration);
@@ -175,7 +175,7 @@ public class WebSocketServerTestCase {
         WebSocketTestServerConnectorListener listener = new WebSocketTestServerConnectorListener();
         connectorFuture.setWSConnectorListener(listener);
         String url = System.getProperty("url", String.format("ws://%s:%d/%s",
-                                                             TestUtil.TEST_HOST, TestUtil.TEST_ALTER_INTERFACE_PORT,
+                                                             TestUtil.TEST_HOST, TestUtil.ALTER_INTERFACE_PORT,
                                                              "test"));
         CountDownLatch latch = new CountDownLatch(1);
         WebSocketTestClient primaryClient = new WebSocketTestClient(url, latch);

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -39,6 +39,7 @@
             <class name="org.wso2.transport.http.netty.ClientConnectorTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.ClientConnectorConnectionRefusedTestCase" />
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkHeaderClientTestCase" />
+            <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolTestCase" />
             <!--<class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />-->
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.websocket.WebSocketServerTestCase"/>


### PR DESCRIPTION
## Purpose
> At the moment we  don't have a test-case to validate the connection re-use of connection pool when we are using the transport for proxy scenarios. This test-case validates it.

In addition to that I have refactored the constant names that are used in Test-Cases.  

## Goals
> Validate the connection re-use functionality. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Available

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A