### PR TITLE
Introduce Timeout exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: java
+
+sudo: required
+
+script: mvn clean install
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/exception/EndpointTimeOutException.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/exception/EndpointTimeOutException.java
@@ -18,12 +18,43 @@
 
 package org.wso2.transport.http.netty.exception;
 
+import org.wso2.transport.http.netty.contract.ClientConnectorException;
+
 /**
  * A class that represent EndpointTimeout Exception.
  */
-public class EndpointTimeOutException extends Exception {
+public class EndpointTimeOutException extends ClientConnectorException {
 
-    public EndpointTimeOutException(String message) {
-        super(message);
+    /**
+     * Constructs a new EndpointTimeOutException with the specified outboundChannelID and detail message.
+     *
+     * @param outboundChannelID  the unique identifier of out bound channel.
+     * @param message the detail message.
+     */
+    public EndpointTimeOutException(String outboundChannelID, String message) {
+        super(outboundChannelID, message);
     }
+
+    /**
+     * Constructs a new EndpointTimeOutException with the specified detail message and HTTP Status code.
+     *
+     * @param message the detail message.
+     * @param httpStatusCode HTTP status code to be set to the EndpointTimeOutException.
+     */
+    public EndpointTimeOutException(String message, int httpStatusCode) {
+        super(message, httpStatusCode);
+    }
+
+    /**
+     * Constructs a new EndpointTimeOutException with the specified outboundChannelID and detail message and
+     * HTTP Status code.
+     *
+     * @param outboundChannelID the unique identifier of out bound channel.
+     * @param message the detail message.
+     * @param httpStatusCode HTTP status code to be set to the EndpointTimeOutException.
+     */
+    public EndpointTimeOutException(String outboundChannelID, String message, int httpStatusCode) {
+        super(outboundChannelID, message, httpStatusCode);
+    }
+
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -32,6 +32,7 @@ import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -193,7 +194,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     private void handleErrorIdleScenarios(String channelID) {
         if (targetRespMsg == null) {
-            httpResponseFuture.notifyHttpListener(new ClientConnectorException(channelID,
+            httpResponseFuture.notifyHttpListener(new EndpointTimeOutException(channelID,
                     Constants.IDLE_TIMEOUT_TRIGGERED_BEFORE_READING_INBOUND_RESPONSE,
                     HttpResponseStatus.GATEWAY_TIMEOUT.code()));
         } else {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/ClientConnectorTimeoutTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.util.HTTPConnectorListener;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -41,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
 /**
@@ -78,6 +80,8 @@ public class ClientConnectorTimeoutTestCase {
 
             Throwable response = listener.getHttpErrorMessage();
             assertNotNull(response);
+            assertTrue(response instanceof EndpointTimeOutException,
+                    "Exception is not an instance of EndpointTimeOutException");
             String result = response.getMessage();
 
             assertEquals(Constants.IDLE_TIMEOUT_TRIGGERED_BEFORE_READING_INBOUND_RESPONSE, result);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
@@ -35,7 +35,6 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnectorException;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
-import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -83,8 +82,7 @@ public class PassthroughMessageProcessorListener implements HttpConnectorListene
 
                     @Override
                     public void onError(Throwable throwable) {
-                        if (throwable instanceof ClientConnectorException
-                                || throwable instanceof EndpointTimeOutException) {
+                        if (throwable instanceof ClientConnectorException) {
                             ClientConnectorException connectorException = (ClientConnectorException) throwable;
                             if (connectorException.getOutboundChannelID() != null) {
                                 sendTimeoutResponse(connectorException.getOutboundChannelID());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
@@ -35,6 +35,7 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnectorException;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -82,7 +83,8 @@ public class PassthroughMessageProcessorListener implements HttpConnectorListene
 
                     @Override
                     public void onError(Throwable throwable) {
-                        if (throwable instanceof ClientConnectorException) {
+                        if (throwable instanceof ClientConnectorException
+                                || throwable instanceof EndpointTimeOutException) {
                             ClientConnectorException connectorException = (ClientConnectorException) throwable;
                             if (connectorException.getOutboundChannelID() != null) {
                                 sendTimeoutResponse(connectorException.getOutboundChannelID());


### PR DESCRIPTION
When an endpoint timeout occurred, the listener will be notified with a client connector exception. this will introduce EndpointTimeoutError which will be helpful to implement programs more resilient to failures.