### PR TITLE
Update Netty version and refactor deprecated Netty API usage

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -135,6 +135,7 @@ public class Util {
      * Prepare request message with Transfer-Encoding/Content-Length
      *
      * @param httpOutboundRequest HTTPCarbonMessage
+     * @param chunkEnabled Specifies whether chunking is enabled or disabled
      */
     public static void setupChunkedOrContentLengthForReq(HTTPCarbonMessage httpOutboundRequest, boolean chunkEnabled) {
         if (chunkEnabled) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/ServerConnectorFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/ServerConnectorFuture.java
@@ -136,6 +136,7 @@ public interface ServerConnectorFuture {
      *
      * @param serverConnectorId The ID of the server connected related to this port unbinding event
      * @param isHttps Specifies whether the server connector is using HTTPS.
+     * @throws ServerConnectorException Thrown if there is an error in unbinding the port.
      */
     void notifyPortUnbindingEvent(String serverConnectorId, boolean isHttps) throws ServerConnectorException;
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/WebSocketInitMessageImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/WebSocketInitMessageImpl.java
@@ -163,7 +163,7 @@ public class WebSocketInitMessageImpl extends WebSocketMessageImpl implements We
         if (isConnectionSecured) {
             protocol = Constants.WEBSOCKET_PROTOCOL_SECURED;
         }
-        String url =   protocol + "://" + req.headers().get("Host") + req.getUri();
+        String url =   protocol + "://" + req.headers().get("Host") + req.uri();
         return url;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpRequestDecoder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpRequestDecoder.java
@@ -59,8 +59,8 @@ public class CustomHttpRequestDecoder extends HttpRequestDecoder {
         for (Object o : out) {
             if (o instanceof DefaultHttpRequest) {
                 DefaultHttpRequest httpRequest = (DefaultHttpRequest) o;
-                if (httpRequest.getDecoderResult().isFailure() && httpRequest.getDecoderResult()
-                        .cause() instanceof TooLongFrameException) {
+                if (httpRequest.decoderResult().isFailure()
+                        && httpRequest.decoderResult().cause() instanceof TooLongFrameException) {
 
                     log.warn("Header size is larger than the valid limit");
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -196,8 +196,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         HttpRequest httpRequest = (HttpRequest) httpMessage;
         sourceReqCmsg.setProperty(Constants.CHNL_HNDLR_CTX, this.ctx);
         sourceReqCmsg.setProperty(Constants.SRC_HANDLER, this);
-        sourceReqCmsg.setProperty(Constants.HTTP_VERSION, httpRequest.getProtocolVersion().text());
-        sourceReqCmsg.setProperty(Constants.HTTP_METHOD, httpRequest.getMethod().name());
+        sourceReqCmsg.setProperty(Constants.HTTP_VERSION, httpRequest.protocolVersion().text());
+        sourceReqCmsg.setProperty(Constants.HTTP_METHOD, httpRequest.method().name());
 
         InetSocketAddress localAddress = (InetSocketAddress) ctx.channel().localAddress();
         sourceReqCmsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_PORT, localAddress.getPort());
@@ -211,8 +211,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         sourceReqCmsg.setProperty(Constants.IS_SECURED_CONNECTION, isSecuredConnection);
 
         sourceReqCmsg.setProperty(Constants.LOCAL_ADDRESS, ctx.channel().localAddress());
-        sourceReqCmsg.setProperty(Constants.REQUEST_URL, httpRequest.getUri());
-        sourceReqCmsg.setProperty(Constants.TO, httpRequest.getUri());
+        sourceReqCmsg.setProperty(Constants.REQUEST_URL, httpRequest.uri());
+        sourceReqCmsg.setProperty(Constants.TO, httpRequest.uri());
         //Added protocol name as a string
 
         return sourceReqCmsg;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
@@ -100,6 +100,7 @@ public interface EntityCollector {
 
     /**
      * Peek the head of the queue
+     * @return An HttpContent instance
      */
     HttpContent peek();
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
@@ -130,10 +130,9 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      *
      * @param ctx   Channel context
      * @param cause Exception occurred
-     * @throws Exception
      */
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         LOG.error("Exception occurred in RedirectHandler.", cause);
         if (ctx != null && ctx.channel().isActive()) {
             if (LOG.isDebugEnabled()) {
@@ -150,10 +149,9 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      *
      * @param ctx Channel context
      * @param evt Event
-     * @throws Exception
      */
     @Override
-    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent event = (IdleStateEvent) evt;
             if (event.state() == IdleState.READER_IDLE || event.state() == IdleState.WRITER_IDLE) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -117,7 +117,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         targetRespMsg.setProperty(org.wso2.carbon.messaging.Constants.DIRECTION,
                 org.wso2.carbon.messaging.Constants.DIRECTION_RESPONSE);
         HttpResponse httpResponse = (HttpResponse) msg;
-        targetRespMsg.setProperty(Constants.HTTP_STATUS_CODE, httpResponse.getStatus().code());
+        targetRespMsg.setProperty(Constants.HTTP_STATUS_CODE, httpResponse.status().code());
 
         //copy required properties for service chaining from incoming carbon message to the response carbon message
         //copy shared worker pool

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/EchoMessageListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/EchoMessageListener.java
@@ -19,7 +19,9 @@
 
 package org.wso2.transport.http.netty.contentaware.listeners;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -44,10 +46,10 @@ public class EchoMessageListener implements HttpConnectorListener {
             try {
                 int length = httpRequest.getFullMessageLength();
                 HTTPCarbonMessage cMsg = httpRequest.cloneCarbonMessageWithData();
-                cMsg.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-                cMsg.setHeader(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(length));
-                cMsg.setHeader(HttpHeaders.Names.CONTENT_TYPE, Constants.TEXT_PLAIN);
-                cMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+                cMsg.setHeader(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.KEEP_ALIVE.toString());
+                cMsg.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(length));
+                cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), Constants.TEXT_PLAIN);
+                cMsg.setProperty(Constants.HTTP_STATUS_CODE, HttpResponseStatus.OK.code());
                 httpRequest.respond(cMsg);
             } catch (ServerConnectorException e) {
                 logger.error("Error occurred during message notification: " + e.getMessage());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/ResponseStreamingWithoutBufferingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/ResponseStreamingWithoutBufferingListener.java
@@ -22,7 +22,8 @@ package org.wso2.transport.http.netty.contentaware.listeners;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -47,12 +48,12 @@ public class ResponseStreamingWithoutBufferingListener implements HttpConnectorL
     @Override
     public void onMessage(HTTPCarbonMessage httpRequestMessage) {
         executor.execute(() -> {
-            HTTPCarbonMessage cMsg = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
-                    HttpResponseStatus.OK));
-            cMsg.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-            cMsg.setHeader(HttpHeaders.Names.TRANSFER_ENCODING, HttpHeaders.Values.CHUNKED);
-            cMsg.setHeader(HttpHeaders.Names.CONTENT_TYPE, Constants.TEXT_PLAIN);
-            cMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+            HTTPCarbonMessage cMsg =
+                    new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+            cMsg.setHeader(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.KEEP_ALIVE.toString());
+            cMsg.setHeader(HttpHeaderNames.TRANSFER_ENCODING.toString(), HttpHeaderValues.CHUNKED.toString());
+            cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_PLAIN.toString());
+            cMsg.setProperty(Constants.HTTP_STATUS_CODE, HttpResponseStatus.OK.code());
             try {
                 httpRequestMessage.respond(cMsg);
             } catch (ServerConnectorException e) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HTTPClientRedirectTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HTTPClientRedirectTestCase.java
@@ -19,7 +19,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
@@ -116,7 +116,7 @@ public class HTTPClientRedirectTestCase {
         embeddedChannel.pipeline().addLast(new RedirectHandler(null, false, 5, true));
         HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.TEMPORARY_REDIRECT,
                 Unpooled.EMPTY_BUFFER);
-        response.headers().set(HttpHeaders.Names.LOCATION, FINAL_DESTINATION);
+        response.headers().set(HttpHeaderNames.LOCATION, FINAL_DESTINATION);
         embeddedChannel.attr(Constants.ORIGINAL_REQUEST)
                 .set(createHttpRequest(Constants.HTTP_GET_METHOD, FINAL_DESTINATION));
         embeddedChannel.writeInbound(response);
@@ -140,7 +140,7 @@ public class HTTPClientRedirectTestCase {
         embeddedChannel.pipeline().addLast(new RedirectHandler(null, false, 5, true, null, false));
         HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.TEMPORARY_REDIRECT,
                 Unpooled.EMPTY_BUFFER);
-        response.headers().set(HttpHeaders.Names.LOCATION, FINAL_DESTINATION);
+        response.headers().set(HttpHeaderNames.LOCATION, FINAL_DESTINATION);
         embeddedChannel.attr(Constants.ORIGINAL_REQUEST)
                 .set(createHttpRequest(Constants.HTTP_GET_METHOD, FINAL_DESTINATION));
         embeddedChannel.attr(Constants.RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL).set(new HttpResponseFutureImpl());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/ChunkBasedServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/ChunkBasedServerInitializer.java
@@ -26,20 +26,18 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.transport.http.netty.common.Constants;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaders.Names.TRANSFER_ENCODING;
-import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
-import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -76,27 +74,27 @@ public class ChunkBasedServerInitializer extends HTTPServerInitializer {
                 if (msg instanceof HttpRequest) {
                     req = (HttpRequest) msg;
                 } else if (msg instanceof LastHttpContent) {
-                    if (is100ContinueExpected(req)) {
+                    if (HttpUtil.is100ContinueExpected(req)) {
                         ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
                     }
-                    boolean keepAlive = isKeepAlive(req);
+                    boolean keepAlive = HttpUtil.isKeepAlive(req);
                     HttpResponseStatus httpResponseStatus = new HttpResponseStatus(responseStatusCode,
                             HttpResponseStatus.valueOf(responseStatusCode).reasonPhrase());
                     FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, httpResponseStatus, content);
                     response.headers().set(CONTENT_TYPE, contentType);
-                    length = req.headers().get(Constants.HTTP_CONTENT_LENGTH);
-                    encoding = req.headers().get(Constants.HTTP_TRANSFER_ENCODING);
+                    length = req.headers().get(CONTENT_LENGTH);
+                    encoding = req.headers().get(TRANSFER_ENCODING);
                     if (length != null) {
                         response.headers().set(CONTENT_LENGTH, content.readableBytes());
                     } else if (encoding != null) {
-                        response.headers().set(TRANSFER_ENCODING, Constants.CHUNKED);
+                        response.headers().set(TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
                     }
                     if (!keepAlive) {
                         ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
                         logger.debug("Writing response with data to client-connector");
                         logger.debug("Closing the client-connector connection");
                     } else {
-                        response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                        response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                         ctx.writeAndFlush(response);
                         logger.debug("Writing response with data to client-connector");
                     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/EchoServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/EchoServerInitializer.java
@@ -24,19 +24,18 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaders.Names.TRANSFER_ENCODING;
-import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
-import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -60,14 +59,14 @@ public class EchoServerInitializer extends HTTPServerInitializer {
             if (msg instanceof HttpRequest) {
                 HttpRequest req = (HttpRequest) msg;
 
-                if (is100ContinueExpected(req)) {
+                if (HttpUtil.is100ContinueExpected(req)) {
                     ctx.write(new DefaultHttpResponse(HTTP_1_1, CONTINUE));
                 }
-                boolean keepAlive = isKeepAlive(req);
+                boolean keepAlive = HttpUtil.isKeepAlive(req);
                 HttpResponseStatus httpResponseStatus = new HttpResponseStatus(responseStatusCode,
                         HttpResponseStatus.valueOf(responseStatusCode).reasonPhrase());
 
-                HttpResponse response = new DefaultHttpResponse(req.getProtocolVersion(), httpResponseStatus);
+                HttpResponse response = new DefaultHttpResponse(req.protocolVersion(), httpResponseStatus);
                 String contentType = req.headers().get(CONTENT_TYPE);
                 if (contentType != null) {
                     response.headers().set(CONTENT_TYPE, contentType);
@@ -78,7 +77,7 @@ public class EchoServerInitializer extends HTTPServerInitializer {
                     ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
                     logger.debug("Writing response to client-connector");
                 } else {
-                    response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                    response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                     ctx.writeAndFlush(response);
                     logger.debug("Writing response to client-connector");
                 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/MockServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/MockServerInitializer.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
@@ -34,9 +34,9 @@ import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -87,7 +87,7 @@ public class MockServerInitializer extends HTTPServerInitializer {
                         logger.debug("Writing response with data to client-connector");
                         logger.debug("Closing the client-connector connection");
                     } else {
-                        response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                        response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                         ctx.writeAndFlush(response);
                         logger.debug("Writing response with data to client-connector");
                     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/RedirectServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/RedirectServerInitializer.java
@@ -26,21 +26,20 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaders.Names.LOCATION;
-import static io.netty.handler.codec.http.HttpHeaders.is100ContinueExpected;
-import static io.netty.handler.codec.http.HttpHeaders.isKeepAlive;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.LOCATION;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -81,10 +80,10 @@ public class RedirectServerInitializer extends HTTPServerInitializer {
                 if (msg instanceof HttpRequest) {
                     req = (HttpRequest) msg;
                 } else if (msg instanceof LastHttpContent) {
-                    if (is100ContinueExpected(req)) {
+                    if (HttpUtil.is100ContinueExpected(req)) {
                         ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
                     }
-                    boolean keepAlive = isKeepAlive(req);
+                    boolean keepAlive = HttpUtil.isKeepAlive(req);
                     HttpResponseStatus httpResponseStatus = new HttpResponseStatus(responseStatusCode,
                             HttpResponseStatus.valueOf(responseStatusCode).reasonPhrase());
                     FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, httpResponseStatus, content);
@@ -100,7 +99,7 @@ public class RedirectServerInitializer extends HTTPServerInitializer {
                         logger.debug("Writing response with data to client-connector");
                         logger.debug("Closing the client-connector connection");
                     } else {
-                        response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+                        response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
                         ctx.executor().schedule(() -> ctx.writeAndFlush(response), delay, TimeUnit.MILLISECONDS);
                         logger.debug("Writing response with data to client-connector");
                     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/SendChannelIDServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/SendChannelIDServerInitializer.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
-import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchHttpListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchHttpListener.java
@@ -19,7 +19,9 @@
 
 package org.wso2.transport.http.netty.websocket;
 
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -44,10 +46,10 @@ public class HttpToWsProtocolSwitchHttpListener implements HttpConnectorListener
             try {
                 int length = httpRequest.getFullMessageLength();
                 HTTPCarbonMessage cMsg = httpRequest.cloneCarbonMessageWithData();
-                cMsg.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
-                cMsg.setHeader(HttpHeaders.Names.CONTENT_LENGTH, String.valueOf(length));
-                cMsg.setHeader(HttpHeaders.Names.CONTENT_TYPE, Constants.TEXT_PLAIN);
-                cMsg.setProperty(Constants.HTTP_STATUS_CODE, 200);
+                cMsg.setHeader(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.KEEP_ALIVE.toString());
+                cMsg.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(length));
+                cMsg.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), HttpHeaderValues.TEXT_PLAIN.toString());
+                cMsg.setProperty(Constants.HTTP_STATUS_CODE, HttpResponseStatus.OK.code());
                 httpRequest.respond(cMsg);
             } catch (ServerConnectorException e) {
                 logger.error("Error occurred during message notification: " + e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.16.Final</netty.version>
+        <netty.version>4.1.19.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>


### PR DESCRIPTION
## Purpose
> To update the Netty version and to remove any usage of the deprecated APIs in Netty.

## Goals
> Update the Netty version
> Remove usage of deprecated Netty APIs

## Approach
> Updated the Netty version in the pom
> Added the compiler argument `-Xlint:deprecation` to the maven compiler plug-in in the pom
> Ran a build and fixed each of the warnings given for deprecated API usage by replacing the deprecated versions with their replacement APIs.

