### PR TITLE
Add method for adding a set of headers to HTTPCarbonMessage

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -159,6 +159,15 @@ public class HTTPCarbonMessage {
     }
 
     /**
+     * Adds the user provided headers to the Carbon message. Duplicate headers are allowed.
+     *
+     * @param httpHeaders Set of headers to be added.
+     */
+    public void addHeaders(HttpHeaders httpHeaders) {
+        this.httpMessage.headers().add(httpHeaders);
+    }
+
+    /**
      * Remove the header using header name.
      *
      * @param key header name.


### PR DESCRIPTION
## Purpose
> Provide a way to add a set of headers to HTTPCarbonMessage. Fix #74 

## Goals
> Add an `addHeaders()` method to HTTPCarbonMessage which will allow the users to add a set of headers to the message, including duplicate headers.

