### PR TITLE
Fix the null pointer issue in target handler

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -202,7 +202,7 @@ public final class Constants {
 
     public static final String HTTP_SOURCE_HANDLER = "SourceHandler";
     public static final String HTTP_ENCODER = "encoder";
-    public static final String HTTP_DECODER = "decoder";
+    public static final String HTTP_CLIENT_CODEC = "codec";
     public static final String WEBSOCKET_SOURCE_HANDLER = "ws_handler";
     public static final String HTTP2_SOURCE_HANDLER = "Http2SourceHandler";
     public static final String HTTP2_ALPN_HANDLER = "Http2ALPNHandler";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -126,7 +126,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
 
     @Override
     public HttpResponseFuture send(HTTPCarbonMessage httpOutboundRequest) {
-        HttpResponseFuture httpResponseFuture;
+        final HttpResponseFuture httpResponseFuture;
 
         SourceHandler srcHandler = (SourceHandler) httpOutboundRequest.getProperty(Constants.SRC_HANDLER);
         if (srcHandler == null) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TLSHandshakeCompletionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TLSHandshakeCompletionHandler.java
@@ -30,9 +30,14 @@ import org.wso2.transport.http.netty.common.Constants;
 public class TLSHandshakeCompletionHandler extends ChannelInboundHandlerAdapter {
 
     private ConnectionAvailabilityFuture connectionAvailabilityFuture;
+    private HttpClientChannelInitializer httpClientChannelInitializer;
+    private TargetHandler targetHandler;
 
-    public TLSHandshakeCompletionHandler(ConnectionAvailabilityFuture connectionAvailabilityFuture) {
+    public TLSHandshakeCompletionHandler(ConnectionAvailabilityFuture connectionAvailabilityFuture,
+            HttpClientChannelInitializer httpClientChannelInitializer, TargetHandler targetHandler) {
         this.connectionAvailabilityFuture = connectionAvailabilityFuture;
+        this.httpClientChannelInitializer = httpClientChannelInitializer;
+        this.targetHandler = targetHandler;
     }
 
     @Override
@@ -43,13 +48,12 @@ public class TLSHandshakeCompletionHandler extends ChannelInboundHandlerAdapter 
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
 
             if (event.isSuccess()) {
+                this.httpClientChannelInitializer.configureHttpPipeline(ctx.pipeline(), targetHandler);
                 connectionAvailabilityFuture.notifySuccess(Constants.HTTP_SCHEME);
-                ctx.fireChannelRead(evt);
             } else {
                 connectionAvailabilityFuture.notifyFailure(event.cause());
             }
         }
-        ctx.fireUserEventTriggered(evt);
     }
 }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
@@ -72,7 +72,7 @@ public class TargetChannel {
 
     private List<HttpContent> contentList = new ArrayList<>();
     private int contentLength = 0;
-    ConnectionAvailabilityFuture connectionAvailabilityFuture;
+    private final ConnectionAvailabilityFuture connectionAvailabilityFuture;
 
     public TargetChannel(HttpClientChannelInitializer httpClientChannelInitializer, ChannelFuture channelFuture,
                          HttpRoute httpRoute, ConnectionAvailabilityFuture connectionAvailabilityFuture) {
@@ -151,7 +151,7 @@ public class TargetChannel {
         TargetHandler targetHandler = this.getTargetHandler();
         targetHandler.setHttpResponseFuture(httpInboundResponseFuture);
         targetHandler.setIncomingMsg(httpCarbonMessage);
-        this.getTargetHandler().setConnectionManager(connectionManager);
+        targetHandler.setConnectionManager(connectionManager);
         targetHandler.setTargetChannel(this);
 
         this.httpInboundResponseFuture = httpInboundResponseFuture;


### PR DESCRIPTION
## Purpose
Fix the null pointer exception which comes when an error occurs.

## Approach
When an error occurs, in a TLS handshake it was giving a null pointer error since the target handler was not set at that moment.
As a solution, removed the rest of the handlers(including target handler) from the pipeline after SSLHandler if the handshake fails.

