### PR TITLE
Remove singleton ConnectionManager and add testcases

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -106,6 +106,7 @@ public final class Constants {
     public static final String MAX_WAIT_FOR_CLIENT_CONNECTION_POOL = "max.wait.for.client.connection.pool";
 
     public static final String MIN_EVICTION_IDLE_TIME = "client.min.eviction.idle.time";
+    public static final String TIME_BETWEEN_EVICTION_RUNS = "client.time.between.eviction.runs";
 
     public static final String ENABLE_GLOBAL_CONNECTION_POOLING = "enable.global.client.connection.pooling";
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpWsConnectorFactoryImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpWsConnectorFactoryImpl.java
@@ -33,6 +33,7 @@ import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.listener.ServerConnectorBootstrap;
 import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
+import org.wso2.transport.http.netty.sender.channel.pool.PoolConfiguration;
 
 import java.util.Map;
 
@@ -69,12 +70,12 @@ public class HttpWsConnectorFactoryImpl implements HttpWsConnectorFactory {
     }
 
     @Override
-    public HttpClientConnector createHttpClientConnector(Map<String, Object> transportProperties,
-            SenderConfiguration senderConfiguration) {
-        ConnectionManager.init(transportProperties);
-        ConnectionManager connectionManager = ConnectionManager.getInstance();
-        BootstrapConfiguration.createBootStrapConfiguration(transportProperties);
-
+    public HttpClientConnector createHttpClientConnector(
+            Map<String, Object> transportProperties, SenderConfiguration senderConfiguration) {
+        PoolConfiguration poolConfiguration = new PoolConfiguration(transportProperties);
+        BootstrapConfiguration bootstrapConfig = new BootstrapConfiguration(transportProperties);
+        ConnectionManager connectionManager =
+                new ConnectionManager(poolConfiguration, transportProperties, bootstrapConfig);
         return new HttpClientConnectorImpl(connectionManager, senderConfiguration);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerBootstrapConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerBootstrapConfiguration.java
@@ -18,7 +18,6 @@ package org.wso2.transport.http.netty.listener;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,14 +25,10 @@ import java.util.Map;
  */
 public class ServerBootstrapConfiguration {
 
-    private static final Map<String, Object> properties = new HashMap<>();
-    private static ServerBootstrapConfiguration bootstrapConfig = new ServerBootstrapConfiguration(properties);
-
     private boolean tcpNoDelay, keepAlive, socketReuse;
-
     private int connectTimeOut, receiveBufferSize, sendBufferSize, soBackLog, socketTimeOut;
 
-    private ServerBootstrapConfiguration(Map<String, Object> properties) {
+    public ServerBootstrapConfiguration(Map<String, Object> properties) {
 
         connectTimeOut = Util.getIntProperty(
                 properties, Constants.SERVER_BOOTSTRAP_CONNECT_TIME_OUT, 15000);
@@ -56,7 +51,6 @@ public class ServerBootstrapConfiguration {
         soBackLog = Util.getIntProperty(properties, Constants.SERVER_BOOTSTRAP_SO_BACKLOG, 100);
 
         socketTimeOut = Util.getIntProperty(properties, Constants.SERVER_BOOTSTRAP_SO_TIMEOUT, 15);
-
     }
 
     public boolean isTcpNoDelay() {
@@ -87,22 +81,7 @@ public class ServerBootstrapConfiguration {
         return soBackLog;
     }
 
-    public static ServerBootstrapConfiguration getInstance() {
-        return bootstrapConfig;
-    }
-
     public int getSoTimeOut() {
         return socketTimeOut;
     }
-
-    /**
-     * configTargetHandler transport level properties such as socket timeouts, tcp no delay
-     *
-     * @param properties to create new bootstrap configuration.
-     */
-    public static void createBootStrapConfiguration(Map<String, Object> properties) {
-        bootstrapConfig = new ServerBootstrapConfiguration(properties);
-
-    }
-
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -30,12 +30,11 @@ import io.netty.handler.codec.http.HttpResponse;
 import org.wso2.carbon.messaging.MessageDataSource;
 import org.wso2.carbon.messaging.MessageUtil;
 import org.wso2.carbon.messaging.exceptions.MessagingException;
+import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.contract.ServerConnectorException;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpResponseStatusFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsServerConnectorFuture;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
-import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -59,18 +58,13 @@ public class HTTPCarbonMessage {
     private final HttpResponseStatusFuture httpOutboundRespStatusFuture = new HttpResponseStatusFuture();
 
     public HTTPCarbonMessage(HttpMessage httpMessage) {
-        int soTimeOut = 60;
-        BootstrapConfiguration clientBootstrapConfig = BootstrapConfiguration.getInstance();
-        if (clientBootstrapConfig != null) {
-            soTimeOut = clientBootstrapConfig.getSocketTimeout();
-        } else {
-            ServerBootstrapConfiguration serverBootstrapConfiguration = ServerBootstrapConfiguration.getInstance();
-            if (serverBootstrapConfiguration != null) {
-                soTimeOut = serverBootstrapConfiguration.getSoTimeOut();
-            }
-        }
         this.httpMessage = httpMessage;
-        setBlockingEntityCollector(new BlockingEntityCollector(soTimeOut));
+        setBlockingEntityCollector(new BlockingEntityCollector(Constants.ENDPOINT_TIMEOUT));
+    }
+
+    public HTTPCarbonMessage(HttpMessage httpMessage, int maxWaitTime) {
+        this.httpMessage = httpMessage;
+        setBlockingEntityCollector(new BlockingEntityCollector(maxWaitTime));
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPConnectorUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPConnectorUtil.java
@@ -73,8 +73,7 @@ public class HTTPConnectorUtil {
                     Collectors.toMap(TransportProperty::getName, TransportProperty::getValue));
         }
         // Create Bootstrap Configuration from listener parameters
-        ServerBootstrapConfiguration.createBootStrapConfiguration(transportProperties);
-        return ServerBootstrapConfiguration.getInstance();
+        return new ServerBootstrapConfiguration(transportProperties);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HTTPClientInitializer.java
@@ -29,6 +29,7 @@ import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.listener.CustomHttpContentCompressor;
 import org.wso2.transport.http.netty.listener.HTTPTraceLoggingHandler;
+import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import javax.net.ssl.SSLEngine;
 
@@ -47,8 +48,10 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
     private boolean chunkEnabled;
     private boolean isKeepAlive;
     private ProxyServerConfiguration proxyServerConfiguration;
+    private ConnectionManager connectionManager;
 
-    public HTTPClientInitializer(SenderConfiguration senderConfiguration, SSLEngine sslEngine) {
+    public HTTPClientInitializer(SenderConfiguration senderConfiguration, SSLEngine sslEngine,
+            ConnectionManager connectionManager) {
         this.sslEngine = sslEngine;
         this.httpTraceLogEnabled = senderConfiguration.isHttpTraceLogEnabled();
         this.followRedirect = senderConfiguration.isFollowRedirect();
@@ -56,6 +59,7 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
         this.chunkEnabled = senderConfiguration.isChunkEnabled();
         this.isKeepAlive = senderConfiguration.isKeepAlive();
         this.proxyServerConfiguration = senderConfiguration.getProxyServerConfiguration();
+        this.connectionManager = connectionManager;
     }
 
     @Override
@@ -91,7 +95,7 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
                 log.debug("Follow Redirect is enabled, so adding the redirect handler to the pipeline.");
             }
             RedirectHandler redirectHandler = new RedirectHandler(sslEngine, httpTraceLogEnabled, maxRedirectCount
-                    , chunkEnabled);
+                    , chunkEnabled, connectionManager);
             ch.pipeline().addLast(Constants.REDIRECT_HANDLER, redirectHandler);
         }
         handler = new TargetHandler();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectChannelInitializer.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.listener.HTTPTraceLoggingHandler;
+import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 
 import javax.net.ssl.SSLEngine;
 
@@ -42,16 +43,18 @@ public class RedirectChannelInitializer extends ChannelInitializer<SocketChannel
     private boolean chunkEnabled;
     private ChannelHandlerContext originalChannelContext;
     private boolean isIdleHandlerOfTargetChannelRemoved;
+    private ConnectionManager connectionManager;
 
-    public RedirectChannelInitializer(SSLEngine sslEngine, boolean httpTraceLogEnabled, int maxRedirectCount
-            , boolean chunkEnabled, ChannelHandlerContext originalChannelContext
-            , boolean isIdleHandlerOfTargetChannelRemoved) {
+    public RedirectChannelInitializer(SSLEngine sslEngine, boolean httpTraceLogEnabled, int maxRedirectCount,
+            boolean chunkEnabled, ChannelHandlerContext originalChannelContext,
+            boolean isIdleHandlerOfTargetChannelRemoved, ConnectionManager connectionManager) {
         this.sslEngine = sslEngine;
         this.httpTraceLogEnabled = httpTraceLogEnabled;
         this.maxRedirectCount = maxRedirectCount;
         this.chunkEnabled = chunkEnabled;
         this.originalChannelContext = originalChannelContext;
         this.isIdleHandlerOfTargetChannelRemoved = isIdleHandlerOfTargetChannelRemoved;
+        this.connectionManager = connectionManager;
     }
 
     @Override
@@ -72,7 +75,7 @@ public class RedirectChannelInitializer extends ChannelInitializer<SocketChannel
                                   new HTTPTraceLoggingHandler("tracelog.http.upstream"));
         }
         RedirectHandler redirectHandler = new RedirectHandler(sslEngine, httpTraceLogEnabled, maxRedirectCount
-                , chunkEnabled, originalChannelContext, isIdleHandlerOfTargetChannelRemoved);
+                , chunkEnabled, originalChannelContext, isIdleHandlerOfTargetChannelRemoved, connectionManager);
         ch.pipeline().addLast(Constants.REDIRECT_HANDLER, redirectHandler);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/BootstrapConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/BootstrapConfiguration.java
@@ -29,13 +29,10 @@ public class BootstrapConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(BootstrapConfiguration.class);
 
-    private static BootstrapConfiguration bootstrapConfig;
-
     private boolean tcpNoDelay, keepAlive, socketReuse;
-
     private int connectTimeOut, receiveBufferSize, sendBufferSize, socketTimeout;
 
-    private BootstrapConfiguration(Map<String, Object> properties) {
+    public BootstrapConfiguration(Map<String, Object> properties) {
 
         connectTimeOut = Util.getIntProperty(
                 properties, Constants.CLIENT_BOOTSTRAP_CONNECT_TIME_OUT, 15000);
@@ -93,14 +90,4 @@ public class BootstrapConfiguration {
     public int getSocketTimeout() {
         return socketTimeout;
     }
-
-    public static BootstrapConfiguration getInstance() {
-        return bootstrapConfig;
-    }
-
-    public static void createBootStrapConfiguration(Map<String, Object> transportProperties) {
-        bootstrapConfig = new BootstrapConfiguration(transportProperties);
-
-    }
-
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -151,6 +151,8 @@ public class ConnectionManager {
         if (targetChannel.getCorrelatedSource() != null) {
             Map<String, GenericObjectPool> objectPoolMap = targetChannel.getCorrelatedSource().getTargetChannelPool();
             releaseChannelToPool(targetChannel, objectPoolMap.get(targetChannel.getHttpRoute().toString()));
+        } else {
+            releaseChannelToPool(targetChannel, this.connGlobalPool.get(targetChannel.getHttpRoute().toString()));
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/ConnectionManager.java
@@ -25,6 +25,7 @@ import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.listener.SourceHandler;
+import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 
 import java.util.Map;
@@ -38,11 +39,11 @@ public class ConnectionManager {
     private EventLoopGroup clientEventGroup;
     private PoolConfiguration poolConfiguration;
     private PoolManagementPolicy poolManagementPolicy;
+    private BootstrapConfiguration bootstrapConfig;
     private final Map<String, GenericObjectPool> connGlobalPool;
-    private EventLoopGroup targetEventLoopGroup;
-    private static volatile ConnectionManager connectionManager;
 
-    private ConnectionManager(PoolConfiguration poolConfiguration, Map<String, Object> transportProperties) {
+    public ConnectionManager(PoolConfiguration poolConfiguration, Map<String, Object> transportProperties,
+            BootstrapConfiguration bootstrapConfiguration) {
         this.poolConfiguration = poolConfiguration;
         if (poolConfiguration.getNumberOfPools() == 1) {
             this.poolManagementPolicy = PoolManagementPolicy.LOCK_DEFAULT_POOLING;
@@ -50,7 +51,8 @@ public class ConnectionManager {
         connGlobalPool = new ConcurrentHashMap<>();
         clientEventGroup = new NioEventLoopGroup(
                 Util.getIntProperty(transportProperties, Constants.CLIENT_BOOTSTRAP_WORKER_GROUP_SIZE, 4));
-        targetEventLoopGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors() * 2);
+
+        this.bootstrapConfig = bootstrapConfiguration;
     }
 
     private GenericObjectPool createPoolForRoute(PoolableTargetChannelFactory poolableTargetChannelFactory) {
@@ -62,34 +64,15 @@ public class ConnectionManager {
                 instantiateAndConfigureConfig());
     }
 
-    public static ConnectionManager getInstance() {
-        return connectionManager;
-    }
-
-    public static void init(Map<String, Object> transportProperties) {
-        if (connectionManager == null) {
-            synchronized (ConnectionManager.class) {
-                if (connectionManager == null) {
-                    PoolConfiguration poolConfiguration = PoolConfiguration.getInstance();
-                    if (poolConfiguration == null) {
-                        PoolConfiguration.createPoolConfiguration(transportProperties);
-                        poolConfiguration = PoolConfiguration.getInstance();
-                    }
-                    connectionManager = new ConnectionManager(poolConfiguration, transportProperties);
-                }
-            }
-        }
-    }
-
     /**
      * @param httpRoute           BE address
      * @param sourceHandler       Incoming channel
-     * @param senderConfiguration The sender configuration instance
+     * @param senderConfig The sender configuration instance
      * @return the target channel which is requested for given parameters.
      * @throws Exception to notify any errors occur during retrieving the target channel
      */
     public TargetChannel borrowTargetChannel(HttpRoute httpRoute, SourceHandler sourceHandler,
-                                             SenderConfiguration senderConfiguration) throws Exception {
+                                             SenderConfiguration senderConfig) throws Exception {
         GenericObjectPool trgHlrConnPool;
 
         if (sourceHandler != null) {
@@ -104,7 +87,8 @@ public class ConnectionManager {
                 trgHlrConnPool = srcHlrConnPool.get(httpRoute.toString());
                 if (trgHlrConnPool == null) {
                     PoolableTargetChannelFactory poolableTargetChannelFactory =
-                            new PoolableTargetChannelFactory(group, cl, httpRoute, senderConfiguration);
+                            new PoolableTargetChannelFactory(group, cl, httpRoute, senderConfig,
+                                    bootstrapConfig, this);
                     trgHlrConnPool = createPoolForRoute(poolableTargetChannelFactory);
                     srcHlrConnPool.put(httpRoute.toString(), trgHlrConnPool);
                 }
@@ -115,7 +99,8 @@ public class ConnectionManager {
                     synchronized (this) {
                         if (!this.connGlobalPool.containsKey(httpRoute.toString())) {
                             PoolableTargetChannelFactory poolableTargetChannelFactory =
-                                    new PoolableTargetChannelFactory(group, cl, httpRoute, senderConfiguration);
+                                    new PoolableTargetChannelFactory(group,
+                                            cl, httpRoute, senderConfig, bootstrapConfig, this);
                             trgHlrConnPool = createPoolForRoute(poolableTargetChannelFactory);
                             this.connGlobalPool.put(httpRoute.toString(), trgHlrConnPool);
                         }
@@ -131,7 +116,8 @@ public class ConnectionManager {
             synchronized (this) {
                 if (!this.connGlobalPool.containsKey(httpRoute.toString())) {
                     PoolableTargetChannelFactory poolableTargetChannelFactory =
-                            new PoolableTargetChannelFactory(group, cl, httpRoute, senderConfiguration);
+                            new PoolableTargetChannelFactory(group, cl,
+                                    httpRoute, senderConfig, bootstrapConfig, this);
                     trgHlrConnPool = createPoolForRoute(poolableTargetChannelFactory);
                     this.connGlobalPool.put(httpRoute.toString(), trgHlrConnPool);
                 }
@@ -179,15 +165,6 @@ public class ConnectionManager {
                 throw new Exception("Cannot invalidate channel from pool", e);
             }
         }
-    }
-
-    /**
-     * Provide specific target channel map.
-     *
-     * @return Map contains pools for each route
-     */
-    public Map<String, GenericObjectPool> getTargetChannelPool() {
-        return this.connGlobalPool;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/PoolConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/PoolConfiguration.java
@@ -56,7 +56,7 @@ public class PoolConfiguration {
 
     private long setMaxWait = 60000L;
 
-    private PoolConfiguration(Map<String, Object> transportProperties) {
+    public PoolConfiguration(Map<String, Object> transportProperties) {
 
         numberOfPools = Util.getIntProperty(transportProperties, Constants.NUMBER_OF_POOLS, 0);
 
@@ -71,6 +71,9 @@ public class PoolConfiguration {
 
         minEvictableIdleTime = Util.getIntProperty(
                 transportProperties, Constants.MIN_EVICTION_IDLE_TIME, 5 * 60 * 1000);
+
+        timeBetweenEvictionRuns = Util.getIntProperty(
+                transportProperties, Constants.TIME_BETWEEN_EVICTION_RUNS, 30 * 1000);
 
         executorServiceThreads = Util.getIntProperty(
                 transportProperties, Constants.NO_THREADS_IN_EXECUTOR_SERVICE, 20);
@@ -87,7 +90,7 @@ public class PoolConfiguration {
         logger.debug(Constants.MAX_IDLE_CONNECTIONS_PER_POOL + ":" + maxIdlePerPool);
         logger.debug(Constants.MIN_EVICTION_IDLE_TIME + ":" + minEvictableIdleTime);
         logger.debug(Constants.NO_THREADS_IN_EXECUTOR_SERVICE + ":" + executorServiceThreads);
-        logger.debug("Time between Evictions Runs" + ":" + timeBetweenEvictionRuns);
+        logger.debug(Constants.TIME_BETWEEN_EVICTION_RUNS + ":" + timeBetweenEvictionRuns);
         logger.debug("Pool exhausted action" + ":" + exhaustedAction);
         logger.debug("Event group executor threads : " + eventGroupExecutorThreads);
     }
@@ -95,10 +98,6 @@ public class PoolConfiguration {
     public static PoolConfiguration getInstance() {
         return poolConfiguration;
 
-    }
-
-    public static void createPoolConfiguration(Map<String, Object> transportProperties) {
-        poolConfiguration = new PoolConfiguration(transportProperties);
     }
 
     public int getMaxActivePerPool() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolMainTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolMainTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.connectionpool;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.HTTPConnectorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+import org.wso2.transport.http.netty.util.server.initializers.SendChannelIDServerInitializer;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for connection pool implementation.
+ */
+public class ConnectionPoolMainTestCase {
+
+    private HttpServer httpServer;
+    private HttpClientConnector httpClientConnector;
+
+    @BeforeClass
+    public void setup() {
+        TransportsConfiguration transportsConfiguration = TestUtil.getConfiguration(
+                "/simple-test-config" + File.separator + "netty-transports.yml");
+
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new SendChannelIDServerInitializer());
+
+        HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
+        httpClientConnector = connectorFactory.createHttpClientConnector(
+                HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
+                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTP_SCHEME));
+    }
+
+    @Test
+    public void testConnectionReuseForMain() {
+        try {
+            CountDownLatch requestOneLatch = new CountDownLatch(1);
+            CountDownLatch requestTwoLatch = new CountDownLatch(1);
+            CountDownLatch requestThreeLatch = new CountDownLatch(1);
+
+            HTTPConnectorListener responseListener;
+
+            responseListener = sendRequestAsync(requestOneLatch);
+
+            // While the fist request is being processed by the back-end,
+            // we send the second request which forces the client connector to
+            // create a new connection.
+            Thread.sleep(2500);
+            sendRequestAsync(requestTwoLatch);
+
+            String responseOne = waitAndGetStringEntity(requestOneLatch, responseListener);
+
+            responseListener = sendRequestAsync(requestThreeLatch);
+            String responseThree = waitAndGetStringEntity(requestThreeLatch, responseListener);
+
+            assertEquals(responseOne, responseThree);
+
+            // Wait for response two to be completed before finishing the test
+            requestTwoLatch.await(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running testConnectionReuseForMain", e);
+        }
+    }
+
+    private String waitAndGetStringEntity(CountDownLatch latch, HTTPConnectorListener responseListener)
+            throws InterruptedException {
+        String response;
+        latch.await(10, TimeUnit.SECONDS);
+        HTTPCarbonMessage httpResponse = responseListener.getHttpResponseMessage();
+        response = new BufferedReader(new InputStreamReader(new HttpMessageDataStreamer(httpResponse)
+                .getInputStream()))
+                .lines().collect(Collectors.joining("\n"));
+        return response;
+    }
+
+    private HTTPConnectorListener sendRequestAsync(CountDownLatch latch) {
+        HTTPCarbonMessage httpsPostReq = TestUtil.
+                createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, "hello", "/");
+        HTTPConnectorListener requestListener = new HTTPConnectorListener(latch);
+        HttpResponseFuture responseFuture = httpClientConnector.send(httpsPostReq);
+        responseFuture.setHttpConnectorListener(requestListener);
+        return requestListener;
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(new ArrayList<>(), httpServer);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolMainTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolMainTestCase.java
@@ -25,24 +25,18 @@ import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.TransportsConfiguration;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
-import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
-import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.HTTPConnectorListener;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.initializers.SendChannelIDServerInitializer;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 
@@ -76,18 +70,18 @@ public class ConnectionPoolMainTestCase {
 
             HTTPConnectorListener responseListener;
 
-            responseListener = sendRequestAsync(requestOneLatch);
+            responseListener = TestUtil.sendRequestAsync(requestOneLatch, httpClientConnector);
 
             // While the first request is being processed by the back-end,
             // we send the second request which forces the client connector to
             // create a new connection.
             Thread.sleep(2500);
-            sendRequestAsync(requestTwoLatch);
+            TestUtil.sendRequestAsync(requestTwoLatch, httpClientConnector);
 
-            String responseOne = waitAndGetStringEntity(requestOneLatch, responseListener);
+            String responseOne = TestUtil.waitAndGetStringEntity(requestOneLatch, responseListener);
 
-            responseListener = sendRequestAsync(requestThreeLatch);
-            String responseThree = waitAndGetStringEntity(requestThreeLatch, responseListener);
+            responseListener = TestUtil.sendRequestAsync(requestThreeLatch, httpClientConnector);
+            String responseThree = TestUtil.waitAndGetStringEntity(requestThreeLatch, responseListener);
 
             assertEquals(responseOne, responseThree);
 
@@ -96,26 +90,6 @@ public class ConnectionPoolMainTestCase {
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running testConnectionReuseForMain", e);
         }
-    }
-
-    private String waitAndGetStringEntity(CountDownLatch latch, HTTPConnectorListener responseListener)
-            throws InterruptedException {
-        String response;
-        latch.await(10, TimeUnit.SECONDS);
-        HTTPCarbonMessage httpResponse = responseListener.getHttpResponseMessage();
-        response = new BufferedReader(new InputStreamReader(new HttpMessageDataStreamer(httpResponse)
-                .getInputStream()))
-                .lines().collect(Collectors.joining("\n"));
-        return response;
-    }
-
-    private HTTPConnectorListener sendRequestAsync(CountDownLatch latch) {
-        HTTPCarbonMessage httpsPostReq = TestUtil.
-                createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, "hello", "/");
-        HTTPConnectorListener requestListener = new HTTPConnectorListener(latch);
-        HttpResponseFuture responseFuture = httpClientConnector.send(httpsPostReq);
-        responseFuture.setHttpConnectorListener(requestListener);
-        return requestListener;
     }
 
     @AfterClass

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolProxyTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolProxyTestCase.java
@@ -25,36 +25,22 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.TransportsConfiguration;
-import org.wso2.transport.http.netty.contract.HttpClientConnector;
-import org.wso2.transport.http.netty.contract.HttpResponseFuture;
-import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
-import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
-import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
-import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.passthrough.PassthroughMessageProcessorListener;
-import org.wso2.transport.http.netty.util.HTTPConnectorListener;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.initializers.SendChannelIDServerInitializer;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -62,13 +48,12 @@ import static org.testng.AssertJUnit.assertNotNull;
 /**
  * Tests for connection pool implementation.
  */
-public class ConnectionPoolTestCase {
+public class ConnectionPoolProxyTestCase {
 
-    private static Logger logger = LoggerFactory.getLogger(ConnectionPoolTestCase.class);
+    private static Logger logger = LoggerFactory.getLogger(ConnectionPoolProxyTestCase.class);
 
     private HttpServer httpServer;
     private List<ServerConnector> serverConnectors;
-    private HttpClientConnector httpClientConnector;
     private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
     private ExecutorService executor = Executors.newFixedThreadPool(2);
 
@@ -80,11 +65,6 @@ public class ConnectionPoolTestCase {
         httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new SendChannelIDServerInitializer());
         serverConnectors = TestUtil.startConnectors(transportsConfiguration,
                 new PassthroughMessageProcessorListener(transportsConfiguration));
-
-        HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
-        httpClientConnector = connectorFactory.createHttpClientConnector(
-                HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
-                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTP_SCHEME));
     }
 
     @Test
@@ -111,43 +91,6 @@ public class ConnectionPoolTestCase {
             assertEquals(requestOneResponse.get(), requestThreeResponse.get());
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running testConnectionReuseForProxy", e);
-        }
-    }
-
-    @Test
-    public void testConnectionReuseForMain() {
-        try {
-            String result1;
-            String result2;
-
-            HTTPCarbonMessage httpsPostReq = TestUtil.
-                    createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, "", "/");
-
-            CountDownLatch latch = new CountDownLatch(1);
-            HTTPConnectorListener listener = new HTTPConnectorListener(latch);
-
-            HttpResponseFuture responseFuture = httpClientConnector.send(httpsPostReq);
-            responseFuture.setHttpConnectorListener(listener);
-            latch.await(5, TimeUnit.SECONDS);
-            HTTPCarbonMessage response = listener.getHttpResponseMessage();
-            assertNotNull(response);
-            String result = new BufferedReader(new InputStreamReader(new HttpMessageDataStreamer(response)
-                    .getInputStream()))
-                    .lines().collect(Collectors.joining("\n"));
-
-            responseFuture = httpClientConnector.send(httpsPostReq);
-            responseFuture.setHttpConnectorListener(listener);
-            latch.await(5, TimeUnit.SECONDS);
-            HTTPCarbonMessage response = listener.getHttpResponseMessage();
-            assertNotNull(response);
-            String result = new BufferedReader(new InputStreamReader(new HttpMessageDataStreamer(response)
-                    .getInputStream()))
-                    .lines().collect(Collectors.joining("\n"));
-
-
-
-        } catch (Exception e) {
-            TestUtil.handleException("IOException occurred while running passthroughPostTest", e);
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolProxyTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/connectionpool/ConnectionPoolProxyTestCase.java
@@ -62,7 +62,8 @@ public class ConnectionPoolProxyTestCase {
         TransportsConfiguration transportsConfiguration = TestUtil.getConfiguration(
                 "/simple-test-config" + File.separator + "netty-transports.yml");
 
-        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new SendChannelIDServerInitializer());
+        httpServer = TestUtil
+                .startHTTPServer(TestUtil.HTTP_SERVER_PORT, new SendChannelIDServerInitializer(5000));
         serverConnectors = TestUtil.startConnectors(transportsConfiguration,
                 new PassthroughMessageProcessorListener(transportsConfiguration));
     }
@@ -79,7 +80,7 @@ public class ConnectionPoolProxyTestCase {
 
             requestOneResponse = executor.submit(clientWorkerOne);
 
-            // While the fist request is being processed by the back-end,
+            // While the first request is being processed by the back-end,
             // we send the second request which forces the client connector to
             // create a new connection.
             Thread.sleep(2500);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -32,7 +32,6 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
@@ -120,7 +119,7 @@ public class CipherSuitesTest {
         listenerConfiguration.setParameters(serverParams);
 
         ServerConnector serverConnector = factory
-                .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = serverConnector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -31,7 +31,6 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
@@ -86,7 +85,7 @@ public class MutualSSLTestCase {
         listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
 
         ServerConnector connector = factory
-                .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = connector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -32,7 +32,6 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
@@ -113,8 +112,9 @@ public class SSLProtocolsTest {
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setScheme(Constants.HTTPS_SCHEME);
         listenerConfiguration.setParameters(severParams);
+
         serverConnector = factory
-                .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = serverConnector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -28,7 +28,6 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
@@ -88,7 +87,7 @@ public class PKCSTest {
         listenerConfiguration.setTlsStoreType(tlsStoreType);
 
         ServerConnector connector = factory
-                .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = connector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/ProxyServerTestCase.java
@@ -39,7 +39,6 @@ import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpCarbonRequest;
@@ -106,7 +105,7 @@ public class ProxyServerTestCase {
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(password);
         serverConnector = factory
-                .createServerConnector(ServerBootstrapConfiguration.getInstance(), listenerConfiguration);
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture future = serverConnector.start();
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestNGListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestNGListener.java
@@ -41,7 +41,7 @@ public class TestNGListener extends TestListenerAdapter {
             for (String wordOfName: testClassWords) {
                 testClassNameFull = testClassNameFull + wordOfName + " ";
             }
-            printStream.println("Start Running " + testClassNameFull.trim() + "..................");
+            printStream.println("Start Running " + testClassNameFull.trim() + " ...");
         }
     }
 
@@ -70,6 +70,4 @@ public class TestNGListener extends TestListenerAdapter {
         LoggerFactory.getLogger(tr.getTestClass().getRealClass()).error(
                 "Test failed: " + testCase + "-> " + e.getMessage());
     }
-
-
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -21,7 +21,6 @@ package org.wso2.transport.http.netty.util;
 import com.google.common.io.ByteStreams;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
@@ -39,7 +38,6 @@ import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
@@ -105,8 +103,8 @@ public class TestUtil {
         }
 
         try {
-            HTTPTransportContextHolder.getInstance().getBossGroup().shutdownGracefully().sync();
-            HTTPTransportContextHolder.getInstance().getWorkerGroup().shutdownGracefully().sync();
+//            HTTPTransportContextHolder.getInstance().getBossGroup().shutdownGracefully().sync();
+//            HTTPTransportContextHolder.getInstance().getWorkerGroup().shutdownGracefully().sync();
             httpServer.shutdown();
         } catch (InterruptedException e) {
             log.error("Thread Interrupted while sleeping ", e);
@@ -122,8 +120,8 @@ public class TestUtil {
                 configuration.getTransportProperties());
         Set<ListenerConfiguration> listenerConfigurationSet = transportsConfiguration.getListenerConfigurations();
 
-        HTTPTransportContextHolder.getInstance().setWorkerGroup(new NioEventLoopGroup());
-        HTTPTransportContextHolder.getInstance().setBossGroup(new NioEventLoopGroup());
+//        HTTPTransportContextHolder.getInstance().setWorkerGroup(new NioEventLoopGroup());
+//        HTTPTransportContextHolder.getInstance().setBossGroup(new NioEventLoopGroup());
 
         connectors = new ArrayList<>();
         futures = new ArrayList<>();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -40,7 +40,6 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
 import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
-import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.HttpsServer;
 import org.wso2.transport.http.netty.util.server.ServerThread;
@@ -96,10 +95,6 @@ public class TestUtil {
             throws ServerConnectorException {
         for (ServerConnector httpServerConnector : serverConnectors) {
             httpServerConnector.stop();
-        }
-
-        if (ConnectionManager.getInstance() != null) {
-            ConnectionManager.getInstance().getTargetChannelPool().clear();
         }
 
         try {
@@ -214,8 +209,7 @@ public class TestUtil {
                     Collectors.toMap(TransportProperty::getName, TransportProperty::getValue));
         }
         // Create Bootstrap Configuration from listener parameters
-        ServerBootstrapConfiguration.createBootStrapConfiguration(transportProperties);
-        return ServerBootstrapConfiguration.getInstance();
+        return new ServerBootstrapConfiguration(transportProperties);
     }
 
     public static TransportsConfiguration getConfiguration(String configFileLocation) {
@@ -258,6 +252,10 @@ public class TestUtil {
         httpPostRequest.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
 
         return httpPostRequest;
+    }
+
+    public static ServerBootstrapConfiguration getDefaultServerBootstrapConfig() {
+        return new ServerBootstrapConfiguration(new HashMap<>());
     }
 }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -103,8 +103,6 @@ public class TestUtil {
         }
 
         try {
-//            HTTPTransportContextHolder.getInstance().getBossGroup().shutdownGracefully().sync();
-//            HTTPTransportContextHolder.getInstance().getWorkerGroup().shutdownGracefully().sync();
             httpServer.shutdown();
         } catch (InterruptedException e) {
             log.error("Thread Interrupted while sleeping ", e);
@@ -119,9 +117,6 @@ public class TestUtil {
         ServerBootstrapConfiguration serverBootstrapConfiguration = getServerBootstrapConfiguration(
                 configuration.getTransportProperties());
         Set<ListenerConfiguration> listenerConfigurationSet = transportsConfiguration.getListenerConfigurations();
-
-//        HTTPTransportContextHolder.getInstance().setWorkerGroup(new NioEventLoopGroup());
-//        HTTPTransportContextHolder.getInstance().setBossGroup(new NioEventLoopGroup());
 
         connectors = new ArrayList<>();
         futures = new ArrayList<>();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/SendChannelIDServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/SendChannelIDServerInitializer.java
@@ -48,10 +48,12 @@ public class SendChannelIDServerInitializer extends HTTPServerInitializer {
 
     private static final Logger logger = LoggerFactory.getLogger(SendChannelIDServerInitializer.class);
 
+    private int delay;
     private HttpRequest req;
     private AtomicInteger requestCount = new AtomicInteger(0);
 
-    public SendChannelIDServerInitializer() {
+    public SendChannelIDServerInitializer(int delay) {
+        this.delay = delay;
     }
 
     protected void addBusinessLogicHandler(Channel channel) {
@@ -83,7 +85,7 @@ public class SendChannelIDServerInitializer extends HTTPServerInitializer {
                     response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
                     if (requestCount.get() < 1) {
                         // this need in order to simulate a delay
-                        Thread.sleep(5000);
+                        Thread.sleep(delay);
                     }
                     ctx.writeAndFlush(response);
                     requestCount.incrementAndGet();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
@@ -28,7 +28,6 @@ import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.util.TestUtil;
 
 import java.io.IOException;
@@ -51,7 +50,7 @@ public class HttpToWsProtocolSwitchTestCase {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
-        serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
+        serverConnector = httpConnectorFactory.createServerConnector(TestUtil.getDefaultServerBootstrapConfig(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();
         connectorFuture.setWSConnectorListener(new HttpToWsProtocolSwitchWebSocketListener());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketMessagePropertiesTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketMessagePropertiesTestCase.java
@@ -30,7 +30,6 @@ import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.websocket.WebSocketTestClient;
 
@@ -55,7 +54,7 @@ public class WebSocketMessagePropertiesTestCase {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
-        serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
+        serverConnector = httpConnectorFactory.createServerConnector(TestUtil.getDefaultServerBootstrapConfig(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();
         connectorFuture.setWSConnectorListener(new WebSocketMessagePropertiesConnectorListener());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassThroughTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassThroughTestCase.java
@@ -31,7 +31,6 @@ import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.websocket.WebSocketTestClient;
 import org.wso2.transport.http.netty.util.server.websocket.WebSocketRemoteServer;
@@ -62,7 +61,7 @@ public class WebSocketPassThroughTestCase {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
-        serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
+        serverConnector = httpConnectorFactory.createServerConnector(TestUtil.getDefaultServerBootstrapConfig(),
                                                                      listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();
         connectorFuture.setWSConnectorListener(new WebSocketPassthroughServerConnectorListener());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketServerTestCase.java
@@ -30,7 +30,6 @@ import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
-import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.websocket.WebSocketTestClient;
 import org.wso2.transport.http.netty.util.client.websocket.WebSocketTestConstants;
@@ -61,7 +60,7 @@ public class WebSocketServerTestCase {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost("localhost");
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
-        serverConnector = httpConnectorFactory.createServerConnector(ServerBootstrapConfiguration.getInstance(),
+        serverConnector = httpConnectorFactory.createServerConnector(TestUtil.getDefaultServerBootstrapConfig(),
                 listenerConfiguration);
         ServerConnectorFuture connectorFuture = serverConnector.start();
         connectorFuture.setWSConnectorListener(new WebSocketTestServerConnectorListener());
@@ -169,7 +168,7 @@ public class WebSocketServerTestCase {
         listenerConfiguration.setHost("localhost");
         listenerConfiguration.setPort(TestUtil.ALTER_INTERFACE_PORT);
         ServerConnector alterServerConnector = httpConnectorFactory.createServerConnector(
-                ServerBootstrapConfiguration.getInstance(),
+                TestUtil.getDefaultServerBootstrapConfig(),
                 listenerConfiguration);
         ServerConnectorFuture connectorFuture = alterServerConnector.start();
         WebSocketTestServerConnectorListener listener = new WebSocketTestServerConnectorListener();

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -39,7 +39,8 @@
             <class name="org.wso2.transport.http.netty.ClientConnectorTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.ClientConnectorConnectionRefusedTestCase" />
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkHeaderClientTestCase" />
-            <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolTestCase" />
+            <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolProxyTestCase" />
+            <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolMainTestCase" />
             <!--<class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />-->
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.websocket.WebSocketServerTestCase"/>

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -41,6 +41,7 @@
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkHeaderClientTestCase" />
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolProxyTestCase" />
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolMainTestCase" />
+            <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolEvictionTestCase" />
             <!--<class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />-->
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.websocket.WebSocketServerTestCase"/>


### PR DESCRIPTION
## Purpose
> While writing a test-cases I realized that making ConnectionManager singleton is wrong. Ideally, it should be per client connector. In addition to that, having singletons turn out to be a bad practice. 

> Hence, I thought of making ConnectionManager per client-connector. While doing so I came across few other singletons which I have removed with this PR.

> In addition to that, When the client connector is used without any association with the server connector, connection pool is not reusing the connections. This has been fixed with this PR as well.

## Goals
> Improving connection pool implementation.

## Approach
> Re-using the global connection pool to fix the bug and removing singleton to make the code clean.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Added

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A