### PR TITLE
Add configuration for access log

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/ListenerConfiguration.java
@@ -94,6 +94,9 @@ public class ListenerConfiguration {
     private boolean httpTraceLogEnabled;
 
     @XmlAttribute
+    private boolean httpAccessLogEnabled;
+
+    @XmlAttribute
     private String verifyClient;
 
     @XmlAttribute
@@ -313,6 +316,14 @@ public class ListenerConfiguration {
 
     public void setHttpTraceLogEnabled(boolean httpTraceLogEnabled) {
         this.httpTraceLogEnabled = httpTraceLogEnabled;
+    }
+
+    public boolean isHttpAccessLogEnabled() {
+        return httpAccessLogEnabled;
+    }
+
+    public void setHttpAccessLogEnabled(boolean httpAccessLogEnabled) {
+        this.httpAccessLogEnabled = httpAccessLogEnabled;
     }
 
     public RequestSizeValidationConfig getRequestSizeValidationConfig() {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -73,6 +73,7 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
         }
         serverConnectorBootstrap.addIdleTimeout(listenerConfig.getSocketIdleTimeout(120000));
         serverConnectorBootstrap.addHttpTraceLogHandler(listenerConfig.isHttpTraceLogEnabled());
+        serverConnectorBootstrap.addHttpAccessLogHandler(listenerConfig.isHttpAccessLogEnabled());
         serverConnectorBootstrap.addThreadPools(bossGroup, workerGroup);
         serverConnectorBootstrap.addHeaderAndEntitySizeValidation(listenerConfig.getRequestSizeValidationConfig());
         serverConnectorBootstrap.addChunkingBehaviour(listenerConfig.getChunkConfig());

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
@@ -51,6 +51,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
     private int socketIdleTimeout;
     private boolean httpTraceLogEnabled;
+    private boolean httpAccessLogEnabled;
     private ChunkConfig chunkConfig;
     private KeepAliveConfig keepAliveConfig;
     private String interfaceId;
@@ -113,7 +114,9 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             serverPipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
                              new HTTPTraceLoggingHandler("tracelog.http.downstream"));
         }
-        serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler("accesslog.http"));
+        if (httpAccessLogEnabled) {
+            serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler("accesslog.http"));
+        }
         serverPipeline.addLast("uriLengthValidator", new UriAndHeaderLengthValidator(this.serverName));
         if (reqSizeValidationConfig.getMaxEntityBodySize() > -1) {
             serverPipeline.addLast("maxEntityBodyValidator", new MaxEntityBodyValidator(this.serverName,
@@ -142,6 +145,10 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
     void setHttpTraceLogEnabled(boolean httpTraceLogEnabled) {
         this.httpTraceLogEnabled = httpTraceLogEnabled;
+    }
+
+    public void setHttpAccessLogEnabled(boolean httpAccessLogEnabled) {
+        this.httpAccessLogEnabled = httpAccessLogEnabled;
     }
 
     void setInterfaceId(String interfaceId) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
@@ -148,6 +148,9 @@ public class ServerConnectorBootstrap {
         httpServerChannelInitializer.setHttpTraceLogEnabled(isHttpTraceLogEnabled);
     }
 
+    public void addHttpAccessLogHandler(Boolean isHttpAccessLogEnabled) {
+        httpServerChannelInitializer.setHttpAccessLogEnabled(isHttpAccessLogEnabled);
+    }
     public void addHeaderAndEntitySizeValidation(RequestSizeValidationConfig requestSizeValidationConfig) {
         httpServerChannelInitializer.setReqSizeValidationConfig(requestSizeValidationConfig);
     }


### PR DESCRIPTION
## Purpose
> Related issue: https://github.com/ballerina-lang/ballerina/issues/4444

## Goals
>Fix access log being on by default

## Approach
> Add to listener configuration

## Related PRs
> https://github.com/wso2/transport-http/pull/67
> https://github.com/ballerina-lang/ballerina/pull/4913
