### PR TITLE
Add tracelogs for HTTP/2

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -259,6 +259,10 @@ public final class Constants {
     public static final String CHUNKED = "chunked";
     public static final String CHUNKING_CONFIG = "chunking_config";
 
+    // Trace Logger related parameters
+    public static final String TRACE_LOG_UPSTREAM = "tracelog.http.upstream";
+    public static final String TRACE_LOG_DOWNSTREAM = "tracelog.http.downstream";
+
     public static final String LISTENER_PORT = "LISTENER_PORT";
 
     public static final String REQUEST_LINE_TOO_LONG = "An HTTP line is larger than";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -207,6 +207,7 @@ public final class Constants {
 
     public static final String HTTP_SOURCE_HANDLER = "SourceHandler";
     public static final String HTTP_ENCODER = "encoder";
+    public static final String HTTP_DECODER = "decoder";
     public static final String HTTP_CLIENT_CODEC = "codec";
     public static final String HTTP_SERVER_CODEC = "ServerCodec";
     public static final String WEBSOCKET_SOURCE_HANDLER = "ws_handler";
@@ -220,6 +221,7 @@ public final class Constants {
     public static final String TARGET_HANDLER = "targetHandler";
     public static final String HTTP2_TIMEOUT_HANDLER = "Http2TimeoutHandler";
     public static final String HTTP2_UPGRADE_HANDLER = "Http2UpgradeHandler";
+    public static final String HTTP2_TO_HTTP_FALLBACK_HANDLER = "Http2ToHttpFallbackHandler";
     public static final String REDIRECT_HANDLER = "redirectHandler";
     public static final String DECOMPRESSOR_HANDLER = "deCompressor";
     public static final String IDLE_STATE_HANDLER = "idleStateHandler";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -207,6 +207,8 @@ public final class Constants {
 
     public static final String HTTP_SOURCE_HANDLER = "SourceHandler";
     public static final String HTTP_ENCODER = "encoder";
+    public static final String HTTP_COMPRESSOR = "compressor";
+    public static final String HTTP_CHUNK_WRITER = "chunkWriter";
     public static final String HTTP_DECODER = "decoder";
     public static final String HTTP_CLIENT_CODEC = "codec";
     public static final String HTTP_SERVER_CODEC = "ServerCodec";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/FrameLogger.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/FrameLogger.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.common;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.logging.LogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+
+import static io.netty.util.internal.StringUtil.NEWLINE;
+
+/**
+ * {@code FrameLogger} logs the HTTP/2 frames.
+ */
+public class FrameLogger extends Http2FrameLogger {
+
+    private final InternalLogger logger;
+    private LogLevel level;
+
+    public FrameLogger(LogLevel level, String name) {
+        super(level, name);
+        logger = InternalLoggerFactory.getInstance(name);
+        this.level = level;
+    }
+
+    public void logData(Http2FrameLogger.Direction direction, ChannelHandlerContext ctx, int streamId,
+                        ByteBuf data, int padding, boolean endStream) {
+        logger.log(level.toInternalLevel(), "{} {} DATA: streamId={} padding={} endStream={} length={} data={}",
+                   ctx.channel(), direction.name(), streamId, padding, endStream, data.readableBytes(),
+                   formatPayload(data));
+    }
+
+    private String formatPayload(ByteBuf msg) {
+        int length = msg.readableBytes();
+        if (length == 0) {
+            return " 0B";
+        } else {
+            int rows = length / 16 + (length % 16 == 0 ? 0 : 1) + 4;
+            StringBuilder stringBuilder = new StringBuilder(10 + 1 + 2 + rows * 80);
+            stringBuilder.append(length).append('B').append(NEWLINE);
+            try {
+                appendPayload(stringBuilder, msg);
+            } catch (CharacterCodingException e) {
+                return "<< Payload could not be decoded >>";
+            }
+            return stringBuilder.toString();
+        }
+    }
+
+    private void appendPayload(StringBuilder stringBuilder, ByteBuf content) throws CharacterCodingException {
+        CharsetDecoder decoder = Charset.forName("UTF8").newDecoder();
+        CharBuffer buffer = decoder.decode(content.nioBuffer());
+        stringBuilder.append(buffer);
+    }
+
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/FrameLogger.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/FrameLogger.java
@@ -62,18 +62,13 @@ public class FrameLogger extends Http2FrameLogger {
             StringBuilder stringBuilder = new StringBuilder(10 + 1 + 2 + rows * 80);
             stringBuilder.append(length).append('B').append(NEWLINE);
             try {
-                appendPayload(stringBuilder, msg);
+                CharsetDecoder decoder = Charset.forName("UTF8").newDecoder();
+                CharBuffer buffer = decoder.decode(msg.nioBuffer());
+                stringBuilder.append(buffer);
             } catch (CharacterCodingException e) {
                 return "<< Payload could not be decoded >>";
             }
             return stringBuilder.toString();
         }
     }
-
-    private void appendPayload(StringBuilder stringBuilder, ByteBuf content) throws CharacterCodingException {
-        CharsetDecoder decoder = Charset.forName("UTF8").newDecoder();
-        CharBuffer buffer = decoder.decode(content.nioBuffer());
-        stringBuilder.append(buffer);
-    }
-
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
@@ -619,5 +620,21 @@ public class Util {
                 outboundRespStatusFuture.notifyHttpListener(throwable);
             }
         });
+    }
+
+    /**
+     * Removes a handler from the pipeline if it is present.
+     *
+     * @param pipeline     the channel pipeline
+     * @param handlerNames handler names
+     */
+    public static void safelyRemoveHandlers(ChannelPipeline pipeline, String... handlerNames) {
+        for (String name : handlerNames) {
+            if (pipeline.get(name) != null) {
+                pipeline.remove(name);
+            } else {
+                log.debug("Trying to remove not engaged {} handler from the pipeline", name);
+            }
+        }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -86,8 +86,8 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
         // Remove unwanted handlers after upgrade
-        ctx.pipeline().remove(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER);
-        ctx.pipeline().remove(Constants.HTTP_COMPRESSOR);
+        Util.safelyRemoveHandlers(ctx.pipeline(), Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER, Constants.HTTP_COMPRESSOR,
+                                  Constants.HTTP_TRACE_LOG_HANDLER);
         this.ctx = ctx;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -85,7 +85,9 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
-        //ctx.pipeline().remove(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER);
+        // Remove unwanted handlers after upgrade
+        ctx.pipeline().remove(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER);
+        ctx.pipeline().remove(Constants.HTTP_COMPRESSOR);
         this.ctx = ctx;
     }
 
@@ -126,7 +128,6 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
             requestCarbonMessage.addHttpContent(new DefaultLastHttpContent(upgradedRequest.content()));
             notifyRequestListener(requestCarbonMessage, 1);
         }
-        //super.userEventTriggered(ctx, evt);
     }
 
     /**
@@ -240,7 +241,6 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
         String uri = httpRequest.uri();
         sourceReqCMsg.setProperty(Constants.REQUEST_URL, uri);
         sourceReqCMsg.setProperty(Constants.TO, uri);
-
         return sourceReqCMsg;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -85,7 +85,7 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
-        ctx.pipeline().remove(Constants.IDLE_STATE_HANDLER); // Remove http idle state handler
+        //ctx.pipeline().remove(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER);
         this.ctx = ctx;
     }
 
@@ -126,7 +126,7 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
             requestCarbonMessage.addHttpContent(new DefaultLastHttpContent(upgradedRequest.content()));
             notifyRequestListener(requestCarbonMessage, 1);
         }
-        super.userEventTriggered(ctx, evt);
+        //super.userEventTriggered(ctx, evt);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
@@ -23,8 +23,8 @@ import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
-import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
+import org.wso2.transport.http.netty.common.FrameLogger;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 
 import static io.netty.handler.logging.LogLevel.TRACE;
@@ -52,7 +52,7 @@ public final class Http2SourceHandlerBuilder
     public Http2SourceHandler build() {
         Http2Connection conn = new DefaultHttp2Connection(true);
         if (serverChannelInitializer.isHttpTraceLogEnabled()) {
-            frameLogger(new Http2FrameLogger(TRACE, "tracelog.http.downstream"));
+            frameLogger(new FrameLogger(TRACE, "tracelog.http.downstream"));
         }
         connection(conn);
         return super.build();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
@@ -23,8 +23,11 @@ import io.netty.handler.codec.http2.DefaultHttp2Connection;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+
+import static io.netty.handler.logging.LogLevel.TRACE;
 
 /**
  * {@code HTTP2SourceHandlerBuilder} is used to build the HTTP2SourceHandler.
@@ -35,17 +38,22 @@ public final class Http2SourceHandlerBuilder
     private String interfaceId;
     private ServerConnectorFuture serverConnectorFuture;
     private String serverName;
+    private HttpServerChannelInitializer serverChannelInitializer;
 
     public Http2SourceHandlerBuilder(String interfaceId, ServerConnectorFuture serverConnectorFuture,
-                                     String serverName) {
+                                     String serverName, HttpServerChannelInitializer serverChannelInitializer) {
         this.interfaceId = interfaceId;
         this.serverConnectorFuture = serverConnectorFuture;
         this.serverName = serverName;
+        this.serverChannelInitializer = serverChannelInitializer;
     }
 
     @Override
     public Http2SourceHandler build() {
         Http2Connection conn = new DefaultHttp2Connection(true);
+        if (serverChannelInitializer.isHttpTraceLogEnabled()) {
+            frameLogger(new Http2FrameLogger(TRACE, "tracelog.http.downstream"));
+        }
         connection(conn);
         return super.build();
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandlerBuilder.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
+import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.FrameLogger;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 
@@ -52,7 +53,7 @@ public final class Http2SourceHandlerBuilder
     public Http2SourceHandler build() {
         Http2Connection conn = new DefaultHttp2Connection(true);
         if (serverChannelInitializer.isHttpTraceLogEnabled()) {
-            frameLogger(new FrameLogger(TRACE, "tracelog.http.downstream"));
+            frameLogger(new FrameLogger(TRACE, Constants.TRACE_LOG_DOWNSTREAM));
         }
         connection(conn);
         return super.build();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
@@ -30,7 +30,7 @@ import org.wso2.transport.http.netty.common.Util;
  */
 public class Http2ToHttpFallbackHandler extends ChannelInboundHandlerAdapter {
 
-    HttpServerChannelInitializer serverChannelInitializer;
+    private HttpServerChannelInitializer serverChannelInitializer;
 
     public Http2ToHttpFallbackHandler(
             HttpServerChannelInitializer serverChannelInitializer) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.common.Util;
 
 /**
  * {@code Http2ToHttpFallbackHandler} is responsible for fallback from http2 to http when http2 upgrade fails.
@@ -38,7 +39,7 @@ public class Http2ToHttpFallbackHandler extends ChannelInboundHandlerAdapter {
 
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ChannelPipeline pipeline = ctx.pipeline();
-        pipeline.remove(Constants.HTTP2_UPGRADE_HANDLER);
+        Util.safelyRemoveHandlers(pipeline, Constants.HTTP2_UPGRADE_HANDLER);
         serverChannelInitializer.configureHttpPipeline(pipeline, Constants.HTTP2_CLEARTEXT_PROTOCOL);
         pipeline.remove(this);
         ctx.fireChannelRead(msg);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.listener;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import org.wso2.transport.http.netty.common.Constants;
+
+/**
+ * {@code Http2ToHttpFallbackHandler} is responsible for fallback from http2 to http when http2 upgrade fails.
+ *
+ */
+public class Http2ToHttpFallbackHandler extends ChannelInboundHandlerAdapter {
+
+    HttpServerChannelInitializer serverChannelInitializer;
+
+    public Http2ToHttpFallbackHandler(
+            HttpServerChannelInitializer serverChannelInitializer) {
+        this.serverChannelInitializer = serverChannelInitializer;
+    }
+
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ChannelPipeline pipeline = ctx.pipeline();
+        pipeline.remove(Constants.HTTP2_UPGRADE_HANDLER);
+        if (serverChannelInitializer.isHttpAccessLogEnabled()) {
+            pipeline.remove(Constants.HTTP_ACCESS_LOG_HANDLER);
+        }
+        if (serverChannelInitializer.isHttpTraceLogEnabled()) {
+            pipeline.remove(Constants.HTTP_TRACE_LOG_HANDLER);
+        }
+        serverChannelInitializer.configureHttpPipeline(pipeline, Constants.HTTP2_CLEARTEXT_PROTOCOL);
+        pipeline.remove(this);
+        ctx.fireChannelRead(msg);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2ToHttpFallbackHandler.java
@@ -39,12 +39,6 @@ public class Http2ToHttpFallbackHandler extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ChannelPipeline pipeline = ctx.pipeline();
         pipeline.remove(Constants.HTTP2_UPGRADE_HANDLER);
-        if (serverChannelInitializer.isHttpAccessLogEnabled()) {
-            pipeline.remove(Constants.HTTP_ACCESS_LOG_HANDLER);
-        }
-        if (serverChannelInitializer.isHttpTraceLogEnabled()) {
-            pipeline.remove(Constants.HTTP_TRACE_LOG_HANDLER);
-        }
         serverChannelInitializer.configureHttpPipeline(pipeline, Constants.HTTP2_CLEARTEXT_PROTOCOL);
         pipeline.remove(this);
         ctx.fireChannelRead(msg);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
@@ -62,13 +62,14 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
             if (ByteBufUtil.equals(inputData, inputData.readerIndex(), clientPrefaceString,
                                    clientPrefaceString.readerIndex(), bytesRead)) {
                 // HTTP/2 request received without an upgrade
+                Util.safelyRemoveHandlers(pipeline, Constants.HTTP_SERVER_CODEC);
                 pipeline.addBefore(
                         Constants.HTTP2_UPGRADE_HANDLER,
                         Constants.HTTP2_SOURCE_HANDLER,
                         new Http2SourceHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, serverChannelInitializer).build());
 
-                Util.safelyRemoveHandlers(pipeline, Constants.HTTP_SERVER_CODEC, Constants.HTTP2_UPGRADE_HANDLER,
+                Util.safelyRemoveHandlers(pipeline, Constants.HTTP2_UPGRADE_HANDLER,
                                           Constants.HTTP_COMPRESSOR, Constants.HTTP_TRACE_LOG_HANDLER);
             }
             pipeline.remove(this);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
@@ -63,6 +63,7 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
                         Constants.HTTP2_UPGRADE_HANDLER, Constants.HTTP2_SOURCE_HANDLER,
                         new Http2SourceHandlerBuilder(interfaceId, serverConnectorFuture, serverName).build());
                 pipeline.remove(Constants.HTTP2_UPGRADE_HANDLER);
+                pipeline.remove(Constants.HTTP_COMPRESSOR);
             }
             pipeline.remove(this);
             ctx.fireChannelRead(msg);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2WithPriorKnowledgeHandler.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 
 import static java.lang.Math.min;
@@ -41,12 +42,15 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
     private String interfaceId;
     private String serverName;
     private ServerConnectorFuture serverConnectorFuture;
+    private HttpServerChannelInitializer serverChannelInitializer;
 
     public Http2WithPriorKnowledgeHandler(String interfaceId, String serverName,
-                                          ServerConnectorFuture serverConnectorFuture) {
+                                          ServerConnectorFuture serverConnectorFuture,
+                                          HttpServerChannelInitializer serverChannelInitializer) {
         this.interfaceId = interfaceId;
         this.serverName = serverName;
         this.serverConnectorFuture = serverConnectorFuture;
+        this.serverChannelInitializer = serverChannelInitializer;
     }
 
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
@@ -55,15 +59,17 @@ public class Http2WithPriorKnowledgeHandler extends ChannelInboundHandlerAdapter
             ByteBuf clientPrefaceString = Http2CodecUtil.connectionPrefaceBuf();
             int bytesRead = min(inputData.readableBytes(), clientPrefaceString.readableBytes());
             ChannelPipeline pipeline = ctx.pipeline();
-            if (ByteBufUtil.equals(inputData, inputData.readerIndex(),
-                                   clientPrefaceString, clientPrefaceString.readerIndex(), bytesRead)) {
+            if (ByteBufUtil.equals(inputData, inputData.readerIndex(), clientPrefaceString,
+                                   clientPrefaceString.readerIndex(), bytesRead)) {
                 // HTTP/2 request received without an upgrade
-                pipeline.remove(Constants.HTTP_SERVER_CODEC);
                 pipeline.addBefore(
-                        Constants.HTTP2_UPGRADE_HANDLER, Constants.HTTP2_SOURCE_HANDLER,
-                        new Http2SourceHandlerBuilder(interfaceId, serverConnectorFuture, serverName).build());
-                pipeline.remove(Constants.HTTP2_UPGRADE_HANDLER);
-                pipeline.remove(Constants.HTTP_COMPRESSOR);
+                        Constants.HTTP2_UPGRADE_HANDLER,
+                        Constants.HTTP2_SOURCE_HANDLER,
+                        new Http2SourceHandlerBuilder(
+                                interfaceId, serverConnectorFuture, serverName, serverChannelInitializer).build());
+
+                Util.safelyRemoveHandlers(pipeline, Constants.HTTP_SERVER_CODEC, Constants.HTTP2_UPGRADE_HANDLER,
+                                          Constants.HTTP_COMPRESSOR, Constants.HTTP_TRACE_LOG_HANDLER);
             }
             pipeline.remove(this);
             ctx.fireChannelRead(msg);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
@@ -179,7 +179,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
             if (httpTraceLogEnabled) {
                 serverPipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
-                                       new HTTPTraceLoggingHandler("tracelog.http.downstream"));
+                                       new HTTPTraceLoggingHandler(Constants.TRACE_LOG_DOWNSTREAM));
             }
             if (httpAccessLogEnabled) {
                 serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER,
@@ -232,7 +232,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         pipeline.addLast(Constants.HTTP_COMPRESSOR, new CustomHttpContentCompressor());
         if (httpTraceLogEnabled) {
             pipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
-                                   new HTTPTraceLoggingHandler("tracelog.http.downstream"));
+                                   new HTTPTraceLoggingHandler(Constants.TRACE_LOG_DOWNSTREAM));
         }
         if (httpAccessLogEnabled) {
             pipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler("accesslog.http"));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/HttpServerChannelInitializer.java
@@ -172,16 +172,18 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                                    new HttpRequestDecoder(reqSizeValidationConfig.getMaxUriLength(),
                                                           reqSizeValidationConfig.getMaxHeaderSize(),
                                                           reqSizeValidationConfig.getMaxChunkSize()));
-        }
-        serverPipeline.addLast("compressor", new CustomHttpContentCompressor());
-        serverPipeline.addLast("chunkWriter", new ChunkedWriteHandler());
 
-        if (httpTraceLogEnabled) {
-            serverPipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
-                             new HTTPTraceLoggingHandler("tracelog.http.downstream"));
-        }
-        if (httpAccessLogEnabled) {
-            serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler("accesslog.http"));
+            serverPipeline.addLast(Constants.HTTP_COMPRESSOR, new CustomHttpContentCompressor());
+            serverPipeline.addLast(Constants.HTTP_CHUNK_WRITER, new ChunkedWriteHandler());
+
+            if (httpTraceLogEnabled) {
+                serverPipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
+                                       new HTTPTraceLoggingHandler("tracelog.http.downstream"));
+            }
+            if (httpAccessLogEnabled) {
+                serverPipeline.addLast(Constants.HTTP_ACCESS_LOG_HANDLER,
+                                       new HttpAccessLoggingHandler("accesslog.http"));
+            }
         }
         serverPipeline.addLast("uriLengthValidator", new UriAndHeaderLengthValidator(this.serverName));
         if (reqSizeValidationConfig.getMaxEntityBodySize() > -1) {
@@ -223,6 +225,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             }
         };
         pipeline.addLast(Constants.HTTP_SERVER_CODEC, sourceCodec);
+        pipeline.addLast(Constants.HTTP_COMPRESSOR, new CustomHttpContentCompressor());
         if (httpTraceLogEnabled) {
             pipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
                                    new HTTPTraceLoggingHandler("tracelog.http.downstream"));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SslHandshakeCompletionHandlerForServer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SslHandshakeCompletionHandlerForServer.java
@@ -48,7 +48,7 @@ public class SslHandshakeCompletionHandlerForServer extends ChannelInboundHandle
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
 
             if (event.isSuccess()) {
-                this.httpServerChannelInitializer.configureHTTPPipeline(serverPipeline, Constants.HTTP_SCHEME);
+                this.httpServerChannelInitializer.configureHttpPipeline(serverPipeline, Constants.HTTP_SCHEME);
                 serverPipeline.fireChannelActive();
             } else {
                 ctx.close();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -31,7 +31,6 @@ import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.Http2FrameListener;
-import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
@@ -42,6 +41,7 @@ import io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.common.FrameLogger;
 import org.wso2.transport.http.netty.common.HttpRoute;
 import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.common.ssl.SSLConfig;
@@ -114,7 +114,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
 
         Http2ConnectionHandlerBuilder connectionHandlerBuilder = new Http2ConnectionHandlerBuilder();
         if (httpTraceLogEnabled) {
-            connectionHandlerBuilder.frameLogger(new Http2FrameLogger(TRACE, "tracelog.http.upstream"));
+            connectionHandlerBuilder.frameLogger(new FrameLogger(TRACE, "tracelog.http.upstream"));
         }
         http2ConnectionHandler = connectionHandlerBuilder.connection(connection).frameListener(frameListener).build();
         clientOutboundHandler = new ClientOutboundHandler(connection, http2ConnectionHandler.encoder());

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -114,7 +114,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
 
         Http2ConnectionHandlerBuilder connectionHandlerBuilder = new Http2ConnectionHandlerBuilder();
         if (httpTraceLogEnabled) {
-            connectionHandlerBuilder.frameLogger(new FrameLogger(TRACE, "tracelog.http.upstream"));
+            connectionHandlerBuilder.frameLogger(new FrameLogger(TRACE, Constants.TRACE_LOG_UPSTREAM));
         }
         http2ConnectionHandler = connectionHandlerBuilder.connection(connection).frameListener(frameListener).build();
         clientOutboundHandler = new ClientOutboundHandler(connection, http2ConnectionHandler.encoder());
@@ -274,7 +274,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         pipeline.addLast(Constants.DECOMPRESSOR_HANDLER, new HttpContentDecompressor());
         if (httpTraceLogEnabled) {
             pipeline.addLast(Constants.HTTP_TRACE_LOG_HANDLER,
-                    new HTTPTraceLoggingHandler("tracelog.http.upstream"));
+                    new HTTPTraceLoggingHandler(Constants.TRACE_LOG_UPSTREAM));
         }
         if (followRedirect) {
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectChannelInitializer.java
@@ -70,7 +70,7 @@ public class RedirectChannelInitializer extends ChannelInitializer<SocketChannel
         ch.pipeline().addLast("encoder", new HttpRequestEncoder());
         if (httpTraceLogEnabled) {
             ch.pipeline().addLast(Constants.HTTP_TRACE_LOG_HANDLER,
-                                  new HTTPTraceLoggingHandler("tracelog.http.upstream"));
+                                  new HTTPTraceLoggingHandler(Constants.TRACE_LOG_UPSTREAM));
         }
         RedirectHandler redirectHandler = new RedirectHandler(sslEngine, httpTraceLogEnabled, maxRedirectCount
                 , originalChannelContext, isIdleHandlerOfTargetChannelRemoved, connectionManager);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -217,7 +217,11 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
         Http2ClientChannel http2ClientChannel = http2ClientOutboundHandler.getHttp2ClientChannel();
         http2ClientChannel.setUpgradedToHttp2(true);
-        targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
+
+        // Remove Http specific handlers
+        Util.safelyRemoveHandlers(targetChannel.getChannel().pipeline(),
+                                  Constants.IDLE_STATE_HANDLER, Constants.HTTP_TRACE_LOG_HANDLER);
+
         http2ClientChannel.getInFlightMessage(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID).setRequestWritten(true);
         http2ClientChannel.getDataEventListeners().
                 forEach(dataEventListener ->


### PR DESCRIPTION
## Purpose
HTTP/2 requests, responses should be visible when trace logs are enabled.

## Goals
Add tracelog functionality to HTTP/2

## Approach
- Introduce a FramLogger to log HTTP/2 frames
- Rearrange client and server pipelines

## User stories

## Release note

## Documentation


## Training


## Certification
N/A

## Marketing


## Automation tests
 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8
 
## Learning
