### PR TITLE
Use lower case headers consistently

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -91,7 +91,6 @@ public final class Constants {
     public static final String TRUSTSTOREFILE = "trustStoreFile";
     public static final String TRUSTSTOREPASS = "trustStorePass";
 
-    public static final String PORT = "PORT";
 
     public static final int DEFAULT_HTTP_PORT = 80;
     public static final int DEFAULT_HTTPS_PORT = 443;
@@ -109,19 +108,9 @@ public final class Constants {
     public static final String ENCODING_DEFLATE = "deflate";
     public static final String HTTP_TRANSFER_ENCODING_IDENTITY = "identity";
 
-    // TODO: Move string constants for HTTP headers and header values to their own class
-    public static final String HTTP_CONNECTION = "Connection";
+    // TODO: Move string constants for HTTP header values to their own class
     public static final String CONNECTION_KEEP_ALIVE = "keep-alive";
     public static final String CONNECTION_CLOSE = "close";
-    public static final String ACCEPT_ENCODING = "Accept-Encoding";
-    public static final String CONTENT_ENCODING = "Content-Encoding";
-    public static final String HTTP_CONTENT_TYPE = "Content-Type";
-    public static final String HTTP_CONTENT_LENGTH = "Content-Length";
-    public static final String HTTP_TRANSFER_ENCODING = "Transfer-Encoding";
-    public static final String HOST = "Host";
-    public static final String HTTP_SERVER_HEADER = "Server";
-    public static final String LOCATION = "Location";
-    public static final String DATE = "Date";
 
     public static final String HTTP_GET_METHOD = "GET";
     public static final String HTTP_POST_METHOD = "POST";
@@ -170,8 +159,6 @@ public final class Constants {
 
     public static final String LOCALHOST = "localhost";
 
-    public static final String CONNECTION = "Connection";
-    public static final String UPGRADE = "Upgrade";
 
     public static final String WEBSOCKET_SERVER_SESSION = "WEBSOCKET_SERVER_SESSION";
     public static final String WEBSOCKET_CLIENT_SESSION = "WEBSOCKET_CLIENT_SESSION";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -99,19 +100,19 @@ public class Util {
     private static void setOutboundRespHeaders(HTTPCarbonMessage outboundResponseMsg, String inboundReqHttpVersion,
             String serverName, boolean keepAlive, HttpResponse outboundNettyResponse) {
         if (!keepAlive && (Float.valueOf(inboundReqHttpVersion) >= Constants.HTTP_1_1)) {
-            outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
+            outboundResponseMsg.setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_CLOSE);
         } else if (keepAlive && (Float.valueOf(inboundReqHttpVersion) < Constants.HTTP_1_1)) {
-            outboundResponseMsg.setHeader(Constants.HTTP_CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
+            outboundResponseMsg.setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_KEEP_ALIVE);
         } else {
-            outboundResponseMsg.removeHeader(Constants.HTTP_CONNECTION);
+            outboundResponseMsg.removeHeader(HttpHeaderNames.CONNECTION.toString());
         }
 
-        if (outboundResponseMsg.getHeader(Constants.HTTP_SERVER_HEADER) == null) {
-            outboundResponseMsg.setHeader(Constants.HTTP_SERVER_HEADER, serverName);
+        if (outboundResponseMsg.getHeader(HttpHeaderNames.SERVER.toString()) == null) {
+            outboundResponseMsg.setHeader(HttpHeaderNames.SERVER.toString(), serverName);
         }
 
-        if (outboundResponseMsg.getHeader(Constants.DATE) == null) {
-            outboundResponseMsg.setHeader(Constants.DATE,
+        if (outboundResponseMsg.getHeader(HttpHeaderNames.DATE.toString()) == null) {
+            outboundResponseMsg.setHeader(HttpHeaderNames.DATE.toString(),
                                           ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME));
         }
 
@@ -170,20 +171,20 @@ public class Util {
     }
 
     public static void setupChunkedRequest(HTTPCarbonMessage httpOutboundRequest) {
-        httpOutboundRequest.removeHeader(Constants.HTTP_CONTENT_LENGTH);
+        httpOutboundRequest.removeHeader(HttpHeaderNames.CONTENT_LENGTH.toString());
         setTransferEncodingHeader(httpOutboundRequest);
     }
 
     public static void setupContentLengthRequest(HTTPCarbonMessage httpOutboundRequest, int contentLength) {
-        httpOutboundRequest.removeHeader(Constants.HTTP_TRANSFER_ENCODING);
-        if (httpOutboundRequest.getHeader(Constants.HTTP_CONTENT_LENGTH) == null) {
-            httpOutboundRequest.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(contentLength));
+        httpOutboundRequest.removeHeader(HttpHeaderNames.TRANSFER_ENCODING.toString());
+        if (httpOutboundRequest.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()) == null) {
+            httpOutboundRequest.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(contentLength));
         }
     }
 
     private static void setTransferEncodingHeader(HTTPCarbonMessage httpOutboundRequest) {
-        if (httpOutboundRequest.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {
-            httpOutboundRequest.setHeader(Constants.HTTP_TRANSFER_ENCODING, Constants.CHUNKED);
+        if (httpOutboundRequest.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()) == null) {
+            httpOutboundRequest.setHeader(HttpHeaderNames.TRANSFER_ENCODING.toString(), Constants.CHUNKED);
         }
     }
 
@@ -516,9 +517,9 @@ public class Util {
     public static void sendAndCloseNoEntityBodyResp(ChannelHandlerContext ctx, HttpResponseStatus status,
             HttpVersion httpVersion, String serverName) {
         HttpResponse outboundResponse = new DefaultHttpResponse(httpVersion, status);
-        outboundResponse.headers().set(Constants.HTTP_CONTENT_LENGTH, 0);
-        outboundResponse.headers().set(Constants.HTTP_CONNECTION, Constants.CONNECTION_CLOSE);
-        outboundResponse.headers().set(Constants.HTTP_SERVER_HEADER, serverName);
+        outboundResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        outboundResponse.headers().set(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_CLOSE);
+        outboundResponse.headers().set(HttpHeaderNames.SERVER.toString(), serverName);
         ChannelFuture outboundRespFuture = ctx.channel().writeAndFlush(outboundResponse);
         outboundRespFuture.addListener(
                 (ChannelFutureListener) channelFuture -> log.warn("Failed to send " + status.reasonPhrase()));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpClientConnectorImpl.java
@@ -22,6 +22,7 @@ package org.wso2.transport.http.netty.contractimpl;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,9 +98,11 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
                                                  targetChannel);
                         }
                         if (!keepAlive && Float.valueOf(httpVersion) >= Constants.HTTP_1_1) {
-                            httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_CLOSE);
+                            httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(),
+                                                          Constants.CONNECTION_CLOSE);
                         } else if (keepAlive && Float.valueOf(httpVersion) < Constants.HTTP_1_1) {
-                            httpOutboundRequest.setHeader(Constants.CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
+                            httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(),
+                                                          Constants.CONNECTION_KEEP_ALIVE);
                         }
                         targetChannel.writeContent(httpOutboundRequest);
                     } else {
@@ -166,12 +169,12 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
 
     private int fetchPort(HTTPCarbonMessage httpCarbonMessage) {
         int port;
-        Object intProperty = httpCarbonMessage.getProperty(Constants.PORT);
+        Object intProperty = httpCarbonMessage.getProperty(Constants.HTTP_PORT);
         if (intProperty != null && intProperty instanceof Integer) {
             port = (int) intProperty;
         } else {
             port = sslConfig != null ? Constants.DEFAULT_HTTPS_PORT : Constants.DEFAULT_HTTP_PORT;
-            httpCarbonMessage.setProperty(Constants.PORT, port);
+            httpCarbonMessage.setProperty(Constants.HTTP_PORT, port);
             log.debug("Cannot find property PORT of type integer, hence using " + port);
         }
         return port;
@@ -179,12 +182,12 @@ public class HttpClientConnectorImpl implements HttpClientConnector {
 
     private String fetchHost(HTTPCarbonMessage httpCarbonMessage) {
         String host;
-        Object hostProperty = httpCarbonMessage.getProperty(Constants.HOST);
+        Object hostProperty = httpCarbonMessage.getProperty(Constants.HTTP_HOST);
         if (hostProperty != null && hostProperty instanceof String) {
             host = (String) hostProperty;
         } else {
             host = Constants.LOCALHOST;
-            httpCarbonMessage.setProperty(Constants.HOST, Constants.LOCALHOST);
+            httpCarbonMessage.setProperty(Constants.HTTP_HOST, Constants.LOCALHOST);
             log.debug("Cannot find property HOST of type string, hence using localhost as the host");
         }
         return host;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpContentCompressor.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/CustomHttpContentCompressor.java
@@ -2,6 +2,7 @@ package org.wso2.transport.http.netty.listener;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpContentCompressor;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -21,8 +22,8 @@ public class CustomHttpContentCompressor extends HttpContentCompressor {
 
     @Override
     protected Result beginEncode(HttpResponse headers, String acceptEncoding) throws Exception {
-        String allowHeader = headers.headers().get("Allow");
-        String contentLength = headers.headers().get("Content-Length");
+        String allowHeader = headers.headers().get(HttpHeaderNames.ALLOW);
+        String contentLength = headers.headers().get(HttpHeaderNames.CONTENT_LENGTH);
         if (method == HttpMethod.OPTIONS && allowHeader != null && contentLength.equals("0")) {
             return null;
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/RequestDataHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/RequestDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.listener;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 
@@ -36,11 +37,11 @@ public class RequestDataHolder {
     private String httpVersion;
 
     public RequestDataHolder(HTTPCarbonMessage requestMessage) {
-        acceptEncodingHeaderValue = requestMessage.getHeader(Constants.ACCEPT_ENCODING);
-        connectionHeaderValue = requestMessage.getHeader(Constants.HTTP_CONNECTION);
-        contentTypeHeaderValue = requestMessage.getHeader(Constants.HTTP_CONTENT_TYPE);
-        transferEncodingHeaderValue = requestMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING);
-        contentLengthHeaderValue = requestMessage.getHeader(Constants.HTTP_CONTENT_LENGTH);
+        acceptEncodingHeaderValue = requestMessage.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString());
+        connectionHeaderValue = requestMessage.getHeader(HttpHeaderNames.CONNECTION.toString());
+        contentTypeHeaderValue = requestMessage.getHeader(HttpHeaderNames.CONTENT_TYPE.toString());
+        transferEncodingHeaderValue = requestMessage.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString());
+        contentLengthHeaderValue = requestMessage.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString());
         httpMethod = (String) requestMessage.getProperty(Constants.HTTP_METHOD);
         httpVersion = (String) requestMessage.getProperty(Constants.HTTP_VERSION);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ResponseContentWriter.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ResponseContentWriter.java
@@ -24,10 +24,10 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.Writer;
-import org.wso2.transport.http.netty.common.Constants;
 
 import java.nio.ByteBuffer;
 
@@ -55,11 +55,7 @@ public class ResponseContentWriter implements Writer {
     @Override
     public void writeLastContent(CarbonMessage carbonMessage) {
         ChannelFuture future = channelHandlerContext.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
-//        if (HTTPTransportContextHolder.getInstance().getHandlerExecutor() != null) {
-//            HTTPTransportContextHolder.getInstance().getHandlerExecutor().
-//                    executeAtSourceResponseSending(carbonMessage);
-//        }
-        String connection = carbonMessage.getHeader(Constants.HTTP_CONNECTION);
+        String connection = carbonMessage.getHeader(HttpHeaderNames.CONNECTION.toString());
         if (connection != null && HTTP_CONNECTION_CLOSE.equalsIgnoreCase(connection)) {
             future.addListener(ChannelFutureListener.CLOSE);
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -21,6 +21,7 @@ package org.wso2.transport.http.netty.listener;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
             HttpHeaders headers = httpRequest.headers();
             String httpMethod = httpRequest.method().name();
             if (httpMethod.equalsIgnoreCase("GET") && isConnectionUpgrade(headers) &&
-                    Constants.WEBSOCKET_UPGRADE.equalsIgnoreCase(headers.get(Constants.UPGRADE))) {
+                    Constants.WEBSOCKET_UPGRADE.equalsIgnoreCase(headers.get(HttpHeaderNames.UPGRADE))) {
                 log.debug("Upgrading the connection from Http to WebSocket for " +
                                   "channel : " + ctx.channel());
                 handleWebSocketHandshake(httpRequest, ctx);
@@ -75,13 +76,13 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
      * @return true if the "Connection" header contains value "Upgrade".
      */
     protected boolean isConnectionUpgrade(HttpHeaders headers) {
-        if (!headers.contains(Constants.CONNECTION)) {
+        if (!headers.contains(HttpHeaderNames.CONNECTION)) {
             return false;
         }
 
-        String connectionHeaderValues = headers.get(Constants.CONNECTION);
+        String connectionHeaderValues = headers.get(HttpHeaderNames.CONNECTION);
         for (String connectionValue: connectionHeaderValues.split(",")) {
-            if (Constants.UPGRADE.equalsIgnoreCase(connectionValue.trim())) {
+            if (HttpHeaderNames.UPGRADE.toString().equalsIgnoreCase(connectionValue.trim())) {
                 return true;
             }
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/HTTP2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/HTTP2SourceHandler.java
@@ -216,8 +216,8 @@ public final class HTTP2SourceHandler extends Http2ConnectionHandler implements 
         // TODO: This fix is temporary and we need to revisit this and the entire http2 implementation.
         HTTPCarbonMessage cMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.GET, ""));
-        cMsg.setProperty(Constants.PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
-        cMsg.setProperty(Constants.HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
+        cMsg.setProperty(Constants.HTTP_PORT, ((InetSocketAddress) ctx.channel().remoteAddress()).getPort());
+        cMsg.setProperty(Constants.HTTP_HOST, ((InetSocketAddress) ctx.channel().remoteAddress()).getHostName());
         cMsg.setProperty(Constants.SCHEME, listenerConfiguration.getScheme());
         cMsg.setProperty(Constants.HTTP_VERSION, Constants.HTTP_VERSION_2_0);
         cMsg.setProperty(org.wso2.carbon.messaging.Constants.LISTENER_PORT,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,12 +176,12 @@ public class HttpMessageDataStreamer {
     }
 
     public InputStream getInputStream() {
-        String contentEncodingHeader = httpCarbonMessage.getHeader(Constants.CONTENT_ENCODING);
+        String contentEncodingHeader = httpCarbonMessage.getHeader(HttpHeaderNames.CONTENT_ENCODING.toString());
         if (contentEncodingHeader != null) {
             // removing the header because, we are handling the decoded content and we need to send out
             // as encoded one. so once this header is removed, transport will encode again by looking the
             // accept-encoding request header
-            httpCarbonMessage.removeHeader(Constants.CONTENT_ENCODING);
+            httpCarbonMessage.removeHeader(HttpHeaderNames.CONTENT_ENCODING.toString());
             try {
                 if (contentEncodingHeader.equalsIgnoreCase(Constants.ENCODING_GZIP)) {
                     return new GZIPInputStream(createInputStreamIfNull());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkAutoClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkAutoClientTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -42,10 +43,10 @@ public class ChunkAutoClientTestCase extends ChunkClientTemplate {
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(response.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
             response = sendRequest(TestUtil.smallEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkAutoServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkAutoServerTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -44,10 +45,10 @@ public class ChunkAutoServerTestCase extends ChunkServerTemplate {
     public void postTest() {
         try {
             HttpURLConnection urlConn = sendEntityBody(TestUtil.largeEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
             urlConn = sendEntityBody(TestUtil.smallEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
             urlConn.disconnect();
         } catch (IOException e) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkClientTemplate.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkClientTemplate.java
@@ -66,9 +66,9 @@ public class ChunkClientTemplate {
         HTTPCarbonMessage requestMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.POST, ""));
 
-        requestMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+        requestMsg.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
         requestMsg.setProperty(Constants.PROTOCOL, Constants.HTTP_SCHEME);
-        requestMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        requestMsg.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
         requestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
 
         CountDownLatch latch = new CountDownLatch(1);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkDisableClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkDisableClientTestCase.java
@@ -18,9 +18,9 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -42,10 +42,10 @@ public class ChunkDisableClientTestCase extends ChunkClientTemplate {
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "9342");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "9342");
 
             response = sendRequest(TestUtil.smallEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkDisableServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkDisableServerTestCase.java
@@ -18,9 +18,9 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.util.TestUtil;
 
@@ -44,10 +44,10 @@ public class ChunkDisableServerTestCase extends ChunkServerTemplate {
     public void postTest() {
         try {
             HttpURLConnection urlConn = sendEntityBody(TestUtil.largeEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_CONTENT_LENGTH), "9342");
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.CONTENT_LENGTH.toString()), "9342");
 
             urlConn = sendEntityBody(TestUtil.smallEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
             urlConn.disconnect();
         } catch (IOException e) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkEnableClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkEnableClientTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -42,10 +43,10 @@ public class ChunkEnableClientTestCase extends ChunkClientTemplate {
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(response.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
             response = sendRequest(TestUtil.smallEntity);
-            assertEquals(response.getHeader(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(response.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkEnableServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/chunkdisable/ChunkEnableServerTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.chunkdisable;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.common.Constants;
@@ -44,10 +45,10 @@ public class ChunkEnableServerTestCase extends ChunkServerTemplate {
     public void postTest() {
         try {
             HttpURLConnection urlConn = sendEntityBody(TestUtil.largeEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
             urlConn = sendEntityBody(TestUtil.smallEntity);
-            assertEquals(urlConn.getHeaderField(Constants.HTTP_TRANSFER_ENCODING), Constants.CHUNKED);
+            assertEquals(urlConn.getHeaderField(HttpHeaderNames.TRANSFER_ENCODING.toString()), Constants.CHUNKED);
 
             urlConn.disconnect();
         } catch (IOException e) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ClientRespDecompressionTestCase.java
@@ -103,9 +103,9 @@ public class ClientRespDecompressionTestCase {
         HTTPCarbonMessage requestMsg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                 HttpMethod.POST, ""));
 
-        requestMsg.setProperty(Constants.PORT, TestUtil.SERVER_CONNECTOR_PORT);
+        requestMsg.setProperty(Constants.HTTP_PORT, TestUtil.SERVER_CONNECTOR_PORT);
         requestMsg.setProperty(Constants.PROTOCOL, Constants.HTTP_SCHEME);
-        requestMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        requestMsg.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
         requestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
 
         requestMsg.setHeader("Accept-Encoding", "deflate;q=1.0, gzip;q=0.8");

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/compression/ServerRespCompressionTestCase.java
@@ -85,28 +85,28 @@ public class ServerRespCompressionTestCase {
 
             FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
-            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_GZIP);
+            httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, Constants.ENCODING_GZIP);
             FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
             assertEquals(Constants.ENCODING_GZIP, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 
             httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
             httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
-            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
+            httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
             httpResponse = httpClient.sendRequest(httpRequest);
             assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 
             httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
             httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
-            httpRequest.headers().set(Constants.ACCEPT_ENCODING, "deflate;q=1.0, gzip;q=0.8");
+            httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "deflate;q=1.0, gzip;q=0.8");
             httpResponse = httpClient.sendRequest(httpRequest);
             assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 
             httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
             httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.smallEntity.getBytes()));
-            httpRequest.headers().set(Constants.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
+            httpRequest.headers().set(HttpHeaderNames.ACCEPT_ENCODING, Constants.ENCODING_DEFLATE);
             httpResponse = httpClient.sendRequest(httpRequest);
             assertEquals(Constants.ENCODING_DEFLATE, httpResponse.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationListener.java
@@ -21,6 +21,7 @@ package org.wso2.transport.http.netty.contentaware.listeners;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -71,15 +72,15 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
                 byte[] arry = responseValue.getBytes("UTF-8");
 
                 HTTPCarbonMessage newMsg = httpRequest.cloneCarbonMessageWithOutData();
-                if (newMsg.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {
-                    newMsg.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(arry.length));
+                if (newMsg.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()) == null) {
+                    newMsg.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(arry.length));
                 }
                 ByteBuffer byteBuffer1 = ByteBuffer.allocate(arry.length);
                 byteBuffer1.put(arry);
                 byteBuffer1.flip();
                 newMsg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer1)));
-                newMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                newMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+                newMsg.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
+                newMsg.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();
@@ -117,8 +118,8 @@ public class RequestResponseCreationListener implements HttpConnectorListener {
 
                             HTTPCarbonMessage httpCarbonMessage = httpResponse
                                     .cloneCarbonMessageWithOutData();
-                            if (httpCarbonMessage.getHeader(Constants.HTTP_TRANSFER_ENCODING) == null) {
-                                httpCarbonMessage.setHeader(Constants.HTTP_CONTENT_LENGTH,
+                            if (httpCarbonMessage.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()) == null) {
+                                httpCarbonMessage.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(),
                                         String.valueOf(responseByteValues.length));
                             }
                             httpCarbonMessage.addHttpContent(

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationStreamingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseCreationStreamingListener.java
@@ -74,8 +74,8 @@ public class RequestResponseCreationStreamingListener implements HttpConnectorLi
                 outputStream.write(bytes);
                 outputStream.flush();
                 outputStream.close();
-                newMsg.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                newMsg.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+                newMsg.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
+                newMsg.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformListener.java
@@ -21,6 +21,7 @@ package org.wso2.transport.http.netty.contentaware.listeners;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -71,14 +72,14 @@ public class RequestResponseTransformListener implements HttpConnectorListener {
                 requestValue = TestUtil.getStringFromInputStream(
                         new HttpMessageDataStreamer(httpRequest).getInputStream());
 
-                httpRequest.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                httpRequest.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+                httpRequest.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
+                httpRequest.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
 
                 if (responseValue != null) {
                     byte[] array = responseValue.getBytes("UTF-8");
                     ByteBuffer byteBuffer = ByteBuffer.allocate(array.length);
                     byteBuffer.put(array);
-                    httpRequest.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(array.length));
+                    httpRequest.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(array.length));
                     byteBuffer.flip();
                     httpRequest.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
                 }
@@ -116,7 +117,8 @@ public class RequestResponseTransformListener implements HttpConnectorListener {
                                 }
                                 ByteBuffer byteBuff = ByteBuffer.allocate(array.length);
                                 byteBuff.put(array);
-                                httpMessage.setHeader(Constants.HTTP_CONTENT_LENGTH, String.valueOf(array.length));
+                                httpMessage.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(),
+                                                      String.valueOf(array.length));
                                 byteBuff.flip();
                                 httpMessage.addHttpContent(
                                         new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuff)));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformStreamingListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/contentaware/listeners/RequestResponseTransformStreamingListener.java
@@ -69,8 +69,8 @@ public class RequestResponseTransformStreamingListener implements HttpConnectorL
                 byte[] bytes = IOUtils.toByteArray(inputStream);
                 outputStream.write(bytes);
                 outputStream.close();
-                httpRequestMessage.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-                httpRequestMessage.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+                httpRequestMessage.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
+                httpRequestMessage.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
 
                 Map<String, Object> transportProperties = new HashMap<>();
                 Set<TransportProperty> transportPropertiesSet = configuration.getTransportProperties();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/DateHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/DateHeaderTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.headers;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contentaware.listeners.EchoStreamingMessageListener;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
@@ -70,8 +70,9 @@ public class DateHeaderTestCase {
     public void testDateHeaderFormatAndExistence() throws IOException {
         URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
         HttpURLConnection connection = TestUtil.request(baseURI, "/", HttpMethod.POST.name(), false);
+
         connection.getOutputStream().write(TestUtil.smallEntity.getBytes());
-        String date = connection.getHeaderField(Constants.DATE);
+        String date = connection.getHeaderField(HttpHeaderNames.DATE.toString());
 
         Assert.assertEquals(connection.getResponseCode(), HttpURLConnection.HTTP_OK);
         Assert.assertNotNull(DateTimeFormatter.RFC_1123_DATE_TIME.parse(date));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
@@ -18,10 +18,10 @@
 
 package org.wso2.transport.http.netty.http1point0test;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -44,10 +44,10 @@ public class ChunkAlwaysHttpOnePointZeroClientTestCase extends ChunkClientTempla
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "9342");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "9342");
 
             response = sendRequest(TestUtil.smallEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAutoHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAutoHttpOnePointZeroClientTestCase.java
@@ -18,10 +18,10 @@
 
 package org.wso2.transport.http.netty.http1point0test;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
-import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -44,10 +44,10 @@ public class ChunkAutoHttpOnePointZeroClientTestCase extends ChunkClientTemplate
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "9342");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "9342");
 
             response = sendRequest(TestUtil.smallEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONTENT_LENGTH), "70");
+            assertEquals(response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()), "70");
 
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/HttpOnePointZeroServerConnectorTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/HttpOnePointZeroServerConnectorTestCase.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
@@ -92,7 +93,7 @@ public class HttpOnePointZeroServerConnectorTestCase {
 
             assertTrue(httpClient.waitForChannelClose());
             assertEquals(TestUtil.largeEntity, TestUtil.getEntityBodyFrom(httpResponse));
-            assertNotNull(httpResponse.headers().get(Constants.HTTP_CONTENT_LENGTH));
+            assertNotNull(httpResponse.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running largeHeaderTest", e);
         }
@@ -105,13 +106,13 @@ public class HttpOnePointZeroServerConnectorTestCase {
 
             FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0,
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
-            httpRequest.headers().set(Constants.HTTP_CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
+            httpRequest.headers().set(HttpHeaderNames.CONNECTION, Constants.CONNECTION_KEEP_ALIVE);
             FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
 
             assertFalse(httpClient.waitForChannelClose());
             assertEquals(TestUtil.largeEntity, TestUtil.getEntityBodyFrom(httpResponse));
-            assertEquals(Constants.CONNECTION_KEEP_ALIVE, httpResponse.headers().get(Constants.CONNECTION));
-            assertNotNull(httpResponse.headers().get(Constants.HTTP_CONTENT_LENGTH));
+            assertEquals(Constants.CONNECTION_KEEP_ALIVE, httpResponse.headers().get(HttpHeaderNames.CONNECTION));
+            assertNotNull(httpResponse.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running largeHeaderTest", e);
         }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.http1point0test;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
@@ -45,7 +46,7 @@ public class KeepAliveHttpOnePointZeroClientTestCase extends ChunkClientTemplate
     public void postTest() {
         try {
             HTTPCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            assertEquals(response.getHeader(Constants.HTTP_CONNECTION), Constants.CONNECTION_KEEP_ALIVE);
+            assertEquals(response.getHeader(HttpHeaderNames.CONNECTION.toString()), Constants.CONNECTION_KEEP_ALIVE);
         } catch (Exception e) {
             TestUtil.handleException("Exception occurred while running postTest", e);
         }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/HTTP2MessageProcessor.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/HTTP2MessageProcessor.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.http2;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -45,11 +46,11 @@ public class HTTP2MessageProcessor implements CarbonMessageProcessor {
 
         DefaultCarbonMessage defaultCarbonMessage = new DefaultCarbonMessage();
         carbonMessage.getProperties().forEach(defaultCarbonMessage::setProperty);
-        defaultCarbonMessage.setHeader("content-type", "text/plain");
+        defaultCarbonMessage.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "text/plain");
         defaultCarbonMessage.setStringMessageBody(TEST_VALUE);
         defaultCarbonMessage.setEndOfMsgAdded(true);
         int length = TEST_VALUE.getBytes().length;
-        defaultCarbonMessage.setHeader("content-length", String.valueOf(length));
+        defaultCarbonMessage.setHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(length));
         carbonCallback.done(defaultCarbonMessage);
         return true;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
@@ -62,8 +62,8 @@ public class PassthroughMessageProcessorListener implements HttpConnectorListene
     @Override
     public void onMessage(HTTPCarbonMessage httpRequestMessage) {
         executor.execute(() -> {
-            httpRequestMessage.setProperty(Constants.HOST, TestUtil.TEST_HOST);
-            httpRequestMessage.setProperty(Constants.PORT, TestUtil.HTTP_SERVER_PORT);
+            httpRequestMessage.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
+            httpRequestMessage.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
             try {
                 clientConnector =
                         httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
@@ -75,7 +75,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 /**
  * Test cases for redirection scenarios
  */
-public class HTTPClientRedirectTestCase {
+public class HttpClientRedirectTestCase {
 
     private HttpClientConnector httpClientConnector;
     private HttpWsConnectorFactory connectorFactory;
@@ -544,9 +544,9 @@ public class HTTPClientRedirectTestCase {
 
     private HTTPCarbonMessage createHttpCarbonRequest(String requestUrl, int destinationPort) {
         HTTPCarbonMessage msg = new HTTPCarbonMessage(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""));
-        msg.setProperty(Constants.PORT, destinationPort);
+        msg.setProperty(Constants.HTTP_PORT, destinationPort);
         msg.setProperty(Constants.PROTOCOL, "http");
-        msg.setProperty(Constants.HOST, "localhost");
+        msg.setProperty(Constants.HTTP_HOST, "localhost");
         msg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
         if (requestUrl != null) {
             msg.setProperty(Constants.REQUEST_URL, requestUrl);
@@ -566,15 +566,15 @@ public class HTTPClientRedirectTestCase {
         HttpMethod httpMethod = new HttpMethod(method);
         HTTPCarbonMessage httpCarbonRequest = new HTTPCarbonMessage(
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, ""));
-        httpCarbonRequest.setProperty(Constants.PORT, locationUrl.getPort());
+        httpCarbonRequest.setProperty(Constants.HTTP_PORT, locationUrl.getPort());
         httpCarbonRequest.setProperty(Constants.PROTOCOL, locationUrl.getProtocol());
-        httpCarbonRequest.setProperty(Constants.HOST, locationUrl.getHost());
+        httpCarbonRequest.setProperty(Constants.HTTP_HOST, locationUrl.getHost());
         httpCarbonRequest.setProperty(Constants.HTTP_METHOD, method);
         httpCarbonRequest.setProperty(Constants.REQUEST_URL, locationUrl.getPath());
         httpCarbonRequest.setProperty(Constants.TO, locationUrl.getPath());
 
-        httpCarbonRequest.setHeader(Constants.HOST, locationUrl.getHost());
-        httpCarbonRequest.setHeader(Constants.PORT, Integer.toString(locationUrl.getPort()));
+        httpCarbonRequest.setHeader(HttpHeaderNames.HOST.toString(), locationUrl.getHost());
+        httpCarbonRequest.setHeader(Constants.HTTP_PORT, Integer.toString(locationUrl.getPort()));
         httpCarbonRequest.completeMessage();
         return httpCarbonRequest;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/urilengthvalidation/Status414And413ResponseTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/urilengthvalidation/Status414And413ResponseTest.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -94,12 +95,12 @@ public class Status414And413ResponseTest {
 
             urlConn = sendExtraLongUri();
             assertEquals(HttpResponseStatus.REQUEST_URI_TOO_LONG.code(), urlConn.getResponseCode());
-            assertEquals(TestUtil.TEST_SERVER, urlConn.getHeaderField(Constants.HTTP_SERVER_HEADER));
+            assertEquals(TestUtil.TEST_SERVER, urlConn.getHeaderField(HttpHeaderNames.SERVER.toString()));
 
             urlConn = sendShortUri();
             String content = TestUtil.getContent(urlConn);
             assertEquals(HttpResponseStatus.OK.code(), urlConn.getResponseCode());
-            assertEquals(TestUtil.TEST_SERVER, urlConn.getHeaderField(Constants.HTTP_SERVER_HEADER));
+            assertEquals(TestUtil.TEST_SERVER, urlConn.getHeaderField(HttpHeaderNames.SERVER.toString()));
             assertEquals(testValue, content);
 
             urlConn.disconnect();
@@ -128,7 +129,7 @@ public class Status414And413ResponseTest {
 
             assertEquals(testValue, payload);
             assertEquals(HttpResponseStatus.OK.code(), httpResponse.status().code());
-            assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(Constants.HTTP_SERVER_HEADER));
+            assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(HttpHeaderNames.SERVER.toString()));
 
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running largeHeaderTest", e);
@@ -156,7 +157,7 @@ public class Status414And413ResponseTest {
                     HttpMethod.POST, "/", Unpooled.wrappedBuffer(TestUtil.smallEntity.getBytes()));
             httpResponse = httpClient.sendRequest(httpRequest);
             assertEquals(HttpResponseStatus.OK.code(), httpResponse.status().code());
-            assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(Constants.HTTP_SERVER_HEADER));
+            assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(HttpHeaderNames.SERVER));
 
         } catch (Exception e) {
             TestUtil.handleException("IOException occurred while running largeEntityBodyTest", e);
@@ -165,8 +166,8 @@ public class Status414And413ResponseTest {
 
     private void assertEntityTooLargeResponse(FullHttpResponse httpResponse) {
         assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE.code(), httpResponse.status().code());
-        assertEquals(Constants.CONNECTION_CLOSE, httpResponse.headers().get(Constants.HTTP_CONNECTION));
-        assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(Constants.HTTP_SERVER_HEADER));
+        assertEquals(Constants.CONNECTION_CLOSE, httpResponse.headers().get(HttpHeaderNames.CONNECTION.toString()));
+        assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(HttpHeaderNames.SERVER));
     }
 
     private String getLargeHeader() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -240,9 +240,9 @@ public class TestUtil {
     public static HTTPCarbonMessage createHttpsPostReq(int serverPort, String payload, String path) {
         HTTPCarbonMessage httpPostRequest = new HTTPCarbonMessage(
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path));
-        httpPostRequest.setProperty(Constants.PORT, serverPort);
+        httpPostRequest.setProperty(Constants.HTTP_PORT, serverPort);
         httpPostRequest.setProperty(Constants.PROTOCOL, Constants.HTTPS_SCHEME);
-        httpPostRequest.setProperty(Constants.HOST, TestUtil.TEST_HOST);
+        httpPostRequest.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
         httpPostRequest.setProperty(Constants.HTTP_METHOD, Constants.HTTP_POST_METHOD);
 
         ByteBuffer byteBuffer = ByteBuffer.wrap(payload.getBytes(Charset.forName("UTF-8")));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/http/HttpClient.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/client/http/HttpClient.java
@@ -29,6 +29,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,12 +79,12 @@ public class HttpClient {
     }
 
     public FullHttpResponse sendChunkRequest(FullHttpRequest httpRequest) {
-        httpRequest.headers().set(Constants.HTTP_TRANSFER_ENCODING, Constants.CHUNKED);
+        httpRequest.headers().set(HttpHeaderNames.TRANSFER_ENCODING, Constants.CHUNKED);
         return send(httpRequest);
     }
 
     public FullHttpResponse sendRequest(FullHttpRequest httpRequest) {
-        httpRequest.headers().set(Constants.HTTP_CONTENT_LENGTH, httpRequest.content().readableBytes());
+        httpRequest.headers().set(HttpHeaderNames.CONTENT_LENGTH, httpRequest.content().readableBytes());
         return send(httpRequest);
     }
 
@@ -93,7 +94,7 @@ public class HttpClient {
         this.responseHandler.setLatch(latch);
         this.responseHandler.setWaitForConnectionClosureLatch(this.waitForConnectionClosureLatch);
 
-        httpRequest.headers().set(Constants.HOST, host + ":" + port);
+        httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
         this.connectedChannel.writeAndFlush(httpRequest);
         try {
             latch.await();
@@ -109,7 +110,7 @@ public class HttpClient {
         this.responseHandler.setLatch(latch);
         this.responseHandler.setWaitForConnectionClosureLatch(this.waitForConnectionClosureLatch);
 
-        httpRequest.headers().set(Constants.HOST, host + ":" + port);
+        httpRequest.headers().set(HttpHeaderNames.HOST, host + ":" + port);
         this.connectedChannel.writeAndFlush(httpRequest.copy());
 
         this.connectedChannel.writeAndFlush(httpRequest);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/BadEchoServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/BadEchoServerInitializer.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -31,7 +32,6 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.transport.http.netty.common.Constants;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -125,7 +125,7 @@ public class BadEchoServerInitializer extends HTTPServerInitializer {
         }
 
         private void checkAndSetEncodingHeader(HttpRequest req) {
-            if (req.headers().get(Constants.HTTP_CONTENT_LENGTH) != null) {
+            if (req.headers().get(HttpHeaderNames.CONTENT_LENGTH) != null) {
                 chunked = false;
             } else {
                 httpResponse.headers().set(TRANSFER_ENCODING, "chunked");

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/EchoServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/EchoServerInitializer.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -31,7 +32,6 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.transport.http.netty.common.Constants;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -116,7 +116,7 @@ public class EchoServerInitializer extends HTTPServerInitializer {
 
         private void writeHeadersAndEntity(ChannelHandlerContext ctx, HttpContent lastHttpContent) {
             contentLength += lastHttpContent.content().readableBytes();
-            httpResponse.headers().set(Constants.HTTP_CONTENT_LENGTH, contentLength);
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
             ctx.write(httpResponse);
 
             while (!content.isEmpty()) {
@@ -132,7 +132,7 @@ public class EchoServerInitializer extends HTTPServerInitializer {
         }
 
         private void checkAndSetEncodingHeader(HttpRequest req) {
-            if (req.headers().get(Constants.HTTP_CONTENT_LENGTH) != null) {
+            if (req.headers().get(HttpHeaderNames.CONTENT_LENGTH) != null) {
                 chunked = false;
             } else {
                 httpResponse.headers().set(TRANSFER_ENCODING, "chunked");

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -44,8 +44,7 @@
             <class name="org.wso2.transport.http.netty.proxyserver.ProxyServerTestCase" />
 
             <class name="org.wso2.transport.http.netty.hostnameverfication.HostnameVerificationTest" />
-
-            <class name="org.wso2.transport.http.netty.redirect.HTTPClientRedirectTestCase" />
+            <class name="org.wso2.transport.http.netty.redirect.HttpClientRedirectTestCase" />
 
             <class name="org.wso2.transport.http.netty.ClientConnectorTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.ClientConnectorConnectionRefusedTestCase" />


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4741

## Goals
> This fixes the inconsistent use of lower case headers.

## Approach
> Use only the header constants from netty's `HttpHeaderNames` as much as possible

## Related PRs
> https://github.com/ballerina-lang/ballerina/pull/4766