### PR TITLE
Fix the issue of not creating http pipeline when certificate validatiion is enabled

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/CertificateValidationHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/CertificateValidationHandler.java
@@ -62,6 +62,7 @@ public class CertificateValidationHandler extends ChannelInboundHandlerAdapter {
                 ctx.close();
                 throw new SSLException("Certificate Chain Validation failed. Hence closing the channel");
             }
+            ctx.fireUserEventTriggered(evt);
         }
     }
 


### PR DESCRIPTION
## Purpose
Server/client fails to create the http pipe line after certificate validation is enabled, since it fails to send go to the SSLHandshakeCompletion handler. 

## Approach
Fire the user event inside the certificate validation handler.

