### PR TITLE
Improve error handling related to HTTP/2 operations

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -193,7 +193,7 @@ public final class Constants {
     public static final String HTTP_VERSION_2_0 = "HTTP/2.0";
     public static final String HTTP2_VERSION = "2.0";
     public static final String STREAM_ID = "STREAM_ID";
-//    public static final String SCHEME = "SCHEME";
+    public static final int HTTP2_INITIAL_STREAM_ID = 1;
     public static final String AUTHORITY = "AUTHORITY";
     public static final String HTTP2_METHOD = ":method";
     public static final String HTTP2_PATH = ":path";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpResponseFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpResponseFuture.java
@@ -61,6 +61,8 @@ public interface HttpResponseFuture {
 
     /**
      * Reset the states associated with the future.
+     *
+     * Status need to be reset if we are to reuse the future for more than once with sync operation.
      */
     void resetStatus();
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpResponseFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpResponseFuture.java
@@ -60,6 +60,11 @@ public interface HttpResponseFuture {
     OperationStatus getStatus();
 
     /**
+     * Reset the states associated with the future.
+     */
+    void resetStatus();
+
+    /**
      * Makes the async operation sync.
      *
      * @return Status future

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -167,7 +167,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
             httpResponseFuture = outboundMsgHolder.getResponseFuture();
 
             // Response for the upgrade request will arrive in stream 1, so use 1 as the stream id
-            freshHttp2ClientChannel.putInFlightMessage(1, outboundMsgHolder);
+            freshHttp2ClientChannel.putInFlightMessage(Constants.HTTP2_INITIAL_STREAM_ID, outboundMsgHolder);
 
             targetChannel.getChannelFuture().addListener(new ChannelFutureListener() {
                 @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -108,7 +108,14 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
 
     @Override
     public HttpResponseFuture getPushResponse(Http2PushPromise pushPromise) {
-        return pushPromise.getOutboundMsgHolder().getResponseFuture();
+        OutboundMsgHolder outboundMsgHolder = pushPromise.getOutboundMsgHolder();
+        if (pushPromise.isRejected()) {
+            outboundMsgHolder.getResponseFuture().
+                    notifyPushResponse(pushPromise.getPromisedStreamId(),
+                                       new ClientConnectorException("Cannot fetch a response for an rejected promise",
+                                                                    HttpResponseStatus.BAD_REQUEST.code()));
+        }
+        return outboundMsgHolder.getResponseFuture();
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpResponseFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpResponseFuture.java
@@ -90,6 +90,7 @@ public class DefaultHttpResponseFuture implements HttpResponseFuture {
     @Override
     public void notifyHttpListener(Throwable throwable) {
         this.throwable = throwable;
+        returnError = throwable;
         if (executionWaitSem != null) {
             executionWaitSem.release();
         }
@@ -100,7 +101,7 @@ public class DefaultHttpResponseFuture implements HttpResponseFuture {
 
     public HttpResponseFuture sync() throws InterruptedException {
         executionWaitSem = new Semaphore(0);
-        if (this.httpCarbonMessage == null && this.throwable == null) {
+        if (this.httpCarbonMessage == null && this.throwable == null && this.returnError == null) {
             executionWaitSem.acquire();
         }
         if (httpCarbonMessage != null) {
@@ -117,6 +118,10 @@ public class DefaultHttpResponseFuture implements HttpResponseFuture {
     public DefaultOperationStatus getStatus() {
         return this.returnError != null ? new DefaultOperationStatus(this.returnError)
                                         : new DefaultOperationStatus(null);
+    }
+
+    public void resetStatus() {
+        this.returnError = null;
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -39,6 +39,7 @@ import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.listener.RequestDataHolder;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.Http2PushPromise;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -97,6 +98,18 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                         }
                     }));
         });
+    }
+
+    @Override
+    public void onPushPromise(Http2PushPromise pushPromise) {
+        inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(new UnsupportedOperationException(
+                "Sending a PUSH_PROMISE is not supported for HTTP/1.x connections"));
+    }
+
+    @Override
+    public void onPushResponse(int promiseId, HTTPCarbonMessage httpMessage) {
+        inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(new UnsupportedOperationException(
+                "Sending Server Push messages is not supported for HTTP/1.x connections"));
     }
 
     private void writeOutboundResponse(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
@@ -45,18 +45,17 @@ public final class Http2SourceHandlerBuilder
 
     @Override
     public Http2SourceHandler build() {
+        Http2Connection conn = new DefaultHttp2Connection(true);
+        connection(conn);
         return super.build();
     }
 
     @Override
     protected Http2SourceHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                        Http2Settings initialSettings) {
-        Http2Connection conn = new DefaultHttp2Connection(true);
-        Http2SourceHandler handler =
-                new Http2SourceHandler(
-                        decoder, encoder, initialSettings, interfaceId, conn, serverConnectorFuture, serverName);
+        Http2SourceHandler handler = new Http2SourceHandler(
+                decoder, encoder, initialSettings, interfaceId, connection(), serverConnectorFuture, serverName);
         frameListener(handler.getHttp2FrameListener());
-        connection(conn);
         return handler;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -42,6 +42,7 @@ import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 import org.wso2.transport.http.netty.sender.http2.ClientOutboundHandler;
+import org.wso2.transport.http.netty.sender.http2.OutboundMsgHolder;
 
 /**
  * A class responsible for handling responses coming from BE.
@@ -80,7 +81,12 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                 if (handlerExecutor != null) {
                     handlerExecutor.executeAtTargetResponseReceiving(targetRespMsg);
                 }
-
+                OutboundMsgHolder msgHolder = http2ClientOutboundHandler.
+                        getHttp2ClientChannel().getInFlightMessage(1);
+                if (msgHolder != null) {
+                    // Response received over HTTP/1.x connection, so mark no push promises available in the channel
+                    msgHolder.markNoPromisesReceived();
+                }
                 if (this.httpResponseFuture != null) {
                     httpResponseFuture.notifyHttpListener(targetRespMsg);
                 } else {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -82,7 +82,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                     handlerExecutor.executeAtTargetResponseReceiving(targetRespMsg);
                 }
                 OutboundMsgHolder msgHolder = http2ClientOutboundHandler.
-                        getHttp2ClientChannel().getInFlightMessage(1);
+                        getHttp2ClientChannel().getInFlightMessage(Constants.HTTP2_INITIAL_STREAM_ID);
                 if (msgHolder != null) {
                     // Response received over HTTP/1.x connection, so mark no push promises available in the channel
                     msgHolder.markNoPromisesReceived();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
@@ -119,7 +119,7 @@ public class Http2ClientChannel {
      * @param streamId stream id
      * @return in-flight message associated with the a particular stream id
      */
-    OutboundMsgHolder getInFlightMessage(int streamId) {
+    public OutboundMsgHolder getInFlightMessage(int streamId) {
         return inFlightMessages.get(streamId);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
@@ -112,6 +112,14 @@ public class OutboundMsgHolder {
     }
 
     /**
+     * Mark no push promises received.
+     */
+    public void markNoPromisesReceived() {
+        allPromisesReceived = true;
+        responseFuture.notifyPromiseAvailability();
+    }
+
+    /**
      * Gets a push response received over a particular stream.
      *
      * @param steamId id of the stream in which the push response is received


### PR DESCRIPTION
## Purpose
Need to improve error handling of HTTP/2 related operation.
- Prevent writing a push response to rejected stream
- Prevent trying to fetch a promised response for a rejected promise
- Throw errors which trying to do HTTP/2 related operation on HTTP/1.x server side connections.

## Goals
Goal is to improve error handling on  HTTP/2 related operation.

## Approach
Fixes to above mentioned facts are included in this PR.

## User stories

## Release note

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing

## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)
If sync() operation is need to be called more than once in a single HttpResponseFuture object,
resetStatus() must be called after checking the status by using getStatus() method before calling the sync() operation again.


## Test environment
JDK 1.8
 
## Learning
