### PR TITLE
Add source handler in pass-through test cases

### DIFF
--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpsTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpsTestCase.java
@@ -100,8 +100,6 @@ public class PassThroughHttpsTestCase {
 
     private static void setSslSystemProperties() {
         Properties systemProps = System.getProperties();
-        systemProps.put("javax.net.ssl.keyStorePassword", TestUtil.KEY_STORE_PASSWORD);
-        systemProps.put("javax.net.ssl.keyStore", TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         systemProps.put("javax.net.ssl.trustStore", TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
         systemProps.put("javax.net.ssl.trustStorePassword", TestUtil.KEY_STORE_PASSWORD);
         System.setProperties(systemProps);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughHttpsMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughHttpsMessageProcessorListener.java
@@ -20,6 +20,7 @@ package org.wso2.transport.http.netty.passthrough;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
@@ -53,11 +54,12 @@ public class PassthroughHttpsMessageProcessorListener implements HttpConnectorLi
     @Override
     public void onMessage(HTTPCarbonMessage httpRequestMessage) {
         executor.execute(() -> {
-            HTTPCarbonMessage msg = TestUtil.createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, testValue, "");
+            HTTPCarbonMessage outboundRequest = TestUtil.createHttpsPostReq(TestUtil.HTTP_SERVER_PORT, testValue, "");
+            outboundRequest.setProperty(Constants.SRC_HANDLER, httpRequestMessage.getProperty(Constants.SRC_HANDLER));
             try {
                 clientConnector =
                         httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
-                HttpResponseFuture future = clientConnector.send(msg);
+                HttpResponseFuture future = clientConnector.send(outboundRequest);
                 future.setHttpConnectorListener(new HttpConnectorListener() {
                     @Override
                     public void onMessage(HTTPCarbonMessage httpResponse) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughMessageProcessorListener.java
@@ -64,6 +64,8 @@ public class PassthroughMessageProcessorListener implements HttpConnectorListene
         executor.execute(() -> {
             httpRequestMessage.setProperty(Constants.HTTP_HOST, TestUtil.TEST_HOST);
             httpRequestMessage.setProperty(Constants.HTTP_PORT, TestUtil.HTTP_SERVER_PORT);
+            httpRequestMessage
+                    .setProperty(Constants.SRC_HANDLER, httpRequestMessage.getProperty(Constants.SRC_HANDLER));
             try {
                 clientConnector =
                         httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);


### PR DESCRIPTION
## Purpose
Add source handler in both http and https pass-through test cases.
Remove setting keystore as a system property since it is not required.

