### PR TITLE
Move Http2MaxActiveStreams parameter to PoolConfig

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
@@ -94,9 +94,6 @@ public class SenderConfiguration {
     private boolean isKeepAlive = true;
 
     @XmlAttribute
-    private int http2MaxActiveStreams = Integer.MAX_VALUE;
-
-    @XmlAttribute
     private boolean forceHttp2 = false;
 
     private String tlsStoreType;
@@ -277,14 +274,6 @@ public class SenderConfiguration {
         if (!httpVersion.isEmpty()) {
             this.httpVersion = httpVersion;
         }
-    }
-
-    public int getHttp2MaxActiveStreams() {
-        return http2MaxActiveStreams;
-    }
-
-    public void setHttp2MaxActiveStreams(int http2MaxActiveStreams) {
-        this.http2MaxActiveStreams = http2MaxActiveStreams;
     }
 
     public boolean isForceHttp2() {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/PoolConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/pool/PoolConfiguration.java
@@ -34,6 +34,7 @@ public class PoolConfiguration {
     private int executorServiceThreads = 20;
     private int eventGroupExecutorThreads = 15;
     private long maxWaitTime = 60000L;
+    private int http2MaxActiveStreamsPerConnection = Integer.MAX_VALUE;
 
     public PoolConfiguration() {
     }
@@ -132,5 +133,13 @@ public class PoolConfiguration {
 
     public void setMaxWaitTime(long maxWaitTime) {
         this.maxWaitTime = maxWaitTime;
+    }
+
+    public int getHttp2MaxActiveStreamsPerConnection() {
+        return http2MaxActiveStreamsPerConnection;
+    }
+
+    public void setHttp2MaxActiveStreamsPerConnection(int http2MaxActiveStreamsPerConnection) {
+        this.http2MaxActiveStreamsPerConnection = http2MaxActiveStreamsPerConnection;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ConnectionManager.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ConnectionManager.java
@@ -90,8 +90,8 @@ public class Http2ConnectionManager {
                 perRouteConnectionPool = fetchConnectionPool(key);
 
                 if (perRouteConnectionPool == null) {
-                    perRouteConnectionPool =
-                            new PerRouteConnectionPool(senderConfig.getHttp2MaxActiveStreams());
+                    perRouteConnectionPool = new PerRouteConnectionPool(
+                            senderConfig.getPoolConfiguration().getHttp2MaxActiveStreamsPerConnection());
                     registerConnectionPool(key, perRouteConnectionPool);
                 }
                 perRouteConnectionPool.addChannel(http2ClientChannel);


### PR DESCRIPTION
## Purpose
Http2MaxActiveStreams parameter currently defined in the SenderConfiguration.But it is a parameter belongs to http2 connection pool, so it need to be placed on the PoolConfig.

## Goals
Move Http2MaxActiveStreams parameter to PoolConfig.

## Approach

## User stories

## Release note

## Documentation

## Training

## Certification

## Marketing

## Automation tests

## Security checks

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
 
## Learning
