### PR TITLE
Allow user to control ssl session creation

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -39,7 +39,7 @@ public final class Constants {
     public static final String SSL_HANDLER = "ssl";
     public static final String CLIENT_SUPPORT_CIPHERS = "ciphers";
     public static final String CLIENT_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
-    public static final String CLIENT_ENABLE_SESSION_CREATION = "client.enable.session.creation";
+    public static final String CLIENT_ENABLE_SESSION_CREATION = "sessionCreation";
 
     // Server Bootstrap related
     public static final String SERVER_BOOTSTRAP_TCP_NO_DELY = "server.bootstrap.nodelay";
@@ -63,7 +63,7 @@ public final class Constants {
     //Server side SSL Parameters
     public static final String SERVER_SUPPORT_CIPHERS = "ciphers";
     public static final String SERVER_SUPPORT_SSL_PROTOCOLS = "sslEnabledProtocols";
-    public static final String SERVER_ENABLE_SESSION_CREATION = "server.enable.session.creation";
+    public static final String SERVER_ENABLE_SESSION_CREATION = "sessionCreation";
     public static final String SERVER_SUPPORTED_SERVER_NAMES = "server.suported.server.names";
     public static final String SERVER_SUPPORTED_SNIMATCHERS = "server.supported.snimatchers";
     public static final String SSL_VERIFY_CLIENT = "sslVerifyClient";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLConfig.java
@@ -43,7 +43,7 @@ public class SSLConfig {
 
     private String[] cipherSuites;
     private String[] enableProtocols;
-    private boolean enableSessionCreation;
+    private boolean enableSessionCreation = true;
     private boolean needClientAuth;
     private boolean wantClientAuth;
     private String[] serverNames;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLHandlerFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLHandlerFactory.java
@@ -59,7 +59,6 @@ import javax.net.ssl.TrustManagerFactory;
  */
 public class SSLHandlerFactory {
 
-    private String protocol = null;
     private final SSLContext sslContext;
     private SSLConfig sslConfig;
     private boolean needClientAuth;
@@ -73,7 +72,7 @@ public class SSLHandlerFactory {
             algorithm = "SunX509";
         }
         needClientAuth = sslConfig.isNeedClientAuth();
-        protocol = sslConfig.getSSLProtocol();
+        String protocol = sslConfig.getSSLProtocol();
         try {
             KeyManager[] keyManagers = null;
             if (sslConfig.getKeyStore() != null) {
@@ -146,16 +145,14 @@ public class SSLHandlerFactory {
      * @param engine client/server ssl engine.
      * @return sslEngine
      */
-    public SSLEngine addCommonConfigs(SSLEngine engine) {
+    private SSLEngine addCommonConfigs(SSLEngine engine) {
         if (sslConfig.getCipherSuites() != null && sslConfig.getCipherSuites().length > 0) {
             engine.setEnabledCipherSuites(sslConfig.getCipherSuites());
         }
         if (sslConfig.getEnableProtocols() != null && sslConfig.getEnableProtocols().length > 0) {
             engine.setEnabledProtocols(sslConfig.getEnableProtocols());
         }
-        if (sslConfig.isEnableSessionCreation()) {
-            engine.setEnableSessionCreation(true);
-        }
+        engine.setEnableSessionCreation(sslConfig.isEnableSessionCreation());
         return engine;
     }
 
@@ -203,11 +200,11 @@ public class SSLHandlerFactory {
                         ApplicationProtocolNames.HTTP_2, ApplicationProtocolNames.HTTP_1_1)).build();
     }
 
-    public KeyManagerFactory getKeyManagerFactory() {
+    private KeyManagerFactory getKeyManagerFactory() {
         return kmf;
     }
 
-    public TrustManagerFactory getTrustStoreFactory() {
+    private TrustManagerFactory getTrustStoreFactory() {
         return tmf;
     }
 


### PR DESCRIPTION
## Purpose
Earlier we didn't have control for ssl session creation. By default it is set to true and user cannot control whether to establish new ssl sessions or to disable creating new ssl sessions.

## Goals
Allow user to control ssl session creation.

## Approach
A parameter is introduced to control this (sessionCreationEnabled). By default this will be set to true which is the default way used in Java. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> List any other related PRs

Related issue : https://github.com/ballerina-lang/ballerina/issues/5345