### PR TITLE
Use Enum for Keep-Alive Config in Sender

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/config/SenderConfiguration.java
@@ -90,8 +90,7 @@ public class SenderConfiguration {
     @XmlAttribute
     private int maxRedirectCount;
 
-    @XmlAttribute
-    private boolean isKeepAlive = true;
+    private KeepAliveConfig keepAliveConfig = KeepAliveConfig.AUTO;
 
     @XmlAttribute
     private boolean forceHttp2 = false;
@@ -250,12 +249,12 @@ public class SenderConfiguration {
         this.maxRedirectCount = maxRedirectCount;
     }
 
-    public boolean isKeepAlive() {
-        return isKeepAlive;
+    public KeepAliveConfig getKeepAliveConfig() {
+        return keepAliveConfig;
     }
 
-    public void setKeepAlive(boolean keepAlive) {
-        isKeepAlive = keepAlive;
+    public void setKeepAliveConfig(KeepAliveConfig keepAliveConfig) {
+        this.keepAliveConfig = keepAliveConfig;
     }
 
     public void setProxyServerConfiguration(ProxyServerConfiguration proxyServerConfiguration) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -31,6 +31,7 @@ import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.config.ForwardedExtensionConfig;
+import org.wso2.transport.http.netty.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
@@ -65,7 +66,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
     private boolean followRedirect;
     private String httpVersion;
     private ChunkConfig chunkConfig;
-    private boolean keepAlive;
+    private KeepAliveConfig keepAliveConfig;
     private boolean isHttp2;
     private ForwardedExtensionConfig forwardedExtensionConfig;
 
@@ -204,13 +205,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                             setChannelAttributes(channelFuture.channel(), httpOutboundRequest, httpResponseFuture,
                                                  targetChannel);
                         }
-                        if (!keepAlive && Float.valueOf(httpVersion) >= Constants.HTTP_1_1) {
-                            httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(),
-                                                          Constants.CONNECTION_CLOSE);
-                        } else if (keepAlive && Float.valueOf(httpVersion) < Constants.HTTP_1_1) {
-                            httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(),
-                                                          Constants.CONNECTION_KEEP_ALIVE);
-                        }
+                        handleOutboundConnectionHeader(keepAliveConfig, httpOutboundRequest);
                         targetChannel.setForwardedExtension(forwardedExtensionConfig, httpOutboundRequest);
                         targetChannel.writeContent(httpOutboundRequest);
                     }
@@ -289,7 +284,27 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
         this.followRedirect = senderConfiguration.isFollowRedirect();
         this.socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(Constants.ENDPOINT_TIMEOUT);
         this.sslConfig = senderConfiguration.getSSLConfig();
-        this.keepAlive = senderConfiguration.isKeepAlive();
+        this.keepAliveConfig = senderConfiguration.getKeepAliveConfig();
         this.forwardedExtensionConfig = senderConfiguration.getForwardedExtensionConfig();
+    }
+
+    private void handleOutboundConnectionHeader(KeepAliveConfig keepAliveConfig,
+                                                        HTTPCarbonMessage httpOutboundRequest) {
+        switch (keepAliveConfig) {
+            case AUTO:
+                if (Float.valueOf(httpVersion) >= Constants.HTTP_1_1) {
+                    httpOutboundRequest
+                            .setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_KEEP_ALIVE);
+                } else {
+                    httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_CLOSE);
+                }
+                break;
+            case ALWAYS:
+                httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_KEEP_ALIVE);
+                break;
+            case NEVER:
+                httpOutboundRequest.setHeader(HttpHeaderNames.CONNECTION.toString(), Constants.CONNECTION_CLOSE);
+                break;
+        }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -46,6 +46,7 @@ import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.common.ssl.SSLHandlerFactory;
+import org.wso2.transport.http.netty.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.listener.HTTPTraceLoggingHandler;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
@@ -73,7 +74,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     private int maxRedirectCount;
     private int cacheSize;
     private int cacheDelay;
-    private boolean isKeepAlive;
+    private KeepAliveConfig keepAliveConfig;
     private ProxyServerConfiguration proxyServerConfiguration;
     private ConnectionManager connectionManager;
     private Http2ConnectionManager http2ConnectionManager;
