### PR TITLE
Fix the logger error getting printed twice when handling redirect exceptions

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
@@ -126,7 +126,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
     }
 
     /**
-     * When an exception occurs, notify the listener.
+     * When an exception occurs in channel pipeline, log error and notify the listener.
      *
      * @param ctx   Channel context
      * @param cause Exception occurred
@@ -134,6 +134,16 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         LOG.error("Exception occurred in RedirectHandler.", cause);
+        handleException(ctx, cause);
+    }
+
+    /**
+     * Notify listener about the exception and close the channel.
+     *
+     * @param ctx   Channel context
+     * @param cause Exception occurred
+     */
+    private void handleException(ChannelHandlerContext ctx, Throwable cause) {
         if (ctx != null && ctx.channel().isActive()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(" And Channel ID is : " + ctx.channel().id());
@@ -249,10 +259,10 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         } catch (UnsupportedEncodingException exception) {
             LOG.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
                     exception);
-            exceptionCaught(ctx, exception.getCause());
+            handleException(ctx, exception.getCause());
         } catch (MalformedURLException exception) {
             LOG.error("MalformedURLException occurred when deciding whether a redirection is required", exception);
-            exceptionCaught(ctx, exception.getCause());
+            handleException(ctx, exception.getCause());
         }
     }
 
@@ -279,10 +289,10 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                 }
             } catch (MalformedURLException exception) {
                 LOG.error("Error occurred when parsing redirect url", exception);
-                exceptionCaught(ctx, exception.getCause());
+                handleException(ctx, exception.getCause());
             } catch (Exception exception) {
                 LOG.error("Error occurred during redirection", exception);
-                exceptionCaught(ctx, exception.getCause());
+                handleException(ctx, exception.getCause());
             }
         } else {
             if (LOG.isDebugEnabled()) {
@@ -351,7 +361,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                     "Error occurred while returning target channel " + targetChannel.getChannel().id() + " from current"
                             + " channel" + ctx.channel().id() + " " + "to its pool in " + "markEndOfMessage",
                     exception);
-            exceptionCaught(ctx, exception.getCause());
+            handleException(ctx, exception.getCause());
         }
     }
 
@@ -430,32 +440,31 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         Map<String, String> redirectState = new HashMap<String, String>();
         String originalRequestMethod =
                 originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_METHOD) : null;
-
         switch (statusCode) {
-        case 300:
-        case 307:
-        case 308:
-        case 305:
-            if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
-                    .equals(originalRequestMethod)) {
-                redirectState.put(Constants.HTTP_METHOD, originalRequestMethod);
-                redirectState.put(Constants.LOCATION, getLocationURI(location, originalRequest));
-            }
-            break;
-        case 301:
-        case 302:
-            if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
-                    .equals(originalRequestMethod)) {
+            case 300:
+            case 307:
+            case 308:
+            case 305:
+                if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
+                        .equals(originalRequestMethod)) {
+                    redirectState.put(Constants.HTTP_METHOD, originalRequestMethod);
+                    redirectState.put(Constants.LOCATION, getLocationURI(location, originalRequest));
+                }
+                break;
+            case 301:
+            case 302:
+                if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
+                        .equals(originalRequestMethod)) {
+                    redirectState.put(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
+                    redirectState.put(Constants.LOCATION, getLocationURI(location, originalRequest));
+                }
+                break;
+            case 303:
                 redirectState.put(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
                 redirectState.put(Constants.LOCATION, getLocationURI(location, originalRequest));
-            }
-            break;
-        case 303:
-            redirectState.put(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
-            redirectState.put(Constants.LOCATION, getLocationURI(location, originalRequest));
-            break;
-        default:
-            return null;
+                break;
+            default:
+                return null;
         }
         return redirectState;
     }
@@ -709,7 +718,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                 }
             } else {
                 LOG.error("Error occurred while trying to connect to redirect channel.", future.cause());
-                exceptionCaught(channelHandlerContext, future.cause());
+                handleException(channelHandlerContext, future.cause());
             }
         });
     }
@@ -776,6 +785,3 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         return defaultPort;
     }
 }
-
-
-


### PR DESCRIPTION
## Purpose
> Purpose is to fix the logger error getting printed twice in case an exception is thrown from RedirectHandler

## Goals
> Separate netty exception handling logic from error handling done for the program code. 

## Approach
> A common error handling logic is moved to a separate method. 

