### PR TITLE
Add a method to count message length

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
@@ -65,6 +65,15 @@ public interface EntityCollector {
     int getFullMessageLength();
 
     /**
+     * Count the message length till the given message length and returns.
+     * If the message length is shorter than the given length it returns with the
+     * available message size. This method is blocking function. Hence, use with care.
+     * @param maxLength is the maximum length to count
+     * @return counted length
+     */
+    int countMessageLengthTill(int maxLength);
+
+    /**
      * Complete the message.
      */
     void completeMessage();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -104,6 +104,17 @@ public class HTTPCarbonMessage {
     }
 
     /**
+     * Count the message length till the given message length and returns.
+     * If the message length is shorter than the given length it returns with the
+     * available message size. This method is blocking function. Hence, use with care.
+     * @param maxLength is the maximum length to count
+     * @return counted length
+     */
+    int countMessageLengthTill(int maxLength) {
+        return this.blockingEntityCollector.countMessageLengthTill(maxLength);
+    }
+
+    /**
      * Return the length of entire payload. This is a blocking method.
      * @return the length.
      */


### PR DESCRIPTION
## Purpose
> At the moment we only have a method get the complete message length. But we do so it required to keep the entire payload in memory till we complete the count. 

But with this method we only count till the maximum message length. As soon as it is reached, this method returns with the counted value.

I have created two new issues as improvements. 

[1] https://github.com/ballerina-platform/ballerina-lang/issues/6933
[2] https://github.com/ballerina-platform/ballerina-lang/issues/6930