### PR TITLE
[HTTP2] Fix request hanging issues found with a load test

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -85,6 +85,7 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
+        ctx.pipeline().remove(Constants.IDLE_STATE_HANDLER); // Remove http idle state handler
         this.ctx = ctx;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.timeout.IdleStateEvent;
@@ -264,8 +265,10 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             handleIdleErrorScenario();
 
             log.warn("Idle timeout has reached hence closing the connection {}", ctx.channel().id().asShortText());
+        } else if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
+            log.debug("Server upgrade event received");
         } else {
-            log.warn("Unexpected user event triggered", evt.toString());
+            log.warn("Unexpected user event {} triggered", evt.toString());
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2ConnectionPrefaceAndSettingsFrameWrittenEvent;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -203,8 +204,10 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                 executePostUpgradeActions(ctx);
             }
             ctx.fireUserEventTriggered(evt);
+        } else if (evt instanceof Http2ConnectionPrefaceAndSettingsFrameWrittenEvent) {
+            log.debug("Connection Preface and Settings frame written");
         } else {
-            log.warn("Unexpected user event triggered", evt.toString());
+            log.warn("Unexpected user event {} triggered", evt.toString());
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -148,6 +148,16 @@ public class ClientInboundHandler extends Http2EventAdapter {
     }
 
     @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
+        log.warn("RST received for streamId: {} errorCode: {}", streamId, errorCode);
+        OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
+        if (outboundMsgHolder != null) {
+            outboundMsgHolder.getResponseFuture().
+                    notifyHttpListener(new Exception("HTTP/2 stream " + streamId + " reset by the remote peer"));
+        }
+    }
+
+    @Override
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
                                   Http2Headers headers, int padding) throws Http2Exception {
         if (log.isDebugEnabled()) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -56,8 +56,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
                           boolean endOfStream) throws Http2Exception {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} Reading data of stream id: {}, isEndOfStream: {}",
-                      Thread.currentThread().getId(), http2ClientChannel.toString(), streamId, endOfStream);
+            log.debug("Reading data on channel: {} with stream id: {}, isEndOfStream: {}",
+                      http2ClientChannel.toString(), streamId, endOfStream);
         }
 
         http2ClientChannel.getDataEventListeners().
@@ -69,8 +69,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
             if (outboundMsgHolder != null) {
                 isServerPush = true;
             } else {
-                log.warn("TID: {} OID: {} Data Frame received over invalid stream id: {}",
-                         Thread.currentThread().getId(), streamId, http2ClientChannel.toString());
+                log.warn("Data Frame received on channel: {} with invalid stream id: {}",
+                         http2ClientChannel.toString(), streamId);
                 return 0;
             }
         }
@@ -105,8 +105,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
                               int padding, boolean endStream) throws Http2Exception {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} Reading Http2 headers of stream id: {}, isEndOfStream: {}",
-                     Thread.currentThread().getId(), http2ClientChannel.toString(), streamId, endStream);
+            log.debug("Reading Http2 headers on channel: {} with stream id: {}, isEndOfStream: {}",
+                      http2ClientChannel.toString(), streamId, endStream);
         }
         http2ClientChannel.getDataEventListeners().
                 forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, endStream));
@@ -117,8 +117,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
             if (outboundMsgHolder != null) {
                 isServerPush = true;
             } else {
-                log.warn("TID: {} OID: {} Header Frame received over invalid stream id: {} ",
-                         Thread.currentThread().getId(), http2ClientChannel.toString(), streamId);
+                log.warn("Header Frame received on channel: {} with invalid stream id: {} ",
+                         http2ClientChannel.toString(), streamId);
                 return;
             }
         }
@@ -149,8 +149,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        log.warn("TID: {} OID: {}  RST received for streamId: {} errorCode: {}",
-                 Thread.currentThread().getId(), http2ClientChannel.toString(), streamId, errorCode);
+        log.warn("RST received on channel: {} for streamId: {} errorCode: {}",
+                 http2ClientChannel.toString(), streamId, errorCode);
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder != null) {
             outboundMsgHolder.getResponseFuture().
@@ -162,16 +162,16 @@ public class ClientInboundHandler extends Http2EventAdapter {
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
                                   Http2Headers headers, int padding) throws Http2Exception {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} Received a push promise over stream id: {}, promisedStreamId: {}",
-                      Thread.currentThread().getId(), http2ClientChannel.toString(), streamId, promisedStreamId);
+            log.debug("Received a push promise on channel: {} over stream id: {}, promisedStreamId: {}",
+                      http2ClientChannel.toString(), streamId, promisedStreamId);
         }
         http2ClientChannel.getDataEventListeners().
                 forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, false));
 
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder == null) {
-            log.warn("TID: {} OID: {} Push promised received over invalid stream id : {}",
-                     Thread.currentThread().getId(), http2ClientChannel.toString(), streamId);
+            log.warn("Push promise received in channel: {} over invalid stream id : {}",
+                     http2ClientChannel.toString(), streamId);
             return;
         }
         http2ClientChannel.putPromisedMessage(promisedStreamId, outboundMsgHolder);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -149,7 +149,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        log.warn("RST received for streamId: {} errorCode: {}", streamId, errorCode);
+        log.warn("TID: {} OID: {}  RST received for streamId: {} errorCode: {}",
+                 Thread.currentThread().getId(), http2ClientChannel.toString(), streamId, errorCode);
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder != null) {
             outboundMsgHolder.getResponseFuture().
@@ -169,7 +170,8 @@ public class ClientInboundHandler extends Http2EventAdapter {
 
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder == null) {
-            log.warn("Push promised received over invalid stream id : {}", streamId);
+            log.warn("TID: {} OID: {} Push promised received over invalid stream id : {}",
+                     Thread.currentThread().getId(), http2ClientChannel.toString(), streamId);
             return;
         }
         http2ClientChannel.putPromisedMessage(promisedStreamId, outboundMsgHolder);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientOutboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientOutboundHandler.java
@@ -107,8 +107,11 @@ public class ClientOutboundHandler extends ChannelOutboundHandlerAdapter {
      *
      * @return next available stream id
      */
-    private synchronized int getNextStreamId() {
-        return connection.local().incrementAndGetNextStreamId();
+    private synchronized int getNextStreamId() throws Http2Exception {
+        int nextStreamId = connection.local().incrementAndGetNextStreamId();
+        connection.local().createStream(nextStreamId, false);
+        log.debug("Stream created streamId: {}", nextStreamId);
+        return nextStreamId;
     }
 
     /**
@@ -126,7 +129,7 @@ public class ClientOutboundHandler extends ChannelOutboundHandlerAdapter {
             httpOutboundRequest = outboundMsgHolder.getRequest();
         }
 
-        void writeContent(ChannelHandlerContext ctx) {
+        void writeContent(ChannelHandlerContext ctx) throws Http2Exception {
             int streamId = getNextStreamId();
             http2ClientChannel.putInFlightMessage(streamId, outboundMsgHolder);
             http2ClientChannel.getDataEventListeners().

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
@@ -120,8 +120,7 @@ public class Http2ClientChannel {
      */
     public void putInFlightMessage(int streamId, OutboundMsgHolder inFlightMessage) {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} In flight message added to stream id: {}",
-                     Thread.currentThread().getId(), this.toString(), streamId);
+            log.debug("In flight message added to channel: {} with stream id: {}  ", this.toString(), streamId);
         }
         inFlightMessages.put(streamId, inFlightMessage);
     }
@@ -134,8 +133,7 @@ public class Http2ClientChannel {
      */
     public OutboundMsgHolder getInFlightMessage(int streamId) {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} Getting in flight message for stream id: {}",
-                      Thread.currentThread().getId(), this.toString(), streamId);
+            log.debug("Getting in flight message for stream id: {} from channel: {}", streamId, this.toString());
         }
         return inFlightMessages.get(streamId);
     }
@@ -147,8 +145,7 @@ public class Http2ClientChannel {
      */
     void removeInFlightMessage(int streamId) {
         if (log.isDebugEnabled()) {
-            log.debug("TID: {} OID: {} In flight message for stream id: {} removed",
-                      Thread.currentThread().getId(), this.toString(), streamId);
+            log.debug("In flight message for stream id: {} removed from channel: {}", streamId, this.toString());
         }
         inFlightMessages.remove(streamId);
     }


### PR DESCRIPTION
## Purpose
Requests get hanged in the middle of a load test due to concurrency issues related to stream creation in HTTP/2. Need to address those issues.

## Goals
Fix request hanging issues found with a load test.

## Approach
- Fix synchronization issues with stream creation.
- Improve debug logs to ease debugging

## User stories

## Release note

## Documentation


## Training


## Certification
N/A

## Marketing
N/A

## Automation tests


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8
 
## Learning
