### PR TITLE
Support Decompression for multiple content-encoding

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -63,9 +63,8 @@ public class HttpMessageDataStreamer {
     }
 
     /**
-     * A class which represents the InputStream of the ByteBuffers
-     * No need to worry about thread safety of this class this is called only once by
-     * for a message instance from one thread.
+     * A class which represents the InputStream of the ByteBuffers No need to worry about thread safety of this class
+     * this is called only once by for a message instance from one thread.
      */
     protected class ByteBufferInputStream extends InputStream {
 
@@ -112,12 +111,10 @@ public class HttpMessageDataStreamer {
     }
 
     /**
-     * A class which write byteStream into ByteBuffers and add those
-     * ByteBuffers to Content Queue.
-     * No need to worry about thread safety of this class this is called only once by
-     * one thread at particular time.
+     * A class which write byteStream into ByteBuffers and add those ByteBuffers to Content Queue. No need to worry
+     * about thread safety of this class this is called only once by one thread at particular time.
      */
-    protected class ByteBufferOutputStream extends OutputStream {
+    protected class ByteBufferOutputStream extends OutputStream     {
 
         private ByteBuf dataHolder;
 
@@ -187,6 +184,19 @@ public class HttpMessageDataStreamer {
                 } else if (contentEncodingHeader.equalsIgnoreCase(Constants.ENCODING_DEFLATE)) {
                     return new InflaterInputStream(createInputStreamIfNull());
                 } else {
+                    String[] headers = contentEncodingHeader.split(",");
+                    if (headers.length == 2) {
+                        if (headers[0].trim().equalsIgnoreCase(Constants.ENCODING_GZIP) &&
+                                headers[1].trim().equalsIgnoreCase(Constants.ENCODING_DEFLATE)) {
+                            InputStream inputStream = new InflaterInputStream(createInputStreamIfNull());
+                            return new GZIPInputStream(inputStream);
+                        } else if (headers[0].trim().equalsIgnoreCase(Constants.ENCODING_DEFLATE) &&
+                                headers[1].trim().equalsIgnoreCase(Constants.ENCODING_GZIP)) {
+                            InputStream inputStream = new GZIPInputStream(createInputStreamIfNull());
+                            return new InflaterInputStream(inputStream);
+                        }
+                    }
+
                     log.warn("Unknown Content-Encoding: " + contentEncodingHeader);
                 }
             } catch (IOException e) {
@@ -197,7 +207,7 @@ public class HttpMessageDataStreamer {
     }
 
     private ByteBuf getBuffer() {
-        if (pooledByteBufAllocator ==  null) {
+        if (pooledByteBufAllocator == null) {
             return Unpooled.buffer(contentBufferSize);
         } else {
             return pooledByteBufAllocator.directBuffer(contentBufferSize);


### PR DESCRIPTION
## Purpose
>Support Decompression in client connector for multiple content-encoding.

## Goals
> support multiple content-encoding in Ballerina client.

## Approach
> Add the check in the `HttpMessageDataStreamer` class.

## Release note
> Support Decompression in client connector for multiple content-encoding.

## Test environment
> JDK 8 | Ubuntu 17.10