@@ -96,7 +97,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         this.httpTraceLogEnabled = senderConfiguration.isHttpTraceLogEnabled();
         this.followRedirect = senderConfiguration.isFollowRedirect();
         this.maxRedirectCount = senderConfiguration.getMaxRedirectCount(Constants.MAX_REDIRECT_COUNT);
-        this.isKeepAlive = senderConfiguration.isKeepAlive();
+        this.keepAliveConfig = senderConfiguration.getKeepAliveConfig();
         this.proxyServerConfiguration = senderConfiguration.getProxyServerConfiguration();
         this.connectionManager = connectionManager;
         this.http2ConnectionManager = connectionManager.getHttp2ConnectionManager();
@@ -130,7 +131,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         HttpClientCodec sourceCodec = new HttpClientCodec();
         targetHandler = new TargetHandler();
         targetHandler.setHttp2ClientOutboundHandler(clientOutboundHandler);
-        targetHandler.setKeepAlive(isKeepAlive);
+        targetHandler.setKeepAliveConfig(getKeepAliveConfig());
         if (http2) {
             SSLConfig sslConfig = senderConfiguration.getSSLConfig();
             if (sslConfig != null) {
@@ -317,8 +318,8 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         return connection;
     }
 
-    public boolean isKeepAlive() {
-        return isKeepAlive;
+    public KeepAliveConfig getKeepAliveConfig() {
+        return keepAliveConfig;
     }
 
     public void setHttp2ClientChannel(Http2ClientChannel http2ClientChannel) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
+import org.wso2.transport.http.netty.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.ClientConnectorException;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
@@ -60,7 +61,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     private ClientOutboundHandler http2ClientOutboundHandler;
     private HTTPCarbonMessage incomingMsg;
     private HandlerExecutor handlerExecutor;
-    private boolean keepAlive;
+    private KeepAliveConfig keepAliveConfig;
     private boolean idleTimeoutTriggered;
 
     @Override
@@ -111,7 +112,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                         this.targetRespMsg = null;
                         targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
 
-                        if (!keepAlive) {
+                        if (!isKeepAlive(keepAliveConfig)) {
                             closeChannel(ctx);
                         }
 
@@ -264,6 +265,10 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         this.connectionManager = connectionManager;
     }
 
+    public HTTPCarbonMessage getIncomingMsg() {
+        return incomingMsg;
+    }
+
     public void setIncomingMsg(HTTPCarbonMessage incomingMsg) {
         this.incomingMsg = incomingMsg;
     }
@@ -272,8 +277,12 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         this.targetChannel = targetChannel;
     }
 
-    public void setKeepAlive(boolean keepAlive) {
-        this.keepAlive = keepAlive;
+    public KeepAliveConfig getKeepAliveConfig() {
+        return keepAliveConfig;
+    }
+
+    public void setKeepAliveConfig(KeepAliveConfig keepAliveConfig) {
+        this.keepAliveConfig = keepAliveConfig;
     }
 
     public HttpResponseFuture getHttpResponseFuture() {
@@ -282,5 +291,23 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     public void setHttp2ClientOutboundHandler(ClientOutboundHandler http2ClientOutboundHandler) {
         this.http2ClientOutboundHandler = http2ClientOutboundHandler;
+    }
+
+    private boolean isKeepAlive(KeepAliveConfig keepAliveConfig) {
+        switch (keepAliveConfig) {
+            case AUTO:
+                if (Float.valueOf((String) getIncomingMsg().getProperty(Constants.HTTP_VERSION)) > Constants.HTTP_1_0) {
+                    return true;
+                } else {
+                    return false;
+                }
+            case ALWAYS:
+                return true;
+            case NEVER:
+                return false;
+            default:
+               // The execution will never reach here. To make the code compilable, default case has to be placed here.
+               return true;
+        }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/KeepAliveHttpOnePointZeroClientTestCase.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.config.ChunkConfig;
+import org.wso2.transport.http.netty.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
 
@@ -38,7 +39,7 @@ public class KeepAliveHttpOnePointZeroClientTestCase extends ChunkClientTemplate
     public void setUp() {
         senderConfiguration.setChunkingConfig(ChunkConfig.AUTO);
         senderConfiguration.setHttpVersion("1.0");
-        senderConfiguration.setKeepAlive(true);
+        senderConfiguration.setKeepAliveConfig(KeepAliveConfig.ALWAYS);
         super.setUp();
     }
 


### PR DESCRIPTION
## Purpose
This will introduce enum for keep-alive configuration in sender configuration.