### PR TITLE
Support standard access logs

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -108,7 +108,8 @@ public final class Constants {
     public static final String ENCODING_DEFLATE = "deflate";
     public static final String HTTP_TRANSFER_ENCODING_IDENTITY = "identity";
 
-    // TODO: Move string constants for HTTP header values to their own class
+    // TODO: Move string constants for HTTP headers and header values to their own class
+    public static final String HTTP_X_FORWARDED_FOR = "x-forwarded-for";
     public static final String CONNECTION_KEEP_ALIVE = "keep-alive";
     public static final String CONNECTION_CLOSE = "close";
     public static final String FORWARDED = "forwarded";
@@ -202,6 +203,7 @@ public final class Constants {
     public static final String REDIRECT_HANDLER = "redirectHandler";
     public static final String IDLE_STATE_HANDLER = "idleStateHandler";
     public static final String HTTP_TRACE_LOG_HANDLER = "http-trace-logger";
+    public static final String HTTP_ACCESS_LOG_HANDLER = "http-access-logger";
     public static final String WEBSOCKET_SERVER_HANDSHAKE_HANDLER = "websocket-server-handshake-handler";
 
     public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpAccessLoggingHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpAccessLoggingHandler.java
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.transport.http.netty.listener;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import org.wso2.transport.http.netty.common.Constants;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Calendar;
+
+/**
+ * Logging handler for HTTP access logs.
+ */
+public class HttpAccessLoggingHandler extends LoggingHandler {
+    private static final LogLevel LOG_LEVEL = LogLevel.INFO;
+    private static final String DEFAULT_LOG_FORMAT =
+            "%1$s - - [%2$td/%2$tb/%2$tY:%2$tT %2$tz] \"%3$s %4$s %5$s\" %6$d %7$d \"%8$s\" \"%9$s\"";
+    private static final String EVENT_WRITE = "WRITE";
+    private String inetAddress;
+    private String method;
+    private String uri;
+    private String protocol;
+    private String userAgent = "-";
+    private String referrer = "-";
+    private int status;
+    private Long contentLength = 0L;
+    private Calendar calendar;
+
+    public HttpAccessLoggingHandler(String name) {
+        super(name, LOG_LEVEL);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        SocketAddress address = ctx.channel().remoteAddress();
+        if (address instanceof InetSocketAddress) {
+            inetAddress = ((InetSocketAddress) address).getAddress().toString();
+        }
+        if (inetAddress.startsWith("/")) {
+            inetAddress = inetAddress.substring(1);
+        }
+        ctx.fireChannelActive();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelInactive();
+        inetAddress = "-";
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof HttpRequest) {
+            HttpRequest httpRequest = (HttpRequest) msg;
+            calendar = Calendar.getInstance();
+            // maybe this request was proxied or load balanced.
+            // try and get the real originating IP
+            if (httpRequest.headers().contains(Constants.HTTP_X_FORWARDED_FOR)) {
+                // can contain multiple IPs for proxy chains. the first ip is our client.
+                String proxyChain = httpRequest.headers().get(Constants.HTTP_X_FORWARDED_FOR);
+                int firstComma = proxyChain.indexOf(',');
+                if (firstComma != -1) {
+                    inetAddress = proxyChain.substring(0, proxyChain.indexOf(','));
+                } else {
+                    inetAddress = proxyChain;
+                }
+            }
+            if (httpRequest.headers().contains(HttpHeaderNames.USER_AGENT)) {
+                userAgent = httpRequest.headers().get(HttpHeaderNames.USER_AGENT);
+            }
+            if (httpRequest.headers().contains(HttpHeaderNames.REFERER)) {
+                referrer = httpRequest.headers().get(HttpHeaderNames.REFERER);
+            }
+            method = httpRequest.method().name();
+            uri = httpRequest.uri();
+            protocol = httpRequest.protocolVersion().toString();
+        }
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        ctx.write(msg, promise);
+        if (msg instanceof HttpResponse) {
+            HttpResponse httpResponse = (HttpResponse) msg;
+            status = httpResponse.status().code();
+            if (httpResponse.headers().contains(HttpHeaderNames.CONTENT_LENGTH)) {
+                contentLength = Long.valueOf(httpResponse.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+                if (logger.isEnabled(internalLevel)) {
+                    logger.log(internalLevel, format(ctx, EVENT_WRITE, msg));
+                }
+                clearState();
+            }
+        } else if (msg instanceof HttpContent) {
+            HttpContent httpContent = (HttpContent) msg;
+            contentLength += httpContent.content().readableBytes();
+            if (msg instanceof LastHttpContent) {
+                if (logger.isEnabled(internalLevel)) {
+                    logger.log(internalLevel, format(ctx, EVENT_WRITE, msg));
+                }
+                clearState();
+            }
+        }
+    }
+
+    @Override
+    protected String format(ChannelHandlerContext ctx, String eventName, Object arg) {
+        if (EVENT_WRITE.equals(eventName)) {
+            return String.format(DEFAULT_LOG_FORMAT, inetAddress, calendar, method, uri, protocol, status,
+                                 contentLength, referrer, userAgent);
+        }
+        return "";
+    }
+
+    private void clearState() {
+        method = null;
+        uri = null;
+        protocol = null;
+        status = -1;
+        contentLength = 0L;
+        calendar = null;
+        userAgent = "-";
+        referrer = "-";
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelRegistered();
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelUnregistered();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireExceptionCaught(cause);
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+        ctx.bind(localAddress, promise);
+    }
+
+    @Override
+    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
+                        ChannelPromise promise) throws Exception {
+        ctx.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.disconnect(promise);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.close(promise);
+    }
+
+    @Override
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.deregister(promise);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelReadComplete();
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
@@ -113,7 +113,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             serverPipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
                              new HTTPTraceLoggingHandler("tracelog.http.downstream"));
         }
-
+        serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler("accesslog.http"));
         serverPipeline.addLast("uriLengthValidator", new UriAndHeaderLengthValidator(this.serverName));
         if (reqSizeValidationConfig.getMaxEntityBodySize() > -1) {
             serverPipeline.addLast("maxEntityBodyValidator", new MaxEntityBodyValidator(this.serverName,


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4444
## Goals
> Access logs will be printed in the console

## Approach
> The access logs are supported as per https://httpd.apache.org/docs/current/logs.html#combined

## Related PRs
> https://github.com/ballerina-lang/ballerina/pull/4913
