### PR TITLE
Add support for handling HTTP 1.0 messages 

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -266,6 +266,9 @@ public final class Constants {
     public static final String REMOTE_CLIENT_ABRUPTLY_CLOSE_RESPONSE_CONNECTION
             = "Remote client closed the connection before completing outbound response";
 
+    public static final String REMOTE_SERVER_CLOSE_RESPONSE_CONNECTION_AFTER_REQUEST_READ
+            = "Remote host closed the connection without sending inbound response";
+
     private Constants() {
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -150,6 +150,8 @@ public final class Constants {
     public static final String SRC_HANDLER = "SRC_HANDLER";
     public static final String POOLED_BYTE_BUFFER_FACTORY = "POOLED_BYTE_BUFFER_FACTORY";
     public static final String DEFAULT_VERSION_HTTP_1_1 = "HTTP/1.1";
+    public static final float HTTP_1_1 = 1.1f;
+    public static final String HTTP_VERSION_PREFIX = "HTTP/";
 
     //Server Connection Related Parameters
     public static final String LOCAL_ADDRESS = "LOCAL_ADDRESS";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -151,6 +151,7 @@ public final class Constants {
     public static final String POOLED_BYTE_BUFFER_FACTORY = "POOLED_BYTE_BUFFER_FACTORY";
     public static final String DEFAULT_VERSION_HTTP_1_1 = "HTTP/1.1";
     public static final float HTTP_1_1 = 1.1f;
+    public static final float HTTP_1_0 = 1.0f;
     public static final String HTTP_VERSION_PREFIX = "HTTP/";
 
     //Server Connection Related Parameters

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -74,10 +74,7 @@ public class Util {
 
         if (!keepAlive && (Float.valueOf(inboundReqHttpVersion) >= Constants.HTTP_1_1)) {
             outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
-        } else {
-            outboundResponseMsg.removeHeader(Constants.HTTP_CONNECTION);
-        }
-        if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < Constants.HTTP_1_1)) {
+        } else if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < Constants.HTTP_1_1)) {
             outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
         } else {
             outboundResponseMsg.removeHeader(Constants.HTTP_CONNECTION);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -68,16 +68,16 @@ public class Util {
     public static HttpResponse createHttpResponse(HTTPCarbonMessage outboundResponseMsg, String inboundReqHttpVersion,
             String serverName, boolean keepAlive) {
 
-        HttpVersion httpVersion = new HttpVersion("HTTP/" + inboundReqHttpVersion, true);
+        HttpVersion httpVersion = new HttpVersion(Constants.HTTP_VERSION_PREFIX + inboundReqHttpVersion, true);
         HttpResponseStatus httpResponseStatus = getHttpResponseStatus(outboundResponseMsg);
         HttpResponse outboundNettyResponse = new DefaultHttpResponse(httpVersion, httpResponseStatus, false);
 
-        if (!keepAlive && (Float.valueOf(inboundReqHttpVersion) >= 1.1)) {
+        if (!keepAlive && (Float.valueOf(inboundReqHttpVersion) >= Constants.HTTP_1_1)) {
             outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
         } else {
             outboundResponseMsg.removeHeader(Constants.HTTP_CONNECTION);
         }
-        if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < 1.1)) {
+        if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < Constants.HTTP_1_1)) {
             outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
         } else {
             outboundResponseMsg.removeHeader(Constants.HTTP_CONNECTION);
@@ -126,7 +126,8 @@ public class Util {
     private static HttpVersion getHttpVersion(HTTPCarbonMessage outboundRequestMsg) {
         HttpVersion httpVersion;
         if (null != outboundRequestMsg.getProperty(Constants.HTTP_VERSION)) {
-            httpVersion = new HttpVersion("HTTP/" + outboundRequestMsg.getProperty(Constants.HTTP_VERSION), true);
+            httpVersion = new HttpVersion(Constants.HTTP_VERSION_PREFIX
+                    + outboundRequestMsg.getProperty(Constants.HTTP_VERSION), true);
         } else {
             httpVersion = new HttpVersion(Constants.DEFAULT_VERSION_HTTP_1_1, true);
         }
@@ -173,7 +174,7 @@ public class Util {
      * @return  boolean value of status.
      */
     public static boolean isVersionCompatibleForChunking(String httpVersion) {
-        return Float.valueOf(httpVersion) >= 1.1;
+        return Float.valueOf(httpVersion) >= Constants.HTTP_1_1;
     }
 
     public static SSLConfig getSSLConfigForListener(String certPass, String keyStorePass, String keyStoreFilePath,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.wso2.transport.http.netty.config;
 
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
@@ -94,7 +93,7 @@ public class SenderConfiguration {
     private boolean isKeepAlive = true;
 
     private String tlsStoreType;
-    private String httpVersion = Constants.DEFAULT_VERSION_HTTP_1_1;
+    private String httpVersion = "1.1";
     private ProxyServerConfiguration proxyServerConfiguration;
 
     public SenderConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -94,9 +94,9 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                             setChannelAttributes(channelFuture.channel(), httpOutboundRequest, httpResponseFuture,
                                                  targetChannel);
                         }
-                        if (!keepAlive && Float.valueOf(httpVersion) >= 1.1) {
+                        if (!keepAlive && Float.valueOf(httpVersion) >= Constants.HTTP_1_1) {
                             httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_CLOSE);
-                        } else if (keepAlive && Float.valueOf(httpVersion) < 1.1) {
+                        } else if (keepAlive && Float.valueOf(httpVersion) < Constants.HTTP_1_1) {
                             httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
                         }
                         targetChannel.writeContent(httpOutboundRequest);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -94,8 +94,10 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                             setChannelAttributes(channelFuture.channel(), httpOutboundRequest, httpResponseFuture,
                                                  targetChannel);
                         }
-                        if (!keepAlive) {
+                        if (!keepAlive && Float.valueOf(httpVersion) >= 1.1) {
                             httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_CLOSE);
+                        } else if (keepAlive && Float.valueOf(httpVersion) < 1.1) {
+                            httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
                         }
                         targetChannel.writeContent(httpOutboundRequest);
                     } else {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -183,7 +183,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     private boolean isKeepAlive() {
         String requestConnectionHeader = requestDataHolder.getConnectionHeaderValue();
 
-        if (Float.valueOf(requestDataHolder.getHttpVersion()) <= 1.0) {
+        if (Float.valueOf(requestDataHolder.getHttpVersion()) <= Constants.HTTP_1_0) {
             return requestConnectionHeader != null && requestConnectionHeader
                     .equalsIgnoreCase(Constants.CONNECTION_KEEP_ALIVE);
         } else {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -77,7 +77,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                 handlerExecutor.executeAtSourceResponseReceiving(outboundResponseMsg);
             }
 
-            boolean keepAlive = isKeepAlive(outboundResponseMsg);
+            boolean keepAlive = isKeepAlive();
 
             outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent ->
                     this.sourceContext.channel().eventLoop().execute(() -> {
@@ -136,7 +136,8 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
 
     private ChannelFuture writeOutboundResponseBody(HttpContent lastHttpContent) {
         HttpResponseFuture outboundRespStatusFuture = inboundRequestMsg.getHttpOutboundRespStatusFuture();
-        if (chunkConfig == ChunkConfig.NEVER) {
+        if (chunkConfig == ChunkConfig.NEVER ||
+                !Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion())) {
             for (HttpContent cachedHttpContent : contentList) {
                 ChannelFuture outboundResponseChannelFuture = sourceContext.writeAndFlush(cachedHttpContent);
                 notifyIfFailure(outboundRespStatusFuture, outboundResponseChannelFuture);
@@ -179,30 +180,27 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     }
 
     // Decides whether to close the connection after sending the response
-    private boolean isKeepAlive(HTTPCarbonMessage responseMsg) {
-        String responseConnectionHeader = responseMsg.getHeader(Constants.HTTP_CONNECTION);
+    private boolean isKeepAlive() {
         String requestConnectionHeader = requestDataHolder.getConnectionHeaderValue();
-        if ((responseConnectionHeader != null &&
-                Constants.CONNECTION_CLOSE.equalsIgnoreCase(responseConnectionHeader))
-                || (requestConnectionHeader != null &&
-                Constants.CONNECTION_CLOSE.equalsIgnoreCase(requestConnectionHeader))) {
-            return false;
+
+        if (Float.valueOf(requestDataHolder.getHttpVersion()) <= 1.0) {
+            return requestConnectionHeader != null && requestConnectionHeader
+                    .equalsIgnoreCase(Constants.CONNECTION_KEEP_ALIVE);
+        } else {
+            return requestConnectionHeader == null || !requestConnectionHeader
+                    .equalsIgnoreCase(Constants.CONNECTION_CLOSE);
         }
-        return true;
+    }
+
+    private void writeOutboundResponseHeaders(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive) {
+        HttpResponse response = Util.createHttpResponse(outboundResponseMsg, requestDataHolder.getHttpVersion(),
+                serverName, keepAlive);
+        isHeaderWritten = true;
+        sourceContext.write(response);
     }
 
     @Override
     public void onError(Throwable throwable) {
-
-    }
-
-    private void writeOutboundResponseHeaders(HTTPCarbonMessage httpOutboundRequest, boolean keepAlive) {
-        HttpResponse response = Util.createHttpResponse(httpOutboundRequest, keepAlive);
-        if (response.headers().get(Constants.HTTP_SERVER_HEADER) == null) {
-            response.headers().add(Constants.HTTP_SERVER_HEADER, serverName);
-        }
-
-        isHeaderWritten = true;
-        sourceContext.write(response);
+        log.error("Couldn't send the outbound response", throwable);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleStateEvent;
 import org.apache.commons.pool.impl.GenericObjectPool;
@@ -212,7 +213,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         return ctx;
     }
 
-    protected HTTPCarbonMessage setupCarbonMessage(HttpMessage httpMessage, ChannelHandlerContext ctx)
+    HTTPCarbonMessage setupCarbonMessage(HttpMessage httpMessage, ChannelHandlerContext ctx)
             throws URISyntaxException {
 
         if (handlerExecutor != null) {
@@ -225,7 +226,9 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         HttpRequest httpRequest = (HttpRequest) httpMessage;
         sourceReqCmsg.setProperty(Constants.CHNL_HNDLR_CTX, this.ctx);
         sourceReqCmsg.setProperty(Constants.SRC_HANDLER, this);
-        sourceReqCmsg.setProperty(Constants.HTTP_VERSION, httpRequest.protocolVersion().text());
+        HttpVersion protocolVersion = httpRequest.protocolVersion();
+        sourceReqCmsg.setProperty(Constants.HTTP_VERSION,
+                protocolVersion.majorVersion() + "." + protocolVersion.minorVersion());
         sourceReqCmsg.setProperty(Constants.HTTP_METHOD, httpRequest.method().name());
         InetSocketAddress localAddress = null;
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -145,11 +145,15 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         }
 
         closeChannel(ctx);
-        connectionManager.invalidateTargetChannel(targetChannel);
 
-        if (targetRespMsg != null && !idleTimeout) {
+        if (targetChannel.isRequestWritten()) {
+            httpResponseFuture.notifyHttpListener(
+                    new ClientConnectorException(Constants.REMOTE_SERVER_CLOSE_RESPONSE_CONNECTION_AFTER_REQUEST_READ));
+        } else if (targetRespMsg != null && !idleTimeout) {
             handleIncompleteInboundResponse(Constants.REMOTE_SERVER_ABRUPTLY_CLOSE_RESPONSE_CONNECTION);
         }
+
+        connectionManager.invalidateTargetChannel(targetChannel);
 
         if (handlerExecutor != null) {
             handlerExecutor.executeAtTargetConnectionTermination(Integer.toString(ctx.hashCode()));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
@@ -220,7 +220,7 @@ public class TargetChannel {
     }
 
     private void writeOutboundRequestBody(HttpContent lastHttpContent) {
-        if (chunkConfig == ChunkConfig.NEVER) {
+        if (chunkConfig == ChunkConfig.NEVER || !Util.isVersionCompatibleForChunking(httpVersion)) {
             for (HttpContent cachedHttpContent : contentList) {
                 ChannelFuture outboundRequestChannelFuture = this.getChannel().writeAndFlush(cachedHttpContent);
                 notifyIfFailure(outboundRequestChannelFuture);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorClosureAfterRequestReadTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorClosureAfterRequestReadTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ChunkConfig;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+import org.wso2.transport.http.netty.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
+import org.wso2.transport.http.netty.util.HTTPConnectorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+import org.wso2.transport.http.netty.util.server.initializers.BadEchoServerInitializer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * Tests for HTTP client connector connection closure after request read.
+ */
+public class ClientConnectorClosureAfterRequestReadTestCase {
+
+    private static Logger logger = LoggerFactory.getLogger(ClientConnectorClosureAfterRequestReadTestCase.class);
+
+    private HttpServer httpServer;
+    private HttpClientConnector httpClientConnector;
+    private HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
+
+    @BeforeClass
+    public void setup() {
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new BadEchoServerInitializer());
+
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setChunkingConfig(ChunkConfig.NEVER);
+
+        httpClientConnector = connectorFactory.createHttpClientConnector(
+                HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
+                senderConfiguration);
+    }
+
+    @Test
+    public void testHttpsGet() {
+        try {
+            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, TestUtil.smallEntity, "");
+
+            CountDownLatch latch = new CountDownLatch(1);
+            HTTPConnectorListener listener = new HTTPConnectorListener(latch);
+            HttpResponseFuture responseFuture = httpClientConnector.send(msg);
+            responseFuture.setHttpConnectorListener(listener);
+
+            latch.await(6, TimeUnit.SECONDS);
+
+            Throwable response = listener.getHttpErrorMessage();
+            assertNotNull(response);
+            String result = response.getMessage();
+
+            assertEquals(Constants.REMOTE_SERVER_CLOSE_RESPONSE_CONNECTION_AFTER_REQUEST_READ, result);
+        } catch (Exception e) {
+            TestUtil.handleException("Exception occurred while running httpsGetTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            httpServer.shutdown();
+        } catch (InterruptedException e) {
+            logger.error("Failed to shutdown the test server");
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkClientTemplate.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkClientTemplate.java
@@ -65,7 +65,7 @@ public class ChunkClientTemplate {
 
         requestMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
         requestMsg.setProperty(Constants.PROTOCOL, Constants.HTTP_SCHEME);
-        requestMsg.setProperty(Constants.HOST, "localhost");
+        requestMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
         requestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/EchoStreamingMessageListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/EchoStreamingMessageListener.java
@@ -21,7 +21,6 @@ package org.wso2.transport.http.netty.contentaware.listeners;
 
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -50,7 +49,6 @@ public class EchoStreamingMessageListener implements HttpConnectorListener {
             try {
                 HTTPCarbonMessage httpResponse = new HttpCarbonResponse(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
                         HttpResponseStatus.OK));
-                httpResponse.setHeader(HttpHeaderNames.CONNECTION.toString(), HttpHeaderValues.KEEP_ALIVE.toString());
                 httpResponse.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), Constants.TEXT_PLAIN);
 
                 HttpMessageDataStreamer httpMessageDataStreamer = new HttpMessageDataStreamer(httpResponse);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.http1point0test;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ChunkConfig;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * A test class for enable chunking behaviour for http 1.0.
+ */
+public class ChunkAlwaysHttpOnePointZeroClientTestCase extends ChunkClientTemplate {
+
+    @BeforeClass
+    public void setUp() {
+        senderConfiguration.setChunkingConfig(ChunkConfig.ALWAYS);
+        senderConfiguration.setHttpVersion("1.0");
+        super.setUp();
+    }
+
+    @Test
+    public void postTest() {
+        try {
+            HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
+            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "9342");
+
+            response = sendRequest(TestUtil.smallEntity);
+            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+
+        } catch (Exception e) {
+            TestUtil.handleException("Exception occurred while running postTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(Collections.EMPTY_LIST , httpServer);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAutoHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAutoHttpOnePointZeroClientTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.http1point0test;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ChunkConfig;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * A test class for auto chunking behaviour for http 1.0.
+ */
+public class ChunkAutoHttpOnePointZeroClientTestCase extends ChunkClientTemplate {
+
+    @BeforeClass
+    public void setUp() {
+        senderConfiguration.setChunkingConfig(ChunkConfig.AUTO);
+        senderConfiguration.setHttpVersion("1.0");
+        super.setUp();
+    }
+
+    @Test
+    public void postTest() {
+        try {
+            HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
+            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "9342");
+
+            response = sendRequest(TestUtil.smallEntity);
+            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+
+        } catch (Exception e) {
+            TestUtil.handleException("Exception occurred while running postTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(Collections.EMPTY_LIST , httpServer);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/HttpOnePointZeroServerConnectorTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/HttpOnePointZeroServerConnectorTestCase.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.http1point0test;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contentaware.listeners.EchoStreamingMessageListener;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http.HttpClient;
+
+import java.util.HashMap;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * This class tests for http 1.0 requests.
+ */
+public class HttpOnePointZeroServerConnectorTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpOnePointZeroServerConnectorTestCase.class);
+
+    protected ServerConnector serverConnector;
+    protected ListenerConfiguration listenerConfiguration;
+
+    HttpOnePointZeroServerConnectorTestCase() {
+        this.listenerConfiguration = new ListenerConfiguration();
+    }
+
+    @BeforeClass
+    public void setUp() {
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        listenerConfiguration.setServerHeader(TestUtil.TEST_SERVER);
+
+        ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
+        HttpWsConnectorFactory httpWsConnectorFactory = new HttpWsConnectorFactoryImpl();
+
+        serverConnector = httpWsConnectorFactory.createServerConnector(serverBootstrapConfig, listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(new EchoStreamingMessageListener());
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            log.error("Thread Interrupted while sleeping ", e);
+        }
+    }
+
+    @Test
+    public void http1point0DefaultRequest() {
+        try {
+            HttpClient httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+
+            FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+            FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
+
+            assertTrue(httpClient.waitForChannelClose());
+            assertEquals(TestUtil.largeEntity, TestUtil.getEntityBodyFrom(httpResponse));
+            assertNotNull(httpResponse.headers().get(Constants.HTTP_CONTENT_LENGTH));
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running largeHeaderTest", e);
+        }
+    }
+
+    @Test
+    public void http1point0KeepAliveRequest() {
+        try {
+            HttpClient httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+
+            FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+            httpRequest.headers().set(Constants.HTTP_CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
+            FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
+
+            assertFalse(httpClient.waitForChannelClose());
+            assertEquals(TestUtil.largeEntity, TestUtil.getEntityBodyFrom(httpResponse));
+            assertEquals(Constants.CONNECTION_KEEP_ALIVE, httpResponse.headers().get(Constants.CONNECTION));
+            assertNotNull(httpResponse.headers().get(Constants.HTTP_CONTENT_LENGTH));
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running largeHeaderTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        serverConnector.stop();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.http1point0test;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ChunkConfig;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * A test class for keep-alive behaviour for http 1.0.
+ */
+public class KeepAliveHttpOnePointZeroClientTestCase extends ChunkClientTemplate {
+
+    @BeforeClass
+    public void setUp() {
+        senderConfiguration.setChunkingConfig(ChunkConfig.AUTO);
+        senderConfiguration.setHttpVersion("1.0");
+        senderConfiguration.setKeepAlive(true);
+        super.setUp();
+    }
+
+    @Test
+    public void postTest() {
+        try {
+            HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
+            assertEquals(response.getHeader(Constants.HTTP_CONNECTION), Constants.CONNECTION_KEEP_ALIVE);
+        } catch (Exception e) {
+            TestUtil.handleException("Exception occurred while running postTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(Collections.EMPTY_LIST , httpServer);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/CommonUtilTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/CommonUtilTestCase.java
@@ -63,7 +63,7 @@ public class CommonUtilTestCase {
         headers.add("aaa", "xyz");
         HTTPCarbonMessage outboundResponseMsg = new HTTPCarbonMessage(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK, headers));
-        HttpResponse outboundNettyResponse = Util.createHttpResponse(outboundResponseMsg, true);
+        HttpResponse outboundNettyResponse = Util.createHttpResponse(outboundResponseMsg, "1.1", "test-server", true);
 
         Assert.assertEquals(outboundNettyResponse.protocolVersion(), HttpVersion.HTTP_1_1);
         Assert.assertEquals(outboundNettyResponse.status(), HttpResponseStatus.OK);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/http/ResponseHandler.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/http/ResponseHandler.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 public class ResponseHandler extends ChannelInboundHandlerAdapter {
 
     private CountDownLatch latch;
+    private CountDownLatch waitForConnectionClosureLatch;
     private FullHttpResponse fullHttpResponse;
 
     @Override
@@ -55,7 +56,16 @@ public class ResponseHandler extends ChannelInboundHandlerAdapter {
         super.exceptionCaught(ctx, cause);
     }
 
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        this.waitForConnectionClosureLatch.countDown();
+    }
+
     public void setLatch(CountDownLatch latch) {
         this.latch = latch;
+    }
+
+    public void setWaitForConnectionClosureLatch(CountDownLatch waitForConnectionClosureLatch) {
+        this.waitForConnectionClosureLatch = waitForConnectionClosureLatch;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/BadEchoServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/BadEchoServerInitializer.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.util.server.initializers;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+/**
+ * An initializer class for HTTP Server.
+ */
+public class BadEchoServerInitializer extends HTTPServerInitializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(BadEchoServerInitializer.class);
+
+    protected void addBusinessLogicHandler(Channel channel) {
+        channel.pipeline().addLast("handler", new EchoServerHandler());
+    }
+
+    private class EchoServerHandler extends ChannelInboundHandlerAdapter {
+
+        private HttpResponse httpResponse;
+        private int responseStatusCode = 200;
+        private boolean chunked = true;
+        private int contentLength = 0;
+        private boolean keepAlive = false;
+        private BlockingQueue<HttpContent> content = new LinkedBlockingQueue<>();
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof HttpRequest) {
+                HttpRequest req = (HttpRequest) msg;
+
+                if (HttpUtil.is100ContinueExpected(req)) {
+                    ctx.write(new DefaultHttpResponse(HTTP_1_1, CONTINUE));
+                }
+
+                createHttpResponse(req);
+                setContentType(req);
+                checkAndSetEncodingHeader(req);
+                setConnectionKeepAliveHeader(req);
+                keepAlive = HttpUtil.isKeepAlive(req);
+
+                if (chunked) {
+                    ctx.writeAndFlush(httpResponse);
+                }
+            } else if (msg instanceof HttpContent) {
+                if (msg instanceof LastHttpContent) {
+                    if (chunked) {
+                        ctx.writeAndFlush(msg);
+                    } else {
+                        writeHeadersAndEntity(ctx);
+                    }
+
+                    if (!keepAlive) {
+                        ctx.close();
+                        logger.debug("Closing the client connection");
+                    }
+                    resetState();
+                } else {
+                    if (chunked) {
+                        ctx.writeAndFlush(msg);
+                        logger.debug("Writing content to client connection");
+                    } else {
+                        collectContent((HttpContent) msg);
+                        logger.debug("Collecting content from client connection");
+                    }
+                }
+            }
+        }
+
+        private void resetState() {
+            contentLength = 0;
+            content.clear();
+            keepAlive = false;
+            chunked = true;
+        }
+
+        private void writeHeadersAndEntity(ChannelHandlerContext ctx) {
+            // Here we need to close connection after reading the request to
+            // produce the bad behaviour
+            ctx.channel().close();
+        }
+
+        private void collectContent(HttpContent msg) {
+            HttpContent httpContent = msg;
+            contentLength += httpContent.content().readableBytes();
+            content.add(msg);
+        }
+
+        private void checkAndSetEncodingHeader(HttpRequest req) {
+            if (req.headers().get(Constants.HTTP_CONTENT_LENGTH) != null) {
+                chunked = false;
+            } else {
+                httpResponse.headers().set(TRANSFER_ENCODING, "chunked");
+            }
+        }
+
+        private void setContentType(HttpRequest req) {
+            String contentType = req.headers().get(CONTENT_TYPE);
+            if (contentType != null) {
+                httpResponse.headers().set(CONTENT_TYPE, contentType);
+            }
+        }
+
+        private void createHttpResponse(HttpRequest req) {
+            HttpResponseStatus httpResponseStatus = new HttpResponseStatus(responseStatusCode,
+                    HttpResponseStatus.valueOf(responseStatusCode).reasonPhrase());
+            httpResponse = new DefaultHttpResponse(req.protocolVersion(), httpResponseStatus);
+        }
+
+        private void setConnectionKeepAliveHeader(HttpRequest req) {
+            boolean keepAlive = HttpUtil.isKeepAlive(req);
+            if (keepAlive) {
+                httpResponse.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+                logger.debug("Setting connection keep-alive header");
+            }
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchTestCase.java
@@ -67,6 +67,7 @@ public class HttpToWsProtocolSwitchTestCase {
         urlConn.setRequestProperty("upgrade", "websocket");
         urlConn.setRequestProperty("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
         urlConn.setRequestProperty("Sec-WebSocket-Version", "13");
+
         Assert.assertEquals(urlConn.getResponseCode(), 101);
         Assert.assertEquals(urlConn.getResponseMessage(), "Switching Protocols");
         Assert.assertEquals(urlConn.getHeaderField("upgrade"), "websocket");
@@ -83,9 +84,9 @@ public class HttpToWsProtocolSwitchTestCase {
         urlConn.setRequestProperty("Upgrade", "websocket");
         urlConn.setRequestProperty("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
         urlConn.setRequestProperty("Sec-WebSocket-Version", "13");
+
         Assert.assertEquals(urlConn.getResponseCode(), 200);
         Assert.assertEquals(urlConn.getResponseMessage(), "OK");
-        Assert.assertEquals(urlConn.getHeaderField("connection"), "keep-alive");
         Assert.assertTrue(urlConn.getHeaderField("sec-websocket-accept") == null);
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -42,6 +42,7 @@
 
             <class name="org.wso2.transport.http.netty.ClientConnectorTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.ClientConnectorConnectionRefusedTestCase" />
+            <class name="org.wso2.transport.http.netty.ClientConnectorClosureAfterRequestReadTestCase" />
 
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkAutoServerTestCase" />
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkEnableServerTestCase" />

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -61,6 +61,10 @@
             <!--<class name="org.wso2.carbon.transport.http.netty.http2.HTTP2RequestResponseTestCase" />-->
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.urilengthvalidation.Status414And413ResponseTest"/>
+            <class name="org.wso2.transport.http.netty.http1point0test.HttpOnePointZeroServerConnectorTestCase"/>
+            <class name="org.wso2.transport.http.netty.http1point0test.KeepAliveHttpOnePointZeroClientTestCase"/>
+            <class name="org.wso2.transport.http.netty.http1point0test.ChunkAutoHttpOnePointZeroClientTestCase"/>
+            <class name="org.wso2.transport.http.netty.http1point0test.ChunkAlwaysHttpOnePointZeroClientTestCase"/>
 
             <class name="org.wso2.transport.http.netty.websocket.WebSocketServerTestCase"/>
             <class name="org.wso2.transport.http.netty.websocket.WebSocketClientTestCase"/>


### PR DESCRIPTION
## Purpose
> There are can be many legacy clients which still depends on http 1.0 protocol. Hence, this PR provides support for such clients. 

## Goals
> Supporting http 1.0 clients 

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests are added

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A

## Learning
> N/A