### PR TITLE
Refactor httpClientChannelInitializer

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLHandlerFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/ssl/SSLHandlerFactory.java
@@ -177,6 +177,7 @@ public class SSLHandlerFactory {
      * This method will provide netty ssl context which supports HTTP2 over TLS using
      * Application Layer Protocol Negotiation (ALPN)
      *
+     * @param enableOcsp whether ocsp is enabled or not (true/false)
      * @return instance of {@link SslContext}
      * @throws SSLException if any error occurred during building SSL context.
      */

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -181,10 +181,11 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
                 socketChannel.pipeline().addLast(new OCSPStaplingHandler(engine));
             }
         } else {
-            clientPipeline.addLast(Constants.SSL_HANDLER, new SslHandler(instantiateAndConfigSSL(sslConfig)));
+            SSLEngine sslEngine = instantiateAndConfigSSL(sslConfig);
+            clientPipeline.addLast(Constants.SSL_HANDLER, new SslHandler(sslEngine));
             if (validateCertEnabled) {
                 clientPipeline.addLast(Constants.HTTP_CERT_VALIDATION_HANDLER,
-                        new CertificateValidationHandler(instantiateAndConfigSSL(sslConfig), this.cacheDelay, this.cacheSize));
+                        new CertificateValidationHandler(sslEngine, this.cacheDelay, this.cacheSize));
             }
         }
         clientPipeline.addLast(Constants.SSL_COMPLETION_HANDLER,
@@ -205,17 +206,15 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
                 ch.pipeline().addLast(new OCSPStaplingHandler(engine));
             }
         } else {
-            SslContext sslCtx = new SSLHandlerFactory(sslConfig)
-                    .createHttp2TLSContextForClient(false);
-            clientPipeline.addLast(sslCtx.newHandler(ch.alloc()));
-            if (validateCertEnabled && sslConfig != null) {
+            SslContext sslCtx = new SSLHandlerFactory(sslConfig).createHttp2TLSContextForClient(false);
+            SslHandler sslHandler = sslCtx.newHandler(ch.alloc());
+            clientPipeline.addLast(sslHandler);
+            if (validateCertEnabled) {
                 clientPipeline.addLast(Constants.HTTP_CERT_VALIDATION_HANDLER,
-                        new CertificateValidationHandler(instantiateAndConfigSSL(sslConfig), this.cacheDelay,
-                                this.cacheSize));
+                        new CertificateValidationHandler(sslHandler.engine(), this.cacheDelay, this.cacheSize));
             }
         }
-        clientPipeline.addLast(new Http2PipelineConfiguratorForClient(targetHandler,
-                connectionAvailabilityFuture));
+        clientPipeline.addLast(new Http2PipelineConfiguratorForClient(targetHandler, connectionAvailabilityFuture));
     }
 
     public TargetHandler getTargetHandler() {
@@ -291,8 +290,8 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     /**
      * Set configurations to create ssl engine.
      *
-     * @param sslConfig
-     * @return
+     * @param sslConfig ssl related configurations
+     * @return ssl engine
      */
     private SSLEngine instantiateAndConfigSSL(SSLConfig sslConfig) {
         // set the pipeline factory, which creates the pipeline for each newly created channels


### PR DESCRIPTION
## Purpose
Earlier we passed sslEngine from the PoolableTargetChannelFactory. Now we will not pass it from there, but create the sslEngine directly inside the httpClientChannelInitializer using sslConfig. 

