### PR TITLE
Set the Date header in accordance with the HTTP spec

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -109,6 +109,7 @@ public final class Constants {
     public static final String ENCODING_DEFLATE = "deflate";
     public static final String HTTP_TRANSFER_ENCODING_IDENTITY = "identity";
 
+    // TODO: Move string constants for HTTP headers and header values to their own class
     public static final String HTTP_CONNECTION = "Connection";
     public static final String CONNECTION_KEEP_ALIVE = "keep-alive";
     public static final String CONNECTION_CLOSE = "close";
@@ -119,8 +120,8 @@ public final class Constants {
     public static final String HTTP_TRANSFER_ENCODING = "Transfer-Encoding";
     public static final String HOST = "Host";
     public static final String HTTP_SERVER_HEADER = "Server";
-
     public static final String LOCATION = "Location";
+    public static final String DATE = "Date";
 
     public static final String HTTP_GET_METHOD = "GET";
     public static final String HTTP_POST_METHOD = "POST";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -36,6 +36,8 @@ import org.wso2.transport.http.netty.config.Parameter;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.io.File;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -106,6 +108,11 @@ public class Util {
 
         if (outboundResponseMsg.getHeader(Constants.HTTP_SERVER_HEADER) == null) {
             outboundResponseMsg.setHeader(Constants.HTTP_SERVER_HEADER, serverName);
+        }
+
+        if (outboundResponseMsg.getHeader(Constants.DATE) == null) {
+            outboundResponseMsg.setHeader(Constants.DATE,
+                                          ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME));
         }
 
         outboundNettyResponse.headers().add(outboundResponseMsg.getHeaders());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/DateHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/DateHeaderTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.headers;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contentaware.listeners.EchoMessageListener;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+
+/**
+ * Test case for ensuring that the Date header is correctly set.
+ */
+public class DateHeaderTestCase {
+
+    private ServerConnector serverConnector;
+    private ListenerConfiguration listenerConfiguration;
+
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+
+        ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
+        HttpWsConnectorFactory httpWsConnectorFactory = new HttpWsConnectorFactoryImpl();
+
+        serverConnector = httpWsConnectorFactory.createServerConnector(serverBootstrapConfig, listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(new EchoMessageListener());
+
+        serverConnectorFuture.sync();
+    }
+
+    @Test
+    public void testDateHeaderFormatAndExistence() throws IOException {
+        HttpURLConnection connection = TestUtil.request(baseURI, "/", HttpMethod.POST.name(), false);
+        connection.getOutputStream().write("Hello World!".getBytes());
+        String date = connection.getHeaderField(Constants.DATE);
+
+        Assert.assertEquals(connection.getResponseCode(), HttpURLConnection.HTTP_OK);
+        Assert.assertNotNull(DateTimeFormatter.RFC_1123_DATE_TIME.parse(date));
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        serverConnector.stop();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -61,6 +61,8 @@
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolEvictionTestCase" />
             <class name="org.wso2.transport.http.netty.connectionpool.ConnectionPoolMaxConnTestCase" />
 
+            <class name="org.wso2.transport.http.netty.headers.DateHeaderTestCase" />
+
             <class name="org.wso2.transport.http.netty.unitfunction.CommonUtilTestCase" />
             <class name="org.wso2.transport.http.netty.unitfunction.HttpCarbonMessageTestCase" />
 


### PR DESCRIPTION
## Purpose
> Currently, the `Date` header is not set if the user has not set it. The correct behaviour should be such that if the user hasn't set the header, it should be set. Fix [ballerina/issues/4641](https://github.com/ballerina-lang/ballerina/issues/4641)

## Goals
> Set the `Date` header in accordance with the HTTP specification.
> [Date - HTTP specification](https://tools.ietf.org/html/rfc7231#section-7.1.1.2)

## Approach
> Check if the outbound response contains the `Date` header field and if it's absent, set the date, using the RFC1123 date formatter provided in JDK.
