### PR TITLE
Use async RemoteEndpoint for WebSocket

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketAsyncRemoteEndpoint.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketAsyncRemoteEndpoint.java
@@ -21,6 +21,7 @@ package org.wso2.transport.http.netty.internal.websocket;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
@@ -28,58 +29,61 @@ import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Writer;
 import java.nio.ByteBuffer;
-import javax.websocket.EncodeException;
 import javax.websocket.RemoteEndpoint;
+import javax.websocket.SendHandler;
 
 /**
  * This is {@link Basic} implementation for WebSocket Connection.
  */
 
-public class WebSocketBasicRemoteEndpoint implements RemoteEndpoint.Basic {
+public class WebSocketAsyncRemoteEndpoint implements RemoteEndpoint.Async {
 
     private final ChannelHandlerContext ctx;
 
-    public WebSocketBasicRemoteEndpoint(ChannelHandlerContext ctx) {
+    public WebSocketAsyncRemoteEndpoint(ChannelHandlerContext ctx) {
         this.ctx = ctx;
     }
 
     @Override
-    public void sendText(String text) throws IOException {
-        ctx.channel().writeAndFlush(new TextWebSocketFrame(text));
+    public long getSendTimeout() {
+        return 0;
     }
 
     @Override
-    public void sendBinary(ByteBuffer data) throws IOException {
+    public void setSendTimeout(long timeoutmillis) {
+
+    }
+
+    @Override
+    public void sendText(String text, SendHandler handler) {
+        throw new UnsupportedOperationException("Method is not supported");
+    }
+
+    @Override
+    public ChannelFuture sendText(String text) {
+        return ctx.channel().writeAndFlush(new TextWebSocketFrame(text));
+    }
+
+    @Override
+    public ChannelFuture sendBinary(ByteBuffer data) {
         ByteBuf byteBuf = Unpooled.wrappedBuffer(data);
-        ctx.channel().writeAndFlush(new BinaryWebSocketFrame(byteBuf));
+        return ctx.channel().writeAndFlush(new BinaryWebSocketFrame(byteBuf));
     }
 
     @Override
-    public void sendText(String partialMessage, boolean isLast) throws IOException {
+    public void sendBinary(ByteBuffer data, SendHandler handler) {
+        throw new UnsupportedOperationException("Method is not supported");
+    }
+
+
+    @Override
+    public ChannelFuture sendObject(Object data) {
         throw new UnsupportedOperationException("Method is not supported");
     }
 
     @Override
-    public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
-        ByteBuf partialByteBuf = Unpooled.wrappedBuffer(partialByte);
-        ctx.channel().writeAndFlush(new BinaryWebSocketFrame(isLast, 0, partialByteBuf));
-    }
-
-    @Override
-    public OutputStream getSendStream() throws IOException {
-        throw new UnsupportedOperationException("Method is not supported");
-    }
-
-    @Override
-    public Writer getSendWriter() throws IOException {
-        throw new UnsupportedOperationException("Method is not supported");
-    }
-
-    @Override
-    public void sendObject(Object data) throws IOException, EncodeException {
+    public void sendObject(Object data, SendHandler handler) {
         throw new UnsupportedOperationException("Method is not supported");
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketSessionImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketSessionImpl.java
@@ -57,9 +57,8 @@ public class WebSocketSessionImpl extends WebSocketSessionAdapter {
     }
 
     @Override
-    public RemoteEndpoint.Basic getBasicRemote() {
-        RemoteEndpoint.Basic basicRemoteEndpoint = new WebSocketBasicRemoteEndpoint(ctx);
-        return basicRemoteEndpoint;
+    public RemoteEndpoint.Async getAsyncRemote() {
+        return new WebSocketAsyncRemoteEndpoint(ctx);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketClientTestCase.java
@@ -75,12 +75,7 @@ public class WebSocketClientTestCase {
         handshakeFuture.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(Session session) {
-                try {
-                    session.getBasicRemote().sendText(textSent);
-                } catch (IOException e) {
-                    log.error(e.getMessage());
-                    Assert.assertTrue(false, e.getMessage());
-                }
+                session.getAsyncRemote().sendText(textSent);
             }
 
             @Override
@@ -105,12 +100,7 @@ public class WebSocketClientTestCase {
         handshakeFuture.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(Session session) {
-                try {
-                    session.getBasicRemote().sendBinary(bufferSent);
-                } catch (IOException e) {
-                    log.error(e.getMessage());
-                    Assert.assertTrue(false, e.getMessage());
-                }
+                session.getAsyncRemote().sendBinary(bufferSent);
             }
 
             @Override
@@ -135,12 +125,7 @@ public class WebSocketClientTestCase {
         pingHandshakeFuture.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(Session session) {
-                try {
-                    session.getBasicRemote().sendText(PING);
-                } catch (IOException e) {
-                    log.error(e.getMessage());
-                    Assert.assertTrue(false, e.getMessage());
-                }
+                session.getAsyncRemote().sendText(PING);
             }
 
             @Override
@@ -163,7 +148,7 @@ public class WebSocketClientTestCase {
                 try {
                     byte[] bytes = {1, 2, 3, 4, 5};
                     ByteBuffer buffer = ByteBuffer.wrap(bytes);
-                    session.getBasicRemote().sendPing(buffer);
+                    session.getAsyncRemote().sendPing(buffer);
                 } catch (IOException e) {
                     log.error(e.getMessage());
                     Assert.assertTrue(false, e.getMessage());
@@ -189,12 +174,7 @@ public class WebSocketClientTestCase {
         handshakeFuture1.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(Session session) {
-                try {
-                    session.getBasicRemote().sendText(textsSent[0]);
-                } catch (IOException e) {
-                    log.error(e.getMessage());
-                    Assert.assertTrue(false, e.getMessage());
-                }
+                session.getAsyncRemote().sendText(textsSent[0]);
             }
 
             @Override
@@ -213,13 +193,8 @@ public class WebSocketClientTestCase {
         handshakeFuture2.setHandshakeListener(new HandshakeListener() {
             @Override
             public void onSuccess(Session session) {
-                try {
-                    for (int i = 0; i < textsSent.length; i++) {
-                        session.getBasicRemote().sendText(textsSent[i]);
-                    }
-                } catch (IOException e) {
-                    log.error(e.getMessage());
-                    Assert.assertTrue(false, e.getMessage());
+                for (int i = 0; i < textsSent.length; i++) {
+                    session.getAsyncRemote().sendText(textsSent[i]);
                 }
             }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughClientConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughClientConnectorListener.java
@@ -28,7 +28,6 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketControlMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketInitMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
 
-import java.io.IOException;
 import javax.websocket.Session;
 
 /**
@@ -45,24 +44,16 @@ public class WebSocketPassthroughClientConnectorListener implements WebSocketCon
 
     @Override
     public void onMessage(WebSocketTextMessage textMessage) {
-        try {
-            Session serverSession = WebSocketPassThroughTestSessionManager.getInstance().
-                    getServerSession(textMessage.getChannelSession());
-            serverSession.getBasicRemote().sendText(textMessage.getText());
-        } catch (IOException e) {
-            logger.error("IO error when sending message: " + e.getMessage());
-        }
+        Session serverSession = WebSocketPassThroughTestSessionManager.getInstance().
+                getServerSession(textMessage.getChannelSession());
+        serverSession.getAsyncRemote().sendText(textMessage.getText());
     }
 
     @Override
     public void onMessage(WebSocketBinaryMessage binaryMessage) {
-        try {
-            Session serverSession = WebSocketPassThroughTestSessionManager.getInstance().
-                    getServerSession(binaryMessage.getChannelSession());
-            serverSession.getBasicRemote().sendBinary(binaryMessage.getByteBuffer());
-        } catch (IOException e) {
-            logger.error("IO error when sending message: " + e.getMessage());
-        }
+        Session serverSession = WebSocketPassThroughTestSessionManager.getInstance().
+                getServerSession(binaryMessage.getChannelSession());
+        serverSession.getAsyncRemote().sendBinary(binaryMessage.getByteBuffer());
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
@@ -88,24 +88,16 @@ public class WebSocketPassthroughServerConnectorListener implements WebSocketCon
 
     @Override
     public void onMessage(WebSocketTextMessage textMessage) {
-        try {
-            Session clientSession = WebSocketPassThroughTestSessionManager.getInstance().
-                    getClientSession(textMessage.getChannelSession());
-            clientSession.getBasicRemote().sendText(textMessage.getText());
-        } catch (IOException e) {
-            logger.error("IO error when sending message: " + e.getMessage());
-        }
+        Session clientSession = WebSocketPassThroughTestSessionManager.getInstance().
+                getClientSession(textMessage.getChannelSession());
+        clientSession.getAsyncRemote().sendText(textMessage.getText());
     }
 
     @Override
     public void onMessage(WebSocketBinaryMessage binaryMessage) {
-        try {
-            Session clientSession = WebSocketPassThroughTestSessionManager.getInstance()
-                    .getClientSession(binaryMessage.getChannelSession());
-            clientSession.getBasicRemote().sendBinary(binaryMessage.getByteBuffer());
-        } catch (IOException e) {
-            logger.error("IO error when sending message: " + e.getMessage());
-        }
+        Session clientSession = WebSocketPassThroughTestSessionManager.getInstance()
+                .getClientSession(binaryMessage.getChannelSession());
+        clientSession.getAsyncRemote().sendBinary(binaryMessage.getByteBuffer());
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestClientConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestClientConnectorListener.java
@@ -64,7 +64,7 @@ public class WebSocketTestClientConnectorListener implements WebSocketConnectorL
     public void onMessage(WebSocketTextMessage textMessage) {
         if (PING.equals(textMessage.getText())) {
             try {
-                textMessage.getChannelSession().getBasicRemote().sendPing(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+                textMessage.getChannelSession().getAsyncRemote().sendPing(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
             } catch (IOException e) {
                 errorsQueue.add(e);
             }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestServerConnectorListener.java
@@ -62,12 +62,8 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
             public void onSuccess(Session session) {
                 sessionList.forEach(
                         currentSession -> {
-                            try {
-                                currentSession.getBasicRemote().
-                                        sendText(WebSocketTestConstants.PAYLOAD_NEW_CLIENT_CONNECTED);
-                            } catch (IOException e) {
-                                log.error("IO exception when sending data : " + e.getMessage(), e);
-                            }
+                            currentSession.getAsyncRemote().
+                                    sendText(WebSocketTestConstants.PAYLOAD_NEW_CLIENT_CONNECTED);
                         }
                 );
                 sessionList.add(session);
@@ -88,10 +84,10 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
         log.debug("text: " + receivedTextToClient);
         try {
             if (PING.equals(receivedTextToClient)) {
-                session.getBasicRemote().sendPing(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
+                session.getAsyncRemote().sendPing(ByteBuffer.wrap(new byte[]{1, 2, 3, 4, 5}));
                 return;
             }
-            session.getBasicRemote().sendText(receivedTextToClient);
+            session.getAsyncRemote().sendText(receivedTextToClient);
         } catch (IOException e) {
             handleError(e);
         }
@@ -102,11 +98,7 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
         Session session = binaryMessage.getChannelSession();
         ByteBuffer receivedByteBufferToClient = binaryMessage.getByteBuffer();
         log.debug("ByteBuffer: " + receivedByteBufferToClient);
-        try {
-            session.getBasicRemote().sendBinary(receivedByteBufferToClient);
-        } catch (IOException e) {
-            handleError(e);
-        }
+        session.getAsyncRemote().sendBinary(receivedByteBufferToClient);
     }
 
     @Override
@@ -119,7 +111,7 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
         if (controlMessage.getControlSignal() == WebSocketControlSignal.PING) {
             Session session = controlMessage.getChannelSession();
             try {
-                session.getBasicRemote().sendPong(controlMessage.getPayload());
+                session.getAsyncRemote().sendPong(controlMessage.getPayload());
             } catch (IOException e) {
                 Assert.assertTrue(false, "Could not send the message.");
             }
@@ -130,12 +122,8 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
     public void onMessage(WebSocketCloseMessage closeMessage) {
         sessionList.forEach(
                 currentSession -> {
-                    try {
-                        currentSession.getBasicRemote().
-                                sendText(WebSocketTestConstants.PAYLOAD_CLIENT_LEFT);
-                    } catch (IOException e) {
-                        log.error("IO exception when sending data : " + e.getMessage(), e);
-                    }
+                    currentSession.getAsyncRemote().
+                            sendText(WebSocketTestConstants.PAYLOAD_CLIENT_LEFT);
                 }
         );
     }


### PR DESCRIPTION
## Purpose
> Use async RemoteEndpoint for WebSocket
Related issue https://github.com/ballerina-lang/ballerina/issues/6069

## Approach
> Make WebSocketEndpoint to implement the RemoteEndpoint.Async interface and hence WebSocketSessionImpl would now implement the method getAsyncRemote().