### PR TITLE
Add unit test cases to validate duplicate header key insertion

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -265,7 +265,7 @@ public class HTTPCarbonMessage {
             httpHeaders = new DefaultHttpHeaders();
             List<Map.Entry<String, String>> headerList = this.httpMessage.headers().entries();
             for (Map.Entry<String, String> entry : headerList) {
-                httpHeaders.set(entry.getKey(), entry.getValue());
+                httpHeaders.add(entry.getKey(), entry.getValue());
             }
         } else {
             HttpResponse httpResponse = (HttpResponse) this.httpMessage;
@@ -274,11 +274,11 @@ public class HTTPCarbonMessage {
             httpHeaders = new DefaultHttpHeaders();
             List<Map.Entry<String, String>> headerList = this.httpMessage.headers().entries();
             for (Map.Entry<String, String> entry : headerList) {
-                httpHeaders.set(entry.getKey(), entry.getValue());
+                httpHeaders.add(entry.getKey(), entry.getValue());
             }
         }
         HTTPCarbonMessage httpCarbonMessage = new HTTPCarbonMessage(newHttpMessage);
-        httpCarbonMessage.setHeaders(httpHeaders);
+        httpCarbonMessage.getHeaders().set(httpHeaders);
         return httpCarbonMessage;
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/CommonUtilTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/CommonUtilTestCase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.unitfunction;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.common.Util;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+/**
+ * A unit test class for common/Util functions.
+ */
+public class CommonUtilTestCase {
+
+    @Test(description = "Test setting headers to Http request with duplicate header keys")
+    public void createHttpRequest() {
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set("aaa", "123");
+        headers.add("aaa", "xyz");
+        HTTPCarbonMessage outboundRequestMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.POST, "", headers));
+        outboundRequestMsg.setProperty(Constants.TO, "/hello");
+        HttpRequest outboundNettyRequest = Util.createHttpRequest(outboundRequestMsg);
+
+        Assert.assertEquals(outboundNettyRequest.method(), HttpMethod.POST);
+        Assert.assertEquals(outboundNettyRequest.protocolVersion(), HttpVersion.HTTP_1_1);
+        Assert.assertEquals(outboundNettyRequest.uri(), "/hello");
+        Assert.assertEquals(outboundNettyRequest.headers().getAll("aaa").size(), 2);
+        Assert.assertEquals(outboundNettyRequest.headers().getAll("aaa").get(0), "123");
+        Assert.assertEquals(outboundNettyRequest.headers().getAll("aaa").get(1), "xyz");
+    }
+
+    @Test(description = "Test setting headers to Http response with duplicate header keys")
+    public void createHttpResponse() {
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set("aaa", "123");
+        headers.add("aaa", "xyz");
+        HTTPCarbonMessage outboundResponseMsg = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.OK, headers));
+        HttpResponse outboundNettyResponse = Util.createHttpResponse(outboundResponseMsg, true);
+
+        Assert.assertEquals(outboundNettyResponse.protocolVersion(), HttpVersion.HTTP_1_1);
+        Assert.assertEquals(outboundNettyResponse.status(), HttpResponseStatus.OK);
+        Assert.assertEquals(outboundNettyResponse.headers().getAll("aaa").size(), 2);
+        Assert.assertEquals(outboundNettyResponse.headers().getAll("aaa").get(0), "123");
+        Assert.assertEquals(outboundNettyResponse.headers().getAll("aaa").get(1), "xyz");
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/HttpCarbonMessageTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/HttpCarbonMessageTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.unitfunction;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.nio.charset.Charset;
+
+/**
+ * A unit test class for message/HTTPCarbonMessage functions.
+ */
+public class HttpCarbonMessageTestCase {
+
+    @Test(description = "Test cloneCarbonMessageWithData to Http request with duplicate header keys")
+    public void cloneCarbonMessageWithData() {
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set("aaa", "123");
+        headers.add("aaa", "xyz");
+        HTTPCarbonMessage outboundRequestMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.POST, "", headers));
+        outboundRequestMsg.setProperty(Constants.TO, "/hello");
+        outboundRequestMsg.addHttpContent(new DefaultLastHttpContent(
+                Unpooled.wrappedBuffer("testRequestHeaders".getBytes(Charset.defaultCharset()))));
+        HTTPCarbonMessage clonedMsg = outboundRequestMsg.cloneCarbonMessageWithData();
+
+        Assert.assertEquals(clonedMsg.getNettyHttpRequest().method(), HttpMethod.POST);
+        Assert.assertEquals(clonedMsg.getNettyHttpRequest().protocolVersion(), HttpVersion.HTTP_1_1);
+        Assert.assertEquals(clonedMsg.getProperty(Constants.TO), "/hello");
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").size(), 2);
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").get(0), "123");
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").get(1), "xyz");
+    }
+
+    @Test(description = "Test cloneCarbonMessageWithOutData to Http response with duplicate header keys")
+    public void cloneCarbonMessageWithOutData() {
+        HttpHeaders headers = new DefaultHttpHeaders();
+        headers.set("aaa", "123");
+        headers.add("aaa", "xyz");
+        HTTPCarbonMessage outboundResponseMsg = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.OK, headers));
+        HTTPCarbonMessage clonedMsg = outboundResponseMsg.cloneCarbonMessageWithOutData();
+
+        Assert.assertEquals(clonedMsg.getNettyHttpResponse().protocolVersion(), HttpVersion.HTTP_1_1);
+        Assert.assertEquals(clonedMsg.getNettyHttpResponse().status(), HttpResponseStatus.OK);
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").size(), 2);
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").get(0), "123");
+        Assert.assertEquals(clonedMsg.getHeaders().getAll("aaa").get(1), "xyz");
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -55,6 +55,9 @@
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolEvictionTestCase" />
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolMaxConnTestCase" />
 
+            <class name="org.wso2.transport.http.netty.unitfunction.CommonUtilTestCase" />
+            <class name="org.wso2.transport.http.netty.unitfunction.HttpCarbonMessageTestCase" />
+
             <!--<class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />-->
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
 


### PR DESCRIPTION
## Purpose
> Validate duplicate header keys existence in transport carbon message

## Goals
> If a user adds same header key multiple times with different header values, those should not be neglected. 

## Approach
> Add headers to Http request/response rather than replacing same header key with different values. Most of the times, old headers have been replaced by the new headers of the same key. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Adding using this PR
 - Integration tests
   > N/A

## Security checks
 N/A

## Samples
> N/A

## Related PRs
> #41 

## Migrations (if applicable)
> N/A

## Test environment
> Java jdk 1.8.0_45 , Linux 16.04
 
## Learning
> N/A