### PR TITLE
Remove Accept-Encoding header in outbound request

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -129,9 +129,6 @@ public class Util {
         outboundNettyRequest.setMethod(httpMethod);
         outboundNettyRequest.setProtocolVersion(httpVersion);
         outboundNettyRequest.setUri(requestPath);
-
-        outboundNettyRequest.headers().set(Constants.ACCEPT_ENCODING,
-                Constants.ENCODING_DEFLATE + ", " + Constants.ENCODING_GZIP);
         outboundNettyRequest.headers().add(outboundRequestMsg.getHeaders());
 
         return outboundNettyRequest;


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4706

## Goals
> Setting of this header would be done in ballerina. This allows more flexibility.

## Test environment
>JDK 8 | Ubuntu 17.10