### PR TITLE
Add support for handling compressing request and decompressing response

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -15,9 +15,11 @@
 
 package org.wso2.transport.http.netty.common;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
@@ -72,6 +74,28 @@ public class Util {
         HttpResponseStatus httpResponseStatus = getHttpResponseStatus(outboundResponseMsg);
         HttpResponse outboundNettyResponse = new DefaultHttpResponse(httpVersion, httpResponseStatus, false);
 
+        setOutboundRespHeaders(outboundResponseMsg, inboundReqHttpVersion, serverName, keepAlive,
+                outboundNettyResponse);
+
+        return outboundNettyResponse;
+    }
+
+    public static HttpResponse createFullHttpResponse(HTTPCarbonMessage outboundResponseMsg,
+            String inboundReqHttpVersion, String serverName, boolean keepAlive, ByteBuf fullContent) {
+
+        HttpVersion httpVersion = new HttpVersion(Constants.HTTP_VERSION_PREFIX + inboundReqHttpVersion, true);
+        HttpResponseStatus httpResponseStatus = getHttpResponseStatus(outboundResponseMsg);
+        HttpResponse outboundNettyResponse =
+                new DefaultFullHttpResponse(httpVersion, httpResponseStatus, fullContent, false);
+
+        setOutboundRespHeaders(outboundResponseMsg, inboundReqHttpVersion, serverName, keepAlive,
+                outboundNettyResponse);
+
+        return outboundNettyResponse;
+    }
+
+    private static void setOutboundRespHeaders(HTTPCarbonMessage outboundResponseMsg, String inboundReqHttpVersion,
+            String serverName, boolean keepAlive, HttpResponse outboundNettyResponse) {
         if (!keepAlive && (Float.valueOf(inboundReqHttpVersion) >= Constants.HTTP_1_1)) {
             outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
         } else if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < Constants.HTTP_1_1)) {
@@ -85,8 +109,6 @@ public class Util {
         }
 
         outboundNettyResponse.headers().add(outboundResponseMsg.getHeaders());
-
-        return outboundNettyResponse;
     }
 
     private static HttpResponseStatus getHttpResponseStatus(HTTPCarbonMessage msg) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -130,6 +130,8 @@ public class Util {
         outboundNettyRequest.setProtocolVersion(httpVersion);
         outboundNettyRequest.setUri(requestPath);
 
+        outboundNettyRequest.headers().set(Constants.ACCEPT_ENCODING,
+                Constants.ENCODING_DEFLATE + ", " + Constants.ENCODING_GZIP);
         outboundNettyRequest.headers().add(outboundRequestMsg.getHeaders());
 
         return outboundNettyRequest;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -178,13 +178,6 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
 
     private ChannelFuture writeOutboundResponseBody(HttpContent lastHttpContent) {
         HttpResponseFuture outboundRespStatusFuture = inboundRequestMsg.getHttpOutboundRespStatusFuture();
-        if (chunkConfig == ChunkConfig.NEVER ||
-                !Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion())) {
-            for (HttpContent cachedHttpContent : contentList) {
-                ChannelFuture outboundResponseChannelFuture = sourceContext.writeAndFlush(cachedHttpContent);
-                notifyIfFailure(outboundRespStatusFuture, outboundResponseChannelFuture);
-            }
-        }
         ChannelFuture outboundChannelFuture = sourceContext.writeAndFlush(lastHttpContent);
         checkForWriteStatus(outboundRespStatusFuture, outboundChannelFuture);
         return outboundChannelFuture;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -19,11 +19,14 @@
 
 package org.wso2.transport.http.netty.contractimpl;
 
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -95,19 +98,23 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
 
     private void writeOutboundResponse(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive,
             HttpContent httpContent) {
+        ChannelFuture outboundChannelFuture;
         if (Util.isLastHttpContent(httpContent)) {
             if (!isHeaderWritten) {
-                if ((chunkConfig == ChunkConfig.ALWAYS)
+                if (chunkConfig == ChunkConfig.ALWAYS
                         && Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion())) {
                     Util.setupChunkedRequest(outboundResponseMsg);
+                    writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+                    outboundChannelFuture = writeOutboundResponseBody(httpContent);
                 } else {
                     contentLength += httpContent.content().readableBytes();
                     Util.setupContentLengthRequest(outboundResponseMsg, contentLength);
+                    outboundChannelFuture = writeOutboundResponseHeaderAndBody(outboundResponseMsg,
+                            (LastHttpContent) httpContent, keepAlive);
                 }
-                writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+            } else {
+                outboundChannelFuture = writeOutboundResponseBody(httpContent);
             }
-
-            ChannelFuture outboundChannelFuture = writeOutboundResponseBody(httpContent);
 
             if (!keepAlive) {
                 outboundChannelFuture.addListener(ChannelFutureListener.CLOSE);
@@ -134,16 +141,27 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
         }
     }
 
-    private ChannelFuture writeOutboundResponseBody(HttpContent lastHttpContent) {
+    private ChannelFuture writeOutboundResponseHeaderAndBody(HTTPCarbonMessage outboundResponseMsg,
+            LastHttpContent lastHttpContent, boolean keepAlive) {
         HttpResponseFuture outboundRespStatusFuture = inboundRequestMsg.getHttpOutboundRespStatusFuture();
-        if (chunkConfig == ChunkConfig.NEVER ||
-                !Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion())) {
-            for (HttpContent cachedHttpContent : contentList) {
-                ChannelFuture outboundResponseChannelFuture = sourceContext.writeAndFlush(cachedHttpContent);
-                notifyIfFailure(outboundRespStatusFuture, outboundResponseChannelFuture);
-            }
+
+        CompositeByteBuf allContent = Unpooled.compositeBuffer();
+        for (HttpContent cachedHttpContent : contentList) {
+            allContent.addComponent(true, cachedHttpContent.content());
         }
-        ChannelFuture outboundChannelFuture = sourceContext.writeAndFlush(lastHttpContent);
+        allContent.addComponent(true, lastHttpContent.content());
+
+        HttpResponse fullOutboundResponse =
+                Util.createFullHttpResponse(outboundResponseMsg, requestDataHolder.getHttpVersion(),
+                serverName, keepAlive, allContent);
+
+        isHeaderWritten = true;
+        ChannelFuture outboundChannelFuture = sourceContext.writeAndFlush(fullOutboundResponse);
+        checkForWriteStatus(outboundRespStatusFuture, outboundChannelFuture);
+        return outboundChannelFuture;
+    }
+
+    private void checkForWriteStatus(HttpResponseFuture outboundRespStatusFuture, ChannelFuture outboundChannelFuture) {
         outboundChannelFuture.addListener(writeOperationPromise -> {
             Throwable throwable = writeOperationPromise.cause();
             if (throwable != null) {
@@ -156,6 +174,19 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                 outboundRespStatusFuture.notifyHttpListener(inboundRequestMsg);
             }
         });
+    }
+
+    private ChannelFuture writeOutboundResponseBody(HttpContent lastHttpContent) {
+        HttpResponseFuture outboundRespStatusFuture = inboundRequestMsg.getHttpOutboundRespStatusFuture();
+        if (chunkConfig == ChunkConfig.NEVER ||
+                !Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion())) {
+            for (HttpContent cachedHttpContent : contentList) {
+                ChannelFuture outboundResponseChannelFuture = sourceContext.writeAndFlush(cachedHttpContent);
+                notifyIfFailure(outboundRespStatusFuture, outboundResponseChannelFuture);
+            }
+        }
+        ChannelFuture outboundChannelFuture = sourceContext.writeAndFlush(lastHttpContent);
+        checkForWriteStatus(outboundRespStatusFuture, outboundChannelFuture);
         return outboundChannelFuture;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpContentCompressor.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpContentCompressor.java
@@ -21,9 +21,6 @@ public class CustomHttpContentCompressor extends HttpContentCompressor {
 
     @Override
     protected Result beginEncode(HttpResponse headers, String acceptEncoding) throws Exception {
-        if (headers.headers().get("Content-Length") != null) {
-            return null;
-        }
         String allowHeader = headers.headers().get("Allow");
         String contentLength = headers.headers().get("Content-Length");
         if (method == HttpMethod.OPTIONS && allowHeader != null && contentLength.equals("0")) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -44,8 +44,7 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
     private final ServerConnectorFuture serverConnectorFuture;
     private final String interfaceId;
 
-    public WebSocketServerHandshakeHandler(
-            ServerConnectorFuture serverConnectorFuture, String interfaceId) {
+    public WebSocketServerHandshakeHandler(ServerConnectorFuture serverConnectorFuture, String interfaceId) {
         this.serverConnectorFuture = serverConnectorFuture;
         this.interfaceId = interfaceId;
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HTTPClientInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HTTPClientInitializer.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
-import org.wso2.transport.http.netty.listener.CustomHttpContentCompressor;
 import org.wso2.transport.http.netty.listener.HTTPTraceLoggingHandler;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 
@@ -81,7 +80,6 @@ public class HTTPClientInitializer extends ChannelInitializer<SocketChannel> {
             ch.pipeline().addLast("ssl", new SslHandler(this.sslEngine));
         }
 
-        ch.pipeline().addLast("compressor", new CustomHttpContentCompressor());
         ch.pipeline().addLast("decoder", new HttpResponseDecoder());
         ch.pipeline().addLast("encoder", new HttpRequestEncoder());
         ch.pipeline().addLast("chunkWriter", new ChunkedWriteHandler());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.compression;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contentaware.listeners.EchoStreamingMessageListener;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.HTTPConnectorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * This class tests for 414 and 413 responses.
+ */
+public class ClientRespDecompressionTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientRespDecompressionTestCase.class);
+
+    private ServerConnector serverConnector;
+    private HttpClientConnector clientConnector;
+    private ListenerConfiguration listenerConfiguration;
+    private SenderConfiguration senderConfiguration;
+
+    ClientRespDecompressionTestCase() {
+        this.listenerConfiguration = new ListenerConfiguration();
+    }
+
+    @BeforeClass
+    public void setUp() {
+        HttpWsConnectorFactory httpWsConnectorFactory = new HttpWsConnectorFactoryImpl();
+
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
+
+        serverConnector = httpWsConnectorFactory.createServerConnector(serverBootstrapConfig, listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(new EchoStreamingMessageListener());
+
+        senderConfiguration = new SenderConfiguration();
+        clientConnector = httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            log.error("Thread Interrupted while sleeping ", e);
+        }
+    }
+
+    @Test
+    public void clientConnectorRespDecompressionTest() {
+        try {
+            HTTPCarbonMessage requestMsg = sendRequest(TestUtil.largeEntity);
+            assertEquals(TestUtil.largeEntity, TestUtil.getStringFromInputStream(
+                    new HttpMessageDataStreamer(requestMsg).getInputStream()));
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running clientConnectorRespDecompressionTest", e);
+        }
+    }
+
+    public HTTPCarbonMessage sendRequest(String content) throws IOException, InterruptedException {
+        HTTPCarbonMessage requestMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.POST, ""));
+
+        requestMsg.setProperty(Constants.PORT, TestUtil.SERVER_CONNECTOR_PORT);
+        requestMsg.setProperty(Constants.PROTOCOL, Constants.HTTP_SCHEME);
+        requestMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        requestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
+
+        requestMsg.setHeader("Accept-Encoding", "deflate;q=1.0, gzip;q=0.8");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        HTTPConnectorListener listener = new HTTPConnectorListener(latch);
+        clientConnector.send(requestMsg).setHttpConnectorListener(listener);
+        HttpMessageDataStreamer httpMessageDataStreamer = new HttpMessageDataStreamer(requestMsg);
+        httpMessageDataStreamer.getOutputStream().write(content.getBytes());
+        httpMessageDataStreamer.getOutputStream().close();
+
+        latch.await(5, TimeUnit.SECONDS);
+
+        return listener.getHttpResponseMessage();
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        serverConnector.stop();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
- * This class tests for 414 and 413 responses.
+ * This class tests handling compressed inbound responses.
  */
 public class ClientRespDecompressionTestCase {
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
@@ -60,6 +60,7 @@ public class ClientRespDecompressionTestCase {
     private HttpClientConnector clientConnector;
     private ListenerConfiguration listenerConfiguration;
     private SenderConfiguration senderConfiguration;
+    private CountDownLatch latch;
 
     ClientRespDecompressionTestCase() {
         this.listenerConfiguration = new ListenerConfiguration();
@@ -67,6 +68,7 @@ public class ClientRespDecompressionTestCase {
 
     @BeforeClass
     public void setUp() {
+        latch = new CountDownLatch(1);
         HttpWsConnectorFactory httpWsConnectorFactory = new HttpWsConnectorFactoryImpl();
 
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
@@ -89,6 +91,7 @@ public class ClientRespDecompressionTestCase {
     public void clientConnectorRespDecompressionTest() {
         try {
             HTTPCarbonMessage requestMsg = sendRequest(TestUtil.largeEntity);
+            latch.await(5, TimeUnit.SECONDS);
             assertEquals(TestUtil.largeEntity, TestUtil.getStringFromInputStream(
                     new HttpMessageDataStreamer(requestMsg).getInputStream()));
         } catch (Exception e) {
@@ -107,7 +110,7 @@ public class ClientRespDecompressionTestCase {
 
         requestMsg.setHeader("Accept-Encoding", "deflate;q=1.0, gzip;q=0.8");
 
-        CountDownLatch latch = new CountDownLatch(1);
+        latch = new CountDownLatch(1);
         HTTPConnectorListener listener = new HTTPConnectorListener(latch);
         clientConnector.send(requestMsg).setHttpConnectorListener(listener);
         HttpMessageDataStreamer httpMessageDataStreamer = new HttpMessageDataStreamer(requestMsg);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
@@ -47,7 +47,7 @@ import java.util.HashMap;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
- * This class tests for 414 and 413 responses.
+ * This class tests compression outbound responses.
  */
 public class ServerRespCompressionTestCase {
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.compression;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contentaware.listeners.EchoStreamingMessageListener;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorException;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http.HttpClient;
+
+import java.util.HashMap;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * This class tests for 414 and 413 responses.
+ */
+public class ServerRespCompressionTestCase {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerRespCompressionTestCase.class);
+
+    protected ServerConnector serverConnector;
+    protected ListenerConfiguration listenerConfiguration;
+
+    ServerRespCompressionTestCase() {
+        this.listenerConfiguration = new ListenerConfiguration();
+    }
+
+    @BeforeClass
+    public void setUp() {
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        listenerConfiguration.setServerHeader(TestUtil.TEST_SERVER);
+        ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
+
+        HttpWsConnectorFactory httpWsConnectorFactory = new HttpWsConnectorFactoryImpl();
+
+        serverConnector = httpWsConnectorFactory.createServerConnector(serverBootstrapConfig, listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(new EchoStreamingMessageListener());
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            log.error("Thread Interrupted while sleeping ", e);
+        }
+    }
+
+    @Test
+    public void serverConnectorRespCompressionTest() {
+        try {
+            HttpClient httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+
+            FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_GZIP);
+            FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
+            assertEquals(Constants.ENCODING_GZIP, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+
+            httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+            httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
+            httpResponse = httpClient.sendRequest(httpRequest);
+            assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+
+            httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+            httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+            httpRequest.headers().set(Constants.ACCEPT_ENCODING, "deflate;q=1.0, gzip;q=0.8");
+            httpResponse = httpClient.sendRequest(httpRequest);
+            assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+
+            httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+            httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                    HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.smallEntity.getBytes()));
+            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
+            httpResponse = httpClient.sendRequest(httpRequest);
+            assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running serverConnectorRespCompressionTest", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        serverConnector.stop();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/ResponseStreamingWithoutBufferingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/ResponseStreamingWithoutBufferingListener.java
@@ -64,7 +64,6 @@ public class ResponseStreamingWithoutBufferingListener implements HttpConnectorL
                 cMsg.addHttpContent(httpContent);
                 if (httpContent instanceof LastHttpContent) {
                     cMsg.addHttpContent(new DefaultLastHttpContent());
-                    httpRequestMessage.release();
                     break;
                 }
             }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -76,9 +76,11 @@ public class HTTPSClientTestCase {
         httpsServer = TestUtil.startHttpsServer(TestUtil.HTTPS_SERVER_PORT,
                 new MockServerInitializer(testValue, "text/plain", 200));
         HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
+        SenderConfiguration senderConfiguration =
+                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME);
+        senderConfiguration.setSSLProtocol("TLSv1.1");
         httpClientConnector = connectorFactory.createHttpClientConnector(
-                HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
-                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME));
+                HTTPConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HTTPSClientTestCase.java
@@ -76,11 +76,9 @@ public class HTTPSClientTestCase {
         httpsServer = TestUtil.startHttpsServer(TestUtil.HTTPS_SERVER_PORT,
                 new MockServerInitializer(testValue, "text/plain", 200));
         HttpWsConnectorFactory connectorFactory = new HttpWsConnectorFactoryImpl();
-        SenderConfiguration senderConfiguration =
-                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME);
-        senderConfiguration.setSSLProtocol("TLSv1.1");
         httpClientConnector = connectorFactory.createHttpClientConnector(
-                HTTPConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
+                HTTPConnectorUtil.getTransportProperties(transportsConfiguration),
+                HTTPConnectorUtil.getSenderConfiguration(transportsConfiguration, Constants.HTTPS_SCHEME));
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/HTTPConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/HTTPConnectorListener.java
@@ -18,6 +18,9 @@
 
 package org.wso2.transport.http.netty.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.compression.ServerRespCompressionTestCase;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
@@ -27,6 +30,8 @@ import java.util.concurrent.CountDownLatch;
  * A connector listener for HTTP
  */
 public class HTTPConnectorListener implements HttpConnectorListener {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerRespCompressionTestCase.class);
 
     private HTTPCarbonMessage httpMessage;
     private Throwable throwable;
@@ -49,10 +54,20 @@ public class HTTPConnectorListener implements HttpConnectorListener {
     }
 
     public HTTPCarbonMessage getHttpResponseMessage() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            log.error("Interrupted while waiting for the response message", e);
+        }
         return httpMessage;
     }
 
     public Throwable getHttpErrorMessage() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            log.error("Interrupted while waiting for the error response", e);
+        }
         return throwable;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/HTTPConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/HTTPConnectorListener.java
@@ -54,20 +54,10 @@ public class HTTPConnectorListener implements HttpConnectorListener {
     }
 
     public HTTPCarbonMessage getHttpResponseMessage() {
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            log.error("Interrupted while waiting for the response message", e);
-        }
         return httpMessage;
     }
 
     public Throwable getHttpErrorMessage() {
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            log.error("Interrupted while waiting for the error response", e);
-        }
         return throwable;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -67,6 +67,9 @@
             <class name="org.wso2.transport.http.netty.http1point0test.ChunkAutoHttpOnePointZeroClientTestCase"/>
             <class name="org.wso2.transport.http.netty.http1point0test.ChunkAlwaysHttpOnePointZeroClientTestCase"/>
 
+            <class name="org.wso2.transport.http.netty.compression.ServerRespCompressionTestCase"/>
+            <class name="org.wso2.transport.http.netty.compression.ClientRespDecompressionTestCase"/>
+
             <class name="org.wso2.transport.http.netty.websocket.WebSocketServerTestCase"/>
             <class name="org.wso2.transport.http.netty.websocket.WebSocketClientTestCase"/>
             <!--<class name="org.wso2.transport.http.netty.websocket.WebSocketPassThroughTestCase"/>-->


### PR DESCRIPTION
## Purpose
> HTTP transport can send compressed responses and also provides a way to negotiate compressing responses using request header. With transport we provide that support.

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - New test-cases are added. 

## Security checks
 - No

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A