### PR TITLE
Add Redirection support for HTTP/2 

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -17,6 +17,7 @@ package org.wso2.transport.http.netty.common;
 
 import io.netty.util.AttributeKey;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpClientConnector;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 
@@ -247,6 +248,8 @@ public final class Constants {
     public static final AttributeKey<TargetChannel> TARGET_CHANNEL_REFERENCE = AttributeKey
             .valueOf
                     ("TARGET_CHANNEL_REFERENCE");
+    public static final AttributeKey<DefaultHttpClientConnector> CLIENT_CONNECTOR =
+            AttributeKey.valueOf("CLIENT_CONNECTOR");
 
     public static final String UTF8 = "UTF-8";
     public static final String URL_AUTHORITY = "://";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -186,10 +186,13 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                         freshHttp2ClientChannel.addDataEventListener(
                                 new TimeoutHandler(socketIdleTimeout, freshHttp2ClientChannel));
 
+                        if (followRedirect) {
+                            setChannelAttributes(channelFuture.channel(), httpOutboundRequest, httpResponseFuture,
+                                                 targetChannel);
+                        }
                         freshHttp2ClientChannel.getChannel().eventLoop().execute(() -> {
                             freshHttp2ClientChannel.getChannel().write(outboundMsgHolder);
                         });
-
                         httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
                     } else {
                         // Response for the upgrade request will arrive in stream 1, so use 1 as the stream id.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -190,9 +190,8 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                             setChannelAttributes(channelFuture.channel(), httpOutboundRequest, httpResponseFuture,
                                                  targetChannel);
                         }
-                        freshHttp2ClientChannel.getChannel().eventLoop().execute(() -> {
-                            freshHttp2ClientChannel.getChannel().write(outboundMsgHolder);
-                        });
+                        freshHttp2ClientChannel.getChannel().eventLoop().
+                                execute(() -> freshHttp2ClientChannel.getChannel().write(outboundMsgHolder));
                         httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
                     } else {
                         // Response for the upgrade request will arrive in stream 1, so use 1 as the stream id.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -250,6 +250,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     private void configureHttp2Pipeline(ChannelPipeline pipeline) {
         pipeline.addLast(Constants.CONNECTION_HANDLER, http2ConnectionHandler);
         pipeline.addLast(Constants.OUTBOUND_HANDLER, clientOutboundHandler);
+        pipeline.addLast(Constants.DECOMPRESSOR_HANDLER, new HttpContentDecompressor());
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/HttpClientChannelInitializer.java
@@ -250,7 +250,6 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     private void configureHttp2Pipeline(ChannelPipeline pipeline) {
         pipeline.addLast(Constants.CONNECTION_HANDLER, http2ConnectionHandler);
         pipeline.addLast(Constants.OUTBOUND_HANDLER, clientOutboundHandler);
-        addCommonHandlers(pipeline);
     }
 
     /**
@@ -314,6 +313,24 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
      */
     public Http2Connection getConnection() {
         return connection;
+    }
+
+    /**
+     * Checks whether redirection is enabled.
+     *
+     * @return whether redirection is enabled
+     */
+    public boolean isFollowRedirect() {
+        return followRedirect;
+    }
+
+    /**
+     * Gets the maximum number of allowed redirection on same request.
+     *
+     * @return  maximum number of redirection
+     */
+    public int getMaxRedirectCount() {
+        return maxRedirectCount;
     }
 
     public boolean isKeepAlive() {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
@@ -667,11 +667,9 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      * @return default port as an int
      */
     private int getDefaultPort(String protocol) {
-        int defaultPort = Constants.HTTPS_SCHEME.equals(protocol) ?
-                          Constants.DEFAULT_HTTPS_PORT :
-                          Constants.DEFAULT_HTTP_PORT;
-
-        return defaultPort;
+        return Constants.HTTPS_SCHEME.equals(protocol) ?
+               Constants.DEFAULT_HTTPS_PORT :
+               Constants.DEFAULT_HTTP_PORT;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
@@ -44,15 +44,17 @@ import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
+
+import static org.wso2.transport.http.netty.sender.RedirectUtil.getResolvedRedirectURI;
 
 /**
  * Class responsible for handling redirects for client connector.
@@ -257,7 +259,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
             }
         } catch (UnsupportedEncodingException exception) {
             LOG.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
-                    exception);
+                      exception);
             handleException(ctx, exception.getCause());
         } catch (MalformedURLException exception) {
             LOG.error("MalformedURLException occurred when deciding whether a redirection is required", exception);
@@ -302,7 +304,6 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
             }
             if (ctx == originalChannelContext) {
                 originalChannelContext.fireChannelRead(msg);
-                //ctx.close();
             } else {
                 markEndOfMessage(ctx, (HttpContent) msg);
             }
@@ -344,7 +345,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         try {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Return target channel : " + targetChannel.getChannel().id() + " back to its pool from "
-                        + "RedirectHandler. Currently in channel : " + ctx.channel().id());
+                          + "RedirectHandler. Currently in channel : " + ctx.channel().id());
             }
             Util.resetChannelAttributes(ctx);
             Util.resetChannelAttributes(originalChannelContext);
@@ -361,7 +362,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         } catch (Exception exception) {
             LOG.error(
                     "Error occurred while returning target channel " + targetChannel.getChannel().id() + " from current"
-                            + " channel" + ctx.channel().id() + " " + "to its pool in " + "markEndOfMessage",
+                    + " channel" + ctx.channel().id() + " " + "to its pool in " + "markEndOfMessage",
                     exception);
             handleException(ctx, exception.getCause());
         }
@@ -400,8 +401,8 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      */
     private String getLocationFromResponseHeader(HttpResponse msg) throws UnsupportedEncodingException {
         return msg.headers().get(HttpHeaderNames.LOCATION) != null ?
-                URLDecoder.decode(msg.headers().get(HttpHeaderNames.LOCATION), Constants.UTF8) :
-                null;
+               URLDecoder.decode(msg.headers().get(HttpHeaderNames.LOCATION), Constants.UTF8) :
+               null;
     }
 
     /**
@@ -450,7 +451,8 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                 if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
                         .equals(originalRequestMethod)) {
                     redirectState.put(Constants.HTTP_METHOD, originalRequestMethod);
-                    redirectState.put(HttpHeaderNames.LOCATION.toString(), getResolvedURI(location, originalRequest));
+                    redirectState.put(
+                            HttpHeaderNames.LOCATION.toString(), getResolvedRedirectURI(location, originalRequest));
                 }
                 break;
             case 301:
@@ -458,35 +460,23 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                 if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
                         .equals(originalRequestMethod)) {
                     redirectState.put(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
-                    redirectState.put(HttpHeaderNames.LOCATION.toString(), getResolvedURI(location, originalRequest));
+                    redirectState.put(
+                            HttpHeaderNames.LOCATION.toString(), getResolvedRedirectURI(location, originalRequest));
                 }
                 break;
             case 303:
                 redirectState.put(Constants.HTTP_METHOD, Constants.HTTP_GET_METHOD);
-                redirectState.put(HttpHeaderNames.LOCATION.toString(), getResolvedURI(location, originalRequest));
+                redirectState.put(
+                        HttpHeaderNames.LOCATION.toString(), getResolvedRedirectURI(location, originalRequest));
                 break;
             default:
                 return null;
         }
         if (originalRequest != null && originalRequest.getHeader(HttpHeaderNames.USER_AGENT.toString()) != null) {
             redirectState.put(HttpHeaderNames.USER_AGENT.toString(),
-                    originalRequest.getHeader(HttpHeaderNames.USER_AGENT.toString()));
+                              originalRequest.getHeader(HttpHeaderNames.USER_AGENT.toString()));
         }
         return redirectState;
-    }
-
-    private String getResolvedURI(String locationString, HTTPCarbonMessage originalRequest)
-            throws URISyntaxException, UnsupportedEncodingException {
-        URI location = new URI(locationString);
-        if (!location.isAbsolute()) {
-            // location is not absolute, we need to resolve it.
-            String baseURIAsString = (String) originalRequest.getProperty(Constants.REQUEST_URL);
-            if (baseURIAsString != null) {
-                URI baseUri = new URI(baseURIAsString);
-                location = baseUri.resolve(location.normalize());
-            }
-        }
-        return location.toString();
     }
 
     /**
@@ -499,20 +489,20 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      */
     private boolean isCrossDomain(String location, HTTPCarbonMessage originalRequest)
             throws UnsupportedEncodingException, MalformedURLException {
-        if (!RedirectUtil.isRelativePath(location)) {
+        if (!isRelativePath(location)) {
             try {
                 URL locationUrl = new URL(location);
                 String protocol =
                         originalRequest != null ? (String) originalRequest.getProperty(Constants.PROTOCOL) : null;
                 String host = originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_HOST) :
-                        null;
+                              null;
                 String port = originalRequest != null ?
-                        originalRequest.getProperty(Constants.HTTP_PORT) != null ?
-                                Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) :
-                                null :
-                        null;
+                              originalRequest.getProperty(Constants.HTTP_PORT) != null ?
+                              Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) :
+                              null :
+                              null;
                 if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
-                        && locationUrl.getPort() == Integer.parseInt(port)) {
+                    && locationUrl.getPort() == Integer.parseInt(port)) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Is cross domain url : " + false);
                     }
@@ -525,7 +515,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
                 }
             } catch (MalformedURLException exception) {
                 LOG.error("MalformedURLException occurred while deciding whether the redirect url is cross domain",
-                        exception);
+                          exception);
                 throw exception;
             }
         }
@@ -581,10 +571,10 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
         Bootstrap clientBootstrap = new Bootstrap();
         clientBootstrap.group(group).channel(NioSocketChannel.class).remoteAddress(
                 new InetSocketAddress(redirectUrl.getHost(), redirectUrl.getPort() != -1 ?
-                        redirectUrl.getPort() :
-                        getDefaultPort(redirectUrl.getProtocol()))).handler(
+                                                             redirectUrl.getPort() :
+                                                             getDefaultPort(redirectUrl.getProtocol()))).handler(
                 new RedirectChannelInitializer(sslEngine, httpTraceLogEnabled, maxRedirectCount, originalChannelContext,
-                        isIdleHandlerOfTargetChannelRemoved, connectionManager));
+                                               isIdleHandlerOfTargetChannelRemoved, connectionManager));
         clientBootstrap.option(ChannelOption.SO_KEEPALIVE, true).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 15000);
         ChannelFuture channelFuture = clientBootstrap.connect();
         registerListener(channelHandlerContext, channelFuture, httpCarbonRequest, httpRequest);
@@ -604,22 +594,23 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
             if (future.isSuccess() && future.isDone()) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Connected to the new channel " + future.channel().id() + " and getting ready to "
-                            + "write request.");
+                              + "write request.");
                 }
                 long channelStartTime = channelHandlerContext.channel().attr(Constants.ORIGINAL_CHANNEL_START_TIME)
                         .get();
                 int timeoutOfOriginalRequest = channelHandlerContext.channel()
                         .attr(Constants.ORIGINAL_CHANNEL_TIMEOUT).get();
                 setChannelAttributes(channelHandlerContext, future, httpCarbonRequest, channelStartTime,
-                        timeoutOfOriginalRequest);
+                                     timeoutOfOriginalRequest);
                 long remainingTimeForRedirection = getRemainingTimeForRedirection(channelStartTime,
-                        timeoutOfOriginalRequest);
+                                                                                  timeoutOfOriginalRequest);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Remaining time for redirection is : " + remainingTimeForRedirection);
                 }
-                future.channel().pipeline().addBefore(Constants.REDIRECT_HANDLER, Constants.IDLE_STATE_HANDLER,
-                        new IdleStateHandler(remainingTimeForRedirection, remainingTimeForRedirection, 0,
-                                TimeUnit.MILLISECONDS));
+                future.channel().pipeline().addBefore(
+                        Constants.REDIRECT_HANDLER, Constants.IDLE_STATE_HANDLER,
+                        new IdleStateHandler(remainingTimeForRedirection,
+                                             remainingTimeForRedirection, 0, TimeUnit.MILLISECONDS));
                 future.channel().write(httpRequest);
                 future.channel().writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
                 /* if the previous channel is not original channel, closes it after sending the request through
@@ -677,9 +668,20 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
      */
     private int getDefaultPort(String protocol) {
         int defaultPort = Constants.HTTPS_SCHEME.equals(protocol) ?
-                Constants.DEFAULT_HTTPS_PORT :
-                Constants.DEFAULT_HTTP_PORT;
+                          Constants.DEFAULT_HTTPS_PORT :
+                          Constants.DEFAULT_HTTP_PORT;
 
         return defaultPort;
+    }
+
+    /**
+     * Checks whether the location includes an absolute path or a relative path.
+     *
+     * @param location value of location header
+     * @return a boolean indicating url state
+     */
+    private boolean isRelativePath(String location) {
+        return !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTP_SCHEME + Constants.URL_AUTHORITY) &&
+               !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTPS_SCHEME + Constants.URL_AUTHORITY);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectHandler.java
@@ -299,7 +299,7 @@ public class RedirectHandler extends ChannelInboundHandlerAdapter {
             }
             if (ctx == originalChannelContext) {
                 originalChannelContext.fireChannelRead(msg);
-                ctx.close();
+                //ctx.close();
             } else {
                 markEndOfMessage(ctx, (HttpContent) msg);
             }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -118,51 +118,6 @@ public class RedirectUtil {
     }
 
     /**
-     * Checks whether the location indicates a cross domain.
-     *
-     * @param location        redirected location
-     * @param originalRequest Original request message
-     * @return whether the location is cross domain or not
-     * @throws UnsupportedEncodingException if url decoding fails
-     */
-    public static boolean isCrossDomain(String location, HTTPCarbonMessage originalRequest)
-            throws UnsupportedEncodingException, MalformedURLException {
-        if (!isRelativePath(location)) {
-            try {
-                URL locationUrl = new URL(location);
-                String protocol = (String) originalRequest.getProperty(Constants.PROTOCOL);
-                String host = (String) originalRequest.getProperty(Constants.HTTP_HOST);
-                String port = originalRequest.getProperty(Constants.HTTP_PORT) != null ?
-                              Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) : null;
-                if (port == null) {
-                    port = String.valueOf(getDefaultPort(protocol));
-                }
-
-                if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
-                    && locationUrl.getPort() == Integer.parseInt(port)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Is cross domain url : " + false);
-                    }
-                    return false;
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Is cross domain url : " + true);
-                    }
-                    return true;
-                }
-            } catch (MalformedURLException exception) {
-                log.error("MalformedURLException occurred while deciding whether the redirect url is cross domain",
-                          exception);
-                throw exception;
-            }
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Is cross domain url : " + false);
-        }
-        return false;
-    }
-
-    /**
      * Builds the redirect URL from relative path.
      *
      * @param requestPath request path of the original request

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -134,8 +134,7 @@ public class RedirectUtil {
                 String port = originalRequest.getProperty(Constants.HTTP_PORT) != null ?
                               Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) : null;
                 if (port == null) {
-                    port = protocol.equalsIgnoreCase(Constants.HTTPS_SCHEME) ?
-                           String.valueOf(Constants.DEFAULT_HTTPS_PORT) : String.valueOf(Constants.DEFAULT_HTTP_PORT);
+                    port = String.valueOf(getDefaultPort(protocol));
                 }
 
                 if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
@@ -199,7 +198,7 @@ public class RedirectUtil {
     }
 
     /**
-     * Check whether the location includes an absolute path or a relative path.
+     * Checks whether the location includes an absolute path or a relative path.
      *
      * @param location value of location header
      * @return a boolean indicating url state
@@ -216,10 +215,6 @@ public class RedirectUtil {
      * @return default port as an int
      */
     private static int getDefaultPort(String protocol) {
-
-        return Constants.HTTPS_SCHEME.equals(protocol) ?
-               Constants.DEFAULT_HTTPS_PORT :
-               Constants.DEFAULT_HTTP_PORT;
+        return Constants.HTTPS_SCHEME.equals(protocol) ? Constants.DEFAULT_HTTPS_PORT : Constants.DEFAULT_HTTP_PORT;
     }
-
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.sender;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code RedirectUtil} contains utility methods used to HTTP client side redirection.
+ */
+public class RedirectUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedirectUtil.class);
+
+
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -83,7 +83,7 @@ public class RedirectUtil {
      * Builds redirect url from the location header value.
      *
      * @param location        value of the location header
-     * @param originalRequest Original request message
+     * @param originalRequest original request message
      * @return a string that holds redirect url
      * @throws UnsupportedEncodingException if url decoding fails
      */

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -18,15 +18,208 @@
 
 package org.wso2.transport.http.netty.sender;
 
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Locale;
 
 /**
  * {@code RedirectUtil} contains utility methods used to HTTP client side redirection.
  */
 public class RedirectUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RedirectUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(RedirectUtil.class);
 
+    /**
+     * Creates redirect request message.
+     *
+     * @return HTTPCarbonMessage with request properties
+     * @throws MalformedURLException if url is malformed
+     */
+    public static HTTPCarbonMessage createRedirectCarbonRequest(String redirectionUrl, String redirectionMethod,
+                                                                String userAgent)
+            throws MalformedURLException {
+        if (log.isDebugEnabled()) {
+            log.debug("Create redirect request with http method  : " + redirectionMethod);
+        }
+        URL locationUrl = new URL(redirectionUrl);
+
+        HttpMethod httpMethod = new HttpMethod(redirectionMethod);
+        HTTPCarbonMessage httpCarbonRequest = new HTTPCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, ""));
+        httpCarbonRequest.setProperty(Constants.HTTP_PORT,
+                                      locationUrl.getPort() != -1 ? locationUrl.getPort() :
+                                      getDefaultPort(locationUrl.getProtocol()));
+        httpCarbonRequest.setProperty(Constants.PROTOCOL, locationUrl.getProtocol());
+        httpCarbonRequest.setProperty(Constants.HTTP_HOST, locationUrl.getHost());
+        httpCarbonRequest.setProperty(Constants.HTTP_METHOD, redirectionMethod);
+        httpCarbonRequest.setProperty(Constants.REQUEST_URL, locationUrl.getPath());
+        httpCarbonRequest.setProperty(Constants.TO, locationUrl.getPath());
+
+        StringBuilder host = new StringBuilder(locationUrl.getHost());
+        if (locationUrl.getPort() != -1 && locationUrl.getPort() != Constants.DEFAULT_HTTP_PORT
+            && locationUrl.getPort() != Constants.DEFAULT_HTTPS_PORT) {
+            host.append(Constants.COLON).append(locationUrl.getPort());
+        }
+        if (userAgent != null) {
+            httpCarbonRequest.setHeader(HttpHeaderNames.USER_AGENT.toString(), userAgent);
+        }
+        httpCarbonRequest.setHeader(HttpHeaderNames.HOST.toString(), host.toString());
+        httpCarbonRequest.completeMessage();
+        return httpCarbonRequest;
+    }
+
+    /**
+     * Builds redirect url from the location header value.
+     *
+     * @param location        value of the location header
+     * @param originalRequest Original request message
+     * @return a string that holds redirect url
+     * @throws UnsupportedEncodingException if url decoding fails
+     */
+    public static String getLocationURI(String location, HTTPCarbonMessage originalRequest)
+            throws UnsupportedEncodingException {
+        if (location != null) {
+            //if location url starts either with http ot https that means an absolute path has been set in header
+            if (!isRelativePath(location)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Location contain an absolute path : " + location);
+                }
+                return location;
+            } else {
+                //Use relative path to build redirect url
+                if (originalRequest == null) {
+                    return null;
+                }
+                String requestPath = (String) originalRequest.getProperty(Constants.TO);
+                String protocol = (String) originalRequest.getProperty(Constants.PROTOCOL);
+                String host = (String) originalRequest.getProperty(Constants.HTTP_HOST);
+                if (host == null) {
+                    return null;
+                }
+                int defaultPort = getDefaultPort(protocol);
+                Integer port = originalRequest.getProperty(Constants.HTTP_PORT) != null ?
+                               (Integer) originalRequest.getProperty(Constants.HTTP_PORT) : defaultPort;
+                return buildRedirectURL(requestPath, location, protocol, host, port);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the location indicates a cross domain.
+     *
+     * @param location        redirected location
+     * @param originalRequest Original request message
+     * @return whether the location is cross domain or not
+     * @throws UnsupportedEncodingException if url decoding fails
+     */
+    public static boolean isCrossDomain(String location, HTTPCarbonMessage originalRequest)
+            throws UnsupportedEncodingException, MalformedURLException {
+        if (!isRelativePath(location)) {
+            try {
+                URL locationUrl = new URL(location);
+                String protocol = (String) originalRequest.getProperty(Constants.PROTOCOL);
+                String host = (String) originalRequest.getProperty(Constants.HTTP_HOST);
+                String port = originalRequest.getProperty(Constants.HTTP_PORT) != null ?
+                              Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) : null;
+                if (port == null) {
+                    port = protocol.equalsIgnoreCase(Constants.HTTPS_SCHEME) ?
+                           String.valueOf(Constants.DEFAULT_HTTPS_PORT) : String.valueOf(Constants.DEFAULT_HTTP_PORT);
+                }
+
+                if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
+                    && locationUrl.getPort() == Integer.parseInt(port)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Is cross domain url : " + false);
+                    }
+                    return false;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Is cross domain url : " + true);
+                    }
+                    return true;
+                }
+            } catch (MalformedURLException exception) {
+                log.error("MalformedURLException occurred while deciding whether the redirect url is cross domain",
+                          exception);
+                throw exception;
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Is cross domain url : " + false);
+        }
+        return false;
+    }
+
+    /**
+     * Builds the redirect URL from relative path.
+     *
+     * @param requestPath request path of the original request
+     * @param location    relative path received as the location
+     * @param protocol    protocol used in the request
+     * @param host        host used in the request
+     * @param port        port used in the request
+     * @return a string containing absolute path for redirection
+     * @throws UnsupportedEncodingException if url decoding fails
+     */
+    private static String buildRedirectURL(String requestPath, String location, String protocol,
+                                           String host, Integer port) throws UnsupportedEncodingException {
+        String newPath = requestPath == null ? Constants.FORWRD_SLASH : URLDecoder.decode(requestPath, Constants.UTF8);
+        if (location.startsWith(Constants.FORWRD_SLASH)) {
+            newPath = location;
+        } else if (newPath.endsWith(Constants.FORWRD_SLASH)) {
+            newPath += location;
+        } else {
+            newPath += Constants.FORWRD_SLASH + location;
+        }
+        StringBuilder newLocation = new StringBuilder(protocol);
+        newLocation.append(Constants.URL_AUTHORITY).append(host);
+        if (Constants.DEFAULT_HTTP_PORT != port) {
+            newLocation.append(Constants.COLON).append(port);
+        }
+        if (newPath.charAt(0) != Constants.FORWRD_SLASH.charAt(0)) {
+            newLocation.append(Constants.FORWRD_SLASH.charAt(0));
+        }
+        newLocation.append(newPath);
+        if (log.isDebugEnabled()) {
+            log.debug("Redirect URL build from relative path is : " + newLocation.toString());
+        }
+        return newLocation.toString();
+    }
+
+    /**
+     * Check whether the location includes an absolute path or a relative path.
+     *
+     * @param location value of location header
+     * @return a boolean indicating url state
+     */
+    private static boolean isRelativePath(String location) {
+        return !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTP_SCHEME + Constants.URL_AUTHORITY) &&
+               !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTPS_SCHEME + Constants.URL_AUTHORITY);
+    }
+
+    /**
+     * Gets the default port based on the protocol.
+     *
+     * @param protocol the http protocol
+     * @return default port as an int
+     */
+    private static int getDefaultPort(String protocol) {
+
+        return Constants.HTTPS_SCHEME.equals(protocol) ?
+               Constants.DEFAULT_HTTPS_PORT :
+               Constants.DEFAULT_HTTP_PORT;
+    }
 
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -102,7 +102,8 @@ public class RedirectUtil {
                     return null;
                 }
                 String requestPath = (String) originalRequest.getProperty(Constants.TO);
-                String protocol = (String) originalRequest.getProperty(Constants.PROTOCOL);
+                String protocol = originalRequest.getProperty(Constants.PROTOCOL) != null ?
+                                  (String) originalRequest.getProperty(Constants.PROTOCOL) : Constants.HTTP_SCHEME;
                 String host = (String) originalRequest.getProperty(Constants.HTTP_HOST);
                 if (host == null) {
                     return null;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/RedirectUtil.java
@@ -159,7 +159,7 @@ public class RedirectUtil {
      * @param location value of location header
      * @return a boolean indicating url state
      */
-    public static boolean isRelativePath(String location) {
+    static boolean isRelativePath(String location) {
         return !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTP_SCHEME + Constants.URL_AUTHORITY) &&
                !location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTPS_SCHEME + Constants.URL_AUTHORITY);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -225,7 +225,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         http2ClientChannel.getInFlightMessage(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID).setRequestWritten(true);
         http2ClientChannel.getDataEventListeners().
                 forEach(dataEventListener ->
-                                dataEventListener.onStreamInit(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID, ctx));
+                                dataEventListener.onStreamInit(ctx, Http2CodecUtil.HTTP_UPGRADE_STREAM_ID));
         handoverChannelToHttp2ConnectionManager();
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -219,9 +219,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         http2ClientChannel.setUpgradedToHttp2(true);
 
         // Remove Http specific handlers
-        Util.safelyRemoveHandlers(targetChannel.getChannel().pipeline(),
-                                  Constants.IDLE_STATE_HANDLER, Constants.HTTP_TRACE_LOG_HANDLER);
-
+        Util.safelyRemoveHandlers(targetChannel.getChannel().pipeline(), Constants.IDLE_STATE_HANDLER,
+                                  Constants.HTTP_TRACE_LOG_HANDLER, Constants.REDIRECT_HANDLER);
         http2ClientChannel.getInFlightMessage(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID).setRequestWritten(true);
         http2ClientChannel.getDataEventListeners().
                 forEach(dataEventListener ->

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
@@ -40,6 +40,7 @@ import org.wso2.transport.http.netty.sender.HttpClientChannelInitializer;
 import org.wso2.transport.http.netty.sender.TargetHandler;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
 import org.wso2.transport.http.netty.sender.http2.Http2ClientChannel;
+import org.wso2.transport.http.netty.sender.http2.RedirectHandler;
 import org.wso2.transport.http.netty.sender.http2.TimeoutHandler;
 
 import java.io.IOException;
@@ -86,6 +87,10 @@ public class TargetChannel {
                     new Http2ClientChannel(httpClientChannelInitializer.getHttp2ConnectionManager(),
                                            httpClientChannelInitializer.getConnection(),
                                            httpRoute, channelFuture.channel());
+            if (httpClientChannelInitializer.isFollowRedirect()) {
+                http2ClientChannel.addDataEventListener(
+                        new RedirectHandler(http2ClientChannel, httpClientChannelInitializer.getMaxRedirectCount()));
+            }
         }
         this.connectionAvailabilityFuture = connectionAvailabilityFuture;
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -175,7 +175,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
                       http2ClientChannel.toString(), streamId, promisedStreamId);
         }
         for (Http2DataEventListener listener : http2ClientChannel.getDataEventListeners()) {
-            if (!listener.onHeadersRead(ctx, streamId, headers, false)) {
+            if (!listener.onPushPromiseRead(ctx, streamId, headers, false)) {
                 return;
             }
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -61,7 +61,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
         }
 
         http2ClientChannel.getDataEventListeners().
-                forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, endOfStream));
+                forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, data, endOfStream));
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         boolean isServerPush = false;
         if (outboundMsgHolder == null) {
@@ -109,7 +109,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
                       http2ClientChannel.toString(), streamId, endStream);
         }
         http2ClientChannel.getDataEventListeners().
-                forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, endStream));
+                forEach(dataEventListener -> dataEventListener.onHeadersRead(streamId, ctx, headers, endStream));
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         boolean isServerPush = false;
         if (outboundMsgHolder == null) {
@@ -166,7 +166,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
                       http2ClientChannel.toString(), streamId, promisedStreamId);
         }
         http2ClientChannel.getDataEventListeners().
-                forEach(dataEventListener -> dataEventListener.onDataRead(streamId, ctx, false));
+                forEach(dataEventListener -> dataEventListener.onHeadersRead(streamId, ctx, headers, false));
 
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder == null) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
@@ -17,7 +17,9 @@
  */
 package org.wso2.transport.http.netty.sender.http2;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Headers;
 
 /**
  * {@code Http2DataEventListener} represents a data listener for http2 data transfer events.
@@ -30,16 +32,27 @@ public interface Http2DataEventListener {
      * @param streamId the related stream id
      * @param ctx      the channel handler context
      */
-    void onStreamInit(int streamId, ChannelHandlerContext ctx);
+    boolean onStreamInit(int streamId, ChannelHandlerContext ctx);
+
+    /**
+     * Gets notified for an event on a header read on a particular stream.
+     *
+     * @param streamId    the related stream id
+     * @param ctx         the channel handler context
+     * @param headers     http2 headers
+     * @param endOfStream whether stream terminate with this data read operation
+     */
+    boolean onHeadersRead(int streamId, ChannelHandlerContext ctx, Http2Headers headers, boolean endOfStream);
 
     /**
      * Gets notified for an event on a data read on a particular stream.
      *
      * @param streamId    the related stream id
      * @param ctx         the channel handler context
+     * @param data        the bytebuf contains data
      * @param endOfStream whether stream terminate with this data read operation
      */
-    void onDataRead(int streamId, ChannelHandlerContext ctx, boolean endOfStream);
+    boolean onDataRead(int streamId, ChannelHandlerContext ctx, ByteBuf data, boolean endOfStream);
 
     /**
      * Gets notified for an event on a data write on a particular stream.
@@ -48,21 +61,21 @@ public interface Http2DataEventListener {
      * @param ctx         the channel handler context
      * @param endOfStream whether stream terminate with this data read operation
      */
-    void onDataWrite(int streamId, ChannelHandlerContext ctx, boolean endOfStream);
+    boolean onDataWrite(int streamId, ChannelHandlerContext ctx, boolean endOfStream);
 
     /**
      * Gets notified on  a stream reset.
      *
      * @param streamId the stream id
      */
-    void onStreamReset(int streamId);
+    boolean onStreamReset(int streamId);
 
     /**
      * Gets notified on a stream close.
      *
      * @param streamId the related stream id
      */
-    void onStreamClose(int streamId);
+    boolean onStreamClose(int streamId);
 
     /**
      * Destroy this {@code Http2DataEventListener}.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
@@ -29,39 +29,50 @@ public interface Http2DataEventListener {
     /**
      * Gets notified for an event on a stream initialization.
      *
-     * @param streamId the related stream id
      * @param ctx      the channel handler context
+     * @param streamId the related stream id
      */
-    boolean onStreamInit(int streamId, ChannelHandlerContext ctx);
+    boolean onStreamInit(ChannelHandlerContext ctx, int streamId);
 
     /**
      * Gets notified for an event on a header read on a particular stream.
      *
-     * @param streamId    the related stream id
      * @param ctx         the channel handler context
+     * @param streamId    the related stream id
      * @param headers     http2 headers
      * @param endOfStream whether stream terminate with this data read operation
      */
-    boolean onHeadersRead(int streamId, ChannelHandlerContext ctx, Http2Headers headers, boolean endOfStream);
+    boolean onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
 
     /**
      * Gets notified for an event on a data read on a particular stream.
      *
-     * @param streamId    the related stream id
      * @param ctx         the channel handler context
+     * @param streamId    the related stream id
      * @param data        the bytebuf contains data
      * @param endOfStream whether stream terminate with this data read operation
      */
-    boolean onDataRead(int streamId, ChannelHandlerContext ctx, ByteBuf data, boolean endOfStream);
+    boolean onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream);
+
+    /**
+     * Gets notified for an event on a headers write on a particular stream.
+     *
+     * @param ctx         the channel handler context
+     * @param streamId    the related stream id
+     * @param headers        http2 headers
+     * @param endOfStream whether stream terminate with this data read operation
+     */
+    boolean onHeadersWrite(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
 
     /**
      * Gets notified for an event on a data write on a particular stream.
      *
-     * @param streamId    the related stream id
      * @param ctx         the channel handler context
+     * @param streamId    the related stream id
+     * @param data        the bytebuf contains data
      * @param endOfStream whether stream terminate with this data read operation
      */
-    boolean onDataWrite(int streamId, ChannelHandlerContext ctx, boolean endOfStream);
+    boolean onDataWrite(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream);
 
     /**
      * Gets notified on  a stream reset.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
@@ -31,6 +31,7 @@ public interface Http2DataEventListener {
      *
      * @param ctx      the channel handler context
      * @param streamId the related stream id
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onStreamInit(ChannelHandlerContext ctx, int streamId);
 
@@ -41,6 +42,7 @@ public interface Http2DataEventListener {
      * @param streamId    the related stream id
      * @param headers     http2 headers
      * @param endOfStream whether stream terminate with this data read operation
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
 
@@ -51,6 +53,7 @@ public interface Http2DataEventListener {
      * @param streamId    the related stream id
      * @param data        the bytebuf contains data
      * @param endOfStream whether stream terminate with this data read operation
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream);
 
@@ -61,6 +64,7 @@ public interface Http2DataEventListener {
      * @param streamId    the related stream id
      * @param headers     http2 headers
      * @param endOfStream whether stream terminate with this data read operation
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onPushPromiseRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
 
@@ -71,6 +75,7 @@ public interface Http2DataEventListener {
      * @param streamId    the related stream id
      * @param headers        http2 headers
      * @param endOfStream whether stream terminate with this data read operation
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onHeadersWrite(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
 
@@ -81,6 +86,7 @@ public interface Http2DataEventListener {
      * @param streamId    the related stream id
      * @param data        the bytebuf contains data
      * @param endOfStream whether stream terminate with this data read operation
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onDataWrite(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream);
 
@@ -88,6 +94,7 @@ public interface Http2DataEventListener {
      * Gets notified on  a stream reset.
      *
      * @param streamId the stream id
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onStreamReset(int streamId);
 
@@ -95,6 +102,7 @@ public interface Http2DataEventListener {
      * Gets notified on a stream close.
      *
      * @param streamId the related stream id
+     * @return whether to continue the execution of rest of the listeners
      */
     boolean onStreamClose(int streamId);
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2DataEventListener.java
@@ -55,6 +55,16 @@ public interface Http2DataEventListener {
     boolean onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream);
 
     /**
+     * Gets notified for an event on a push promise read on a particular stream.
+     *
+     * @param ctx         the channel handler context
+     * @param streamId    the related stream id
+     * @param headers     http2 headers
+     * @param endOfStream whether stream terminate with this data read operation
+     */
+    boolean onPushPromiseRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream);
+
+    /**
      * Gets notified for an event on a headers write on a particular stream.
      *
      * @param ctx         the channel handler context

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
@@ -53,12 +53,15 @@ public class OutboundMsgHolder {
     private AtomicInteger redirectCount = new AtomicInteger(0);
     private Http2Headers redirectResponseHeaders;
 
-    public OutboundMsgHolder(HTTPCarbonMessage httpCarbonMessage, Http2ClientChannel http2ClientChannel) {
+    public OutboundMsgHolder(HTTPCarbonMessage httpCarbonMessage) {
         this.requestCarbonMessage = httpCarbonMessage;
-        this.http2ClientChannel = http2ClientChannel;
         promises = new LinkedBlockingQueue<>();
         pushResponsesMap = new ConcurrentHashMap<>();
         responseFuture = new DefaultHttpResponseFuture(this);
+    }
+
+    public void setHttp2ClientChannel(Http2ClientChannel http2ClientChannel) {
+        this.http2ClientChannel = http2ClientChannel;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/OutboundMsgHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.sender.http2;
 
+import io.netty.handler.codec.http2.Http2Headers;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpResponseFuture;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -27,6 +28,7 @@ import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * {@code OutboundMsgHolder} holds data related to a single outbound invocation.
@@ -46,6 +48,10 @@ public class OutboundMsgHolder {
     private boolean allPromisesReceived = false;
     private long lastReadWriteTime;
     private boolean requestWritten;
+
+    private boolean markedForRedirection = false;
+    private AtomicInteger redirectCount = new AtomicInteger(0);
+    private Http2Headers redirectResponseHeaders;
 
     public OutboundMsgHolder(HTTPCarbonMessage httpCarbonMessage, Http2ClientChannel http2ClientChannel) {
         this.requestCarbonMessage = httpCarbonMessage;
@@ -204,6 +210,40 @@ public class OutboundMsgHolder {
      */
     public void setRequestWritten(boolean requestWritten) {
         this.requestWritten = requestWritten;
+    }
+
+    /**
+     * Increments and gets the redirects count.
+     *
+     * @return number of redirects
+     */
+    public int incrementRedirectCount() {
+        return redirectCount.incrementAndGet();
+    }
+
+    public boolean isMarkedForRedirection() {
+        return markedForRedirection;
+    }
+
+    public void markForRedirection() {
+        this.markedForRedirection = true;
+    }
+
+    public Http2Headers getRedirectResponseHeaders() {
+        return redirectResponseHeaders;
+    }
+
+    public void setRedirectResponseHeaders(Http2Headers redirectResponseHeaders) {
+        this.redirectResponseHeaders = redirectResponseHeaders;
+    }
+
+    public void clearRedirectionState() {
+        markedForRedirection = false;
+        redirectResponseHeaders = null;
+    }
+
+    public void updateRequest(HTTPCarbonMessage requestCarbonMessage) {
+        this.requestCarbonMessage = requestCarbonMessage;
     }
 }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
@@ -20,11 +20,8 @@ package org.wso2.transport.http.netty.sender.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil;
@@ -33,12 +30,10 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpClientConnector;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.sender.RedirectUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.Locale;
 
 /**
  * {@code RedirectHandler} is responsible for HTTP/2 redirection.
@@ -77,7 +72,7 @@ public class RedirectHandler implements Http2DataEventListener {
             return true;
         }
         if (endOfStream) {
-            doRedirection(ctx, streamId, statusCode, outboundMsgHolder, location);
+            doRedirection(ctx, streamId, statusCode, outboundMsgHolder, location, fetchUserAgentHeaderVal(headers));
         } else {
             outboundMsgHolder.markForRedirection();
             outboundMsgHolder.setRedirectResponseHeaders(headers);
@@ -91,8 +86,8 @@ public class RedirectHandler implements Http2DataEventListener {
         if (outboundMsgHolder.isMarkedForRedirection()) {
             if (endOfStream) {
                 Http2Headers headers = outboundMsgHolder.getRedirectResponseHeaders();
-                doRedirection(
-                        ctx, streamId, fetchStatusCode(headers), outboundMsgHolder, fetchLocationHeaderVal(headers));
+                doRedirection(ctx, streamId, fetchStatusCode(headers), outboundMsgHolder,
+                              fetchLocationHeaderVal(headers), fetchUserAgentHeaderVal(headers));
             }
             return false;
         }
@@ -130,17 +125,17 @@ public class RedirectHandler implements Http2DataEventListener {
     }
 
     private void doRedirection(ChannelHandlerContext ctx, int streamId, int statusCode,
-                               OutboundMsgHolder outboundMsgHolder, String location) {
+                               OutboundMsgHolder outboundMsgHolder, String location, String userAgent) {
         try {
             HTTPCarbonMessage originalRequest = outboundMsgHolder.getRequest();
             String redirectionMethod = getRedirectionRequestMethod(statusCode, originalRequest);
-            String redirectionURL = getLocationURI(location, originalRequest);
-            boolean crossDomain = isCrossDomain(location, originalRequest);
+            String redirectionURL = RedirectUtil.getLocationURI(location, originalRequest);
+            boolean crossDomain = RedirectUtil.isCrossDomain(location, originalRequest);
 
-            HTTPCarbonMessage request = createRedirectRequest(redirectionURL, redirectionMethod);
+            HTTPCarbonMessage request =
+                    RedirectUtil.createRedirectCarbonRequest(redirectionURL, redirectionMethod, userAgent);
             outboundMsgHolder.clearRedirectionState();
             http2ClientChannel.removeInFlightMessage(streamId);
-
             outboundMsgHolder.updateRequest(request);
             if (crossDomain) {
                 DefaultHttpClientConnector connector = ctx.channel().attr(Constants.CLIENT_CONNECTOR).get();
@@ -148,7 +143,6 @@ public class RedirectHandler implements Http2DataEventListener {
             } else {
                 ctx.write(outboundMsgHolder);
             }
-
         } catch (UnsupportedEncodingException e) {
             log.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
                       e);
@@ -169,6 +163,11 @@ public class RedirectHandler implements Http2DataEventListener {
 
     private String fetchLocationHeaderVal(Http2Headers headers) {
         return headers.get(HttpHeaderNames.LOCATION) != null ? headers.get(HttpHeaderNames.LOCATION).toString() : null;
+    }
+
+    private String fetchUserAgentHeaderVal(Http2Headers headers) {
+        return headers.
+                get(HttpHeaderNames.USER_AGENT) != null ? headers.get(HttpHeaderNames.USER_AGENT).toString() : null;
     }
 
     private boolean isRedirectionResponse(int statusCode) {
@@ -200,188 +199,5 @@ public class RedirectHandler implements Http2DataEventListener {
                 return Constants.HTTP_GET_METHOD;
         }
         return null;
-    }
-
-    /**
-     * Build redirect url from the location header value.
-     *
-     * @param location        value of location header
-     * @param originalRequest Original request
-     * @return a string that holds redirect url
-     * @throws UnsupportedEncodingException
-     */
-    private String getLocationURI(String location, HTTPCarbonMessage originalRequest)
-            throws UnsupportedEncodingException {
-        if (location != null) {
-            //if location url starts either with http ot https that means an absolute path has been set in header
-            if (!isRelativePath(location)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Location contain an absolute path : " + location);
-                }
-                return location;
-            } else {
-                //Use relative path to build redirect url
-                String requestPath =
-                        originalRequest != null ? (String) originalRequest.getProperty(Constants.TO) : null;
-                String protocol = originalRequest != null ?
-                                  (String) originalRequest.getProperty(Constants.PROTOCOL) :
-                                  Constants.HTTP_SCHEME;
-                String host = originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_HOST) :
-                              null;
-                if (host == null) {
-                    return null;
-                }
-                int defaultPort = getDefaultPort(protocol);
-                Integer port = originalRequest != null ?
-                               originalRequest.getProperty(Constants.HTTP_PORT) != null ?
-                               (Integer) originalRequest.getProperty(Constants.HTTP_PORT) :
-                               defaultPort :
-                               defaultPort;
-                return buildRedirectURL(requestPath, location, protocol, host, port);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Check whether the location includes an absolute path or a relative path.
-     *
-     * @param location value of location header
-     * @return a boolean indicating url state
-     */
-    private boolean isRelativePath(String location) {
-        if (location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTP_SCHEME + Constants.URL_AUTHORITY) || location
-                .toLowerCase(Locale.ROOT).startsWith(Constants.HTTPS_SCHEME + Constants.URL_AUTHORITY)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Get default port based on the protocol.
-     *
-     * @param protocol http protocol
-     * @return default port as an int
-     */
-    private int getDefaultPort(String protocol) {
-        int defaultPort = Constants.HTTPS_SCHEME.equals(protocol) ?
-                          Constants.DEFAULT_HTTPS_PORT :
-                          Constants.DEFAULT_HTTP_PORT;
-
-        return defaultPort;
-    }
-
-    /**
-     * Build redirect URL from relative path.
-     *
-     * @param requestPath request path of the original request
-     * @param location    relative path received as the location
-     * @param protocol    protocol used in the request
-     * @param host        host used in the request
-     * @param port        port used in the request
-     * @return a string containing absolute path for redirection
-     * @throws UnsupportedEncodingException
-     */
-    private String buildRedirectURL(String requestPath, String location, String protocol, String host, Integer port)
-            throws UnsupportedEncodingException {
-        String newPath = requestPath == null ? Constants.FORWRD_SLASH : URLDecoder.decode(requestPath, Constants.UTF8);
-        if (location.startsWith(Constants.FORWRD_SLASH)) {
-            newPath = location;
-        } else if (newPath.endsWith(Constants.FORWRD_SLASH)) {
-            newPath += location;
-        } else {
-            newPath += Constants.FORWRD_SLASH + location;
-        }
-        StringBuilder newLocation = new StringBuilder(protocol);
-        newLocation.append(Constants.URL_AUTHORITY).append(host);
-        if (Constants.DEFAULT_HTTP_PORT != port) {
-            newLocation.append(Constants.COLON).append(port);
-        }
-        if (newPath.charAt(0) != Constants.FORWRD_SLASH.charAt(0)) {
-            newLocation.append(Constants.FORWRD_SLASH.charAt(0));
-        }
-        newLocation.append(newPath);
-        if (log.isDebugEnabled()) {
-            log.debug("Redirect URL build from relative path is : " + newLocation.toString());
-        }
-        return newLocation.toString();
-    }
-
-    /**
-     * Check whether the location indicates a cross domain.
-     *
-     * @param location        Response message
-     * @param originalRequest Original request
-     * @return a boolean to denote whether the location is cross domain or not
-     * @throws UnsupportedEncodingException
-     */
-    private boolean isCrossDomain(String location, HTTPCarbonMessage originalRequest)
-            throws UnsupportedEncodingException, MalformedURLException {
-        if (!isRelativePath(location)) {
-            try {
-                URL locationUrl = new URL(location);
-                String protocol =
-                        originalRequest != null ? (String) originalRequest.getProperty(Constants.PROTOCOL) : null;
-                String host = originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_HOST) :
-                              null;
-                String port = originalRequest != null ?
-                              originalRequest.getProperty(Constants.HTTP_PORT) != null ?
-                              Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) :
-                              null :
-                              null;
-                if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
-                    && locationUrl.getPort() == Integer.parseInt(port)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Is cross domain url : " + false);
-                    }
-                    return false;
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Is cross domain url : " + true);
-                    }
-                    return true;
-                }
-            } catch (MalformedURLException exception) {
-                log.error("MalformedURLException occurred while deciding whether the redirect url is cross domain",
-                          exception);
-                throw exception;
-            }
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Is cross domain url : " + false);
-        }
-        return false;
-    }
-
-    /**
-     * Create redirect request.
-     *
-     * @return HTTPCarbonMessage with request properties
-     * @throws MalformedURLException
-     */
-    private HTTPCarbonMessage createRedirectRequest(String redirectionUrl, String redirectionMethod)
-            throws MalformedURLException {
-
-        URL locationUrl = new URL(redirectionUrl);
-        HttpMethod httpMethod = new HttpMethod(redirectionMethod);
-        HTTPCarbonMessage httpCarbonRequest = new HTTPCarbonMessage(
-                new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, ""));
-        httpCarbonRequest.setProperty(
-                Constants.HTTP_PORT,
-                locationUrl.getPort() != -1 ? locationUrl.getPort() : getDefaultPort(locationUrl.getProtocol()));
-        httpCarbonRequest.setProperty(Constants.PROTOCOL, locationUrl.getProtocol());
-        httpCarbonRequest.setProperty(Constants.HTTP_HOST, locationUrl.getHost());
-        httpCarbonRequest.setProperty(Constants.HTTP_METHOD, redirectionMethod);
-        httpCarbonRequest.setProperty(Constants.REQUEST_URL, locationUrl.getPath());
-        httpCarbonRequest.setProperty(Constants.TO, locationUrl.getPath());
-
-        StringBuffer host = new StringBuffer(locationUrl.getHost());
-        if (locationUrl.getPort() != -1 && locationUrl.getPort() != Constants.DEFAULT_HTTP_PORT
-            && locationUrl.getPort() != Constants.DEFAULT_HTTPS_PORT) {
-            host.append(Constants.COLON).append(locationUrl.getPort());
-        }
-        httpCarbonRequest.setHeader(HttpHeaderNames.HOST.toString(), host.toString());
-        httpCarbonRequest.completeMessage();
-        return httpCarbonRequest;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
@@ -34,6 +34,7 @@ import org.wso2.transport.http.netty.sender.RedirectUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 
 /**
  * {@code RedirectHandler} is responsible for HTTP/2 redirection.
@@ -129,7 +130,7 @@ public class RedirectHandler implements Http2DataEventListener {
         try {
             HTTPCarbonMessage originalRequest = outboundMsgHolder.getRequest();
             String redirectionMethod = getRedirectionRequestMethod(statusCode, originalRequest);
-            String redirectionURL = RedirectUtil.getLocationURI(location, originalRequest);
+            String redirectionURL = RedirectUtil.getResolvedRedirectURI(location, originalRequest);
             HTTPCarbonMessage request =
                     RedirectUtil.createRedirectCarbonRequest(redirectionURL, redirectionMethod, userAgent);
             outboundMsgHolder.clearRedirectionState();
@@ -138,10 +139,12 @@ public class RedirectHandler implements Http2DataEventListener {
             DefaultHttpClientConnector connector = ctx.channel().attr(Constants.CLIENT_CONNECTOR).get();
             connector.send(outboundMsgHolder, request);
         } catch (UnsupportedEncodingException e) {
-            log.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
+            log.error("UnsupportedEncodingException occurred when constructing direction request",
                       e);
         } catch (MalformedURLException e) {
-            log.error("MalformedURLException occurred when deciding whether a redirection is required", e);
+            log.error("MalformedURLException occurred when constructing direction request", e);
+        } catch (URISyntaxException e) {
+            log.error("URISyntaxException occurred when constructing direction request", e);
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.sender.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Locale;
+
+/**
+ * {@code RedirectHandler} is responsible for HTTP/2 redirection.
+ */
+public class RedirectHandler implements Http2DataEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(RedirectHandler.class);
+
+    private Http2ClientChannel http2ClientChannel;
+    private int maxRedirectCount;
+
+    public RedirectHandler(Http2ClientChannel http2ClientChannel,int maxRedirectCount) {
+        this.http2ClientChannel = http2ClientChannel;
+        this.maxRedirectCount = maxRedirectCount;
+    }
+
+    @Override
+    public boolean onStreamInit(ChannelHandlerContext ctx, int streamId) {
+        return false;
+    }
+
+    @Override
+    public boolean onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream) {
+
+        OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
+
+        int statusCode = fetchStatusCode(headers);
+        if (!isRedirectionResponse(statusCode)) {
+            return true;
+        }
+        String location = fetchLocationHeaderVal(headers);
+        if (location == null) {
+            return true;
+        }
+        if (outboundMsgHolder.incrementRedirectCount() > maxRedirectCount) {
+            return true;
+        }
+        if (endOfStream) {
+            doRedirection(ctx, streamId, statusCode, outboundMsgHolder, location);
+        } else {
+            outboundMsgHolder.markForRedirection();
+            outboundMsgHolder.setRedirectResponseHeaders(headers);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream) {
+        OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
+        if (outboundMsgHolder.isMarkedForRedirection()) {
+            if (endOfStream) {
+                Http2Headers headers = outboundMsgHolder.getRedirectResponseHeaders();
+                doRedirection(
+                        ctx, streamId, fetchStatusCode(headers), outboundMsgHolder, fetchLocationHeaderVal(headers));
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onPushPromiseRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                     boolean endOfStream) {
+        return true;
+    }
+
+    @Override
+    public boolean onHeadersWrite(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream) {
+        return true;
+    }
+
+    @Override
+    public boolean onDataWrite(ChannelHandlerContext ctx, int streamId, ByteBuf data, boolean endOfStream) {
+        return true;
+    }
+
+    @Override
+    public boolean onStreamReset(int streamId) {
+        return true;
+    }
+
+    @Override
+    public boolean onStreamClose(int streamId) {
+        return true;
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    private void doRedirection(ChannelHandlerContext ctx, int streamId, int statusCode,
+                               OutboundMsgHolder outboundMsgHolder, String location) {
+        try {
+            HTTPCarbonMessage originalRequest = outboundMsgHolder.getRequest();
+            String redirectionMethod = getRedirectionRequestMethod(statusCode, originalRequest);
+            String redirectionURL = getLocationURI(location, originalRequest);
+            boolean crossDomain = isCrossDomain(location, originalRequest);
+
+            HTTPCarbonMessage request = createRedirectRequest(redirectionURL, redirectionMethod);
+            outboundMsgHolder.clearRedirectionState();
+            http2ClientChannel.removeInFlightMessage(streamId);
+
+            if (!crossDomain) {
+                outboundMsgHolder.updateRequest(request);
+                ctx.write(outboundMsgHolder);
+            }
+
+        } catch (UnsupportedEncodingException e) {
+            log.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
+                      e);
+        } catch (MalformedURLException e) {
+            log.error("MalformedURLException occurred when deciding whether a redirection is required", e);
+        }
+    }
+
+    private int fetchStatusCode(Http2Headers headers) {
+        HttpResponseStatus responseStatus;
+        try {
+            responseStatus = HttpConversionUtil.parseStatus(headers.status());
+        } catch (Http2Exception e) {
+            responseStatus = HttpResponseStatus.BAD_GATEWAY;
+        }
+        return responseStatus.code();
+    }
+
+    private String fetchLocationHeaderVal(Http2Headers headers) {
+        return headers.get(HttpHeaderNames.LOCATION) != null ? headers.get(HttpHeaderNames.LOCATION).toString() : null;
+    }
+
+    private boolean isRedirectionResponse(int statusCode) {
+        return statusCode >= 300 && statusCode < 400;
+    }
+
+    private String getRedirectionRequestMethod(int statusCode, HTTPCarbonMessage originalRequest) {
+        String originalRequestMethod =
+                originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_METHOD) : null;
+
+        switch (statusCode) {
+            case 300:
+            case 305:
+            case 307:
+            case 308:
+                if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
+                        .equals(originalRequestMethod)) {
+                    return originalRequestMethod;
+                }
+                break;
+            case 301:
+            case 302:
+                if (Constants.HTTP_GET_METHOD.equals(originalRequestMethod) || Constants.HTTP_HEAD_METHOD
+                        .equals(originalRequestMethod)) {
+                    return Constants.HTTP_GET_METHOD;
+                }
+                break;
+            case 303:
+                return Constants.HTTP_GET_METHOD;
+        }
+        return null;
+    }
+
+    /**
+     * Build redirect url from the location header value.
+     *
+     * @param location        value of location header
+     * @param originalRequest Original request
+     * @return a string that holds redirect url
+     * @throws UnsupportedEncodingException
+     */
+    private String getLocationURI(String location, HTTPCarbonMessage originalRequest)
+            throws UnsupportedEncodingException {
+        if (location != null) {
+            //if location url starts either with http ot https that means an absolute path has been set in header
+            if (!isRelativePath(location)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Location contain an absolute path : " + location);
+                }
+                return location;
+            } else {
+                //Use relative path to build redirect url
+                String requestPath =
+                        originalRequest != null ? (String) originalRequest.getProperty(Constants.TO) : null;
+                String protocol = originalRequest != null ?
+                                  (String) originalRequest.getProperty(Constants.PROTOCOL) :
+                                  Constants.HTTP_SCHEME;
+                String host = originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_HOST) :
+                              null;
+                if (host == null) {
+                    return null;
+                }
+                int defaultPort = getDefaultPort(protocol);
+                Integer port = originalRequest != null ?
+                               originalRequest.getProperty(Constants.HTTP_PORT) != null ?
+                               (Integer) originalRequest.getProperty(Constants.HTTP_PORT) :
+                               defaultPort :
+                               defaultPort;
+                return buildRedirectURL(requestPath, location, protocol, host, port);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check whether the location includes an absolute path or a relative path.
+     *
+     * @param location value of location header
+     * @return a boolean indicating url state
+     */
+    private boolean isRelativePath(String location) {
+        if (location.toLowerCase(Locale.ROOT).startsWith(Constants.HTTP_SCHEME + Constants.URL_AUTHORITY) || location
+                .toLowerCase(Locale.ROOT).startsWith(Constants.HTTPS_SCHEME + Constants.URL_AUTHORITY)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get default port based on the protocol.
+     *
+     * @param protocol http protocol
+     * @return default port as an int
+     */
+    private int getDefaultPort(String protocol) {
+        int defaultPort = Constants.HTTPS_SCHEME.equals(protocol) ?
+                          Constants.DEFAULT_HTTPS_PORT :
+                          Constants.DEFAULT_HTTP_PORT;
+
+        return defaultPort;
+    }
+
+    /**
+     * Build redirect URL from relative path.
+     *
+     * @param requestPath request path of the original request
+     * @param location    relative path received as the location
+     * @param protocol    protocol used in the request
+     * @param host        host used in the request
+     * @param port        port used in the request
+     * @return a string containing absolute path for redirection
+     * @throws UnsupportedEncodingException
+     */
+    private String buildRedirectURL(String requestPath, String location, String protocol, String host, Integer port)
+            throws UnsupportedEncodingException {
+        String newPath = requestPath == null ? Constants.FORWRD_SLASH : URLDecoder.decode(requestPath, Constants.UTF8);
+        if (location.startsWith(Constants.FORWRD_SLASH)) {
+            newPath = location;
+        } else if (newPath.endsWith(Constants.FORWRD_SLASH)) {
+            newPath += location;
+        } else {
+            newPath += Constants.FORWRD_SLASH + location;
+        }
+        StringBuilder newLocation = new StringBuilder(protocol);
+        newLocation.append(Constants.URL_AUTHORITY).append(host);
+        if (Constants.DEFAULT_HTTP_PORT != port) {
+            newLocation.append(Constants.COLON).append(port);
+        }
+        if (newPath.charAt(0) != Constants.FORWRD_SLASH.charAt(0)) {
+            newLocation.append(Constants.FORWRD_SLASH.charAt(0));
+        }
+        newLocation.append(newPath);
+        if (log.isDebugEnabled()) {
+            log.debug("Redirect URL build from relative path is : " + newLocation.toString());
+        }
+        return newLocation.toString();
+    }
+
+    /**
+     * Check whether the location indicates a cross domain.
+     *
+     * @param location        Response message
+     * @param originalRequest Original request
+     * @return a boolean to denote whether the location is cross domain or not
+     * @throws UnsupportedEncodingException
+     */
+    private boolean isCrossDomain(String location, HTTPCarbonMessage originalRequest)
+            throws UnsupportedEncodingException, MalformedURLException {
+        if (!isRelativePath(location)) {
+            try {
+                URL locationUrl = new URL(location);
+                String protocol =
+                        originalRequest != null ? (String) originalRequest.getProperty(Constants.PROTOCOL) : null;
+                String host = originalRequest != null ? (String) originalRequest.getProperty(Constants.HTTP_HOST) :
+                              null;
+                String port = originalRequest != null ?
+                              originalRequest.getProperty(Constants.HTTP_PORT) != null ?
+                              Integer.toString((Integer) originalRequest.getProperty(Constants.HTTP_PORT)) :
+                              null :
+                              null;
+                if (locationUrl.getProtocol().equals(protocol) && locationUrl.getHost().equals(host)
+                    && locationUrl.getPort() == Integer.parseInt(port)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Is cross domain url : " + false);
+                    }
+                    return false;
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Is cross domain url : " + true);
+                    }
+                    return true;
+                }
+            } catch (MalformedURLException exception) {
+                log.error("MalformedURLException occurred while deciding whether the redirect url is cross domain",
+                          exception);
+                throw exception;
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Is cross domain url : " + false);
+        }
+        return false;
+    }
+
+    /**
+     * Create redirect request.
+     *
+     * @return HTTPCarbonMessage with request properties
+     * @throws MalformedURLException
+     */
+    private HTTPCarbonMessage createRedirectRequest(String redirectionUrl, String redirectionMethod)
+            throws MalformedURLException {
+
+        URL locationUrl = new URL(redirectionUrl);
+
+        HttpMethod httpMethod = new HttpMethod(redirectionMethod);
+        HTTPCarbonMessage httpCarbonRequest = new HTTPCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, httpMethod, ""));
+        httpCarbonRequest.setProperty(
+                Constants.HTTP_PORT,
+                locationUrl.getPort() != -1 ? locationUrl.getPort() : getDefaultPort(locationUrl.getProtocol()));
+        httpCarbonRequest.setProperty(Constants.PROTOCOL, locationUrl.getProtocol());
+        httpCarbonRequest.setProperty(Constants.HTTP_HOST, locationUrl.getHost());
+        httpCarbonRequest.setProperty(Constants.HTTP_METHOD, redirectionMethod);
+        httpCarbonRequest.setProperty(Constants.REQUEST_URL, locationUrl.getPath());
+        httpCarbonRequest.setProperty(Constants.TO, locationUrl.getPath());
+
+        StringBuffer host = new StringBuffer(locationUrl.getHost());
+        if (locationUrl.getPort() != -1 && locationUrl.getPort() != Constants.DEFAULT_HTTP_PORT
+            && locationUrl.getPort() != Constants.DEFAULT_HTTPS_PORT) {
+            host.append(Constants.COLON).append(locationUrl.getPort());
+        }
+        httpCarbonRequest.setHeader(HttpHeaderNames.HOST.toString(), host.toString());
+        httpCarbonRequest.completeMessage();
+        return httpCarbonRequest;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/RedirectHandler.java
@@ -130,19 +130,13 @@ public class RedirectHandler implements Http2DataEventListener {
             HTTPCarbonMessage originalRequest = outboundMsgHolder.getRequest();
             String redirectionMethod = getRedirectionRequestMethod(statusCode, originalRequest);
             String redirectionURL = RedirectUtil.getLocationURI(location, originalRequest);
-            boolean crossDomain = RedirectUtil.isCrossDomain(location, originalRequest);
-
             HTTPCarbonMessage request =
                     RedirectUtil.createRedirectCarbonRequest(redirectionURL, redirectionMethod, userAgent);
             outboundMsgHolder.clearRedirectionState();
             http2ClientChannel.removeInFlightMessage(streamId);
             outboundMsgHolder.updateRequest(request);
-            if (crossDomain) {
-                DefaultHttpClientConnector connector = ctx.channel().attr(Constants.CLIENT_CONNECTOR).get();
-                connector.send(outboundMsgHolder, request);
-            } else {
-                ctx.write(outboundMsgHolder);
-            }
+            DefaultHttpClientConnector connector = ctx.channel().attr(Constants.CLIENT_CONNECTOR).get();
+            connector.send(outboundMsgHolder, request);
         } catch (UnsupportedEncodingException e) {
             log.error("UnsupportedEncodingException occurred when deciding whether a redirection is required",
                       e);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/TimeoutHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/TimeoutHandler.java
@@ -82,6 +82,13 @@ public class TimeoutHandler  implements Http2DataEventListener {
     }
 
     @Override
+    public boolean onPushPromiseRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                     boolean endOfStream) {
+        updateLastReadTime(streamId, endOfStream);
+        return true;
+    }
+
+    @Override
     public boolean onHeadersWrite(ChannelHandlerContext ctx, int streamId, Http2Headers headers, boolean endOfStream) {
         updateLastWriteTime(streamId);
         return true;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientConnectorBasicTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientConnectorBasicTestCase.java
@@ -33,8 +33,8 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.TestUtil;
-import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.initializers.Http2EchoServerInitializer;
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientConnectorBasicTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientConnectorBasicTestCase.java
@@ -34,7 +34,7 @@ import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
-import org.wso2.transport.http.netty.util.client.http2.RequestGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 import org.wso2.transport.http.netty.util.server.HttpServer;
 import org.wso2.transport.http.netty.util.server.initializers.Http2EchoServerInitializer;
 
@@ -67,7 +67,7 @@ public class Http2ClientConnectorBasicTestCase {
 
     @Test
     public void testHttp2Get() {
-        HTTPCarbonMessage httpCarbonMessage = RequestGenerator.generateRequest(HttpMethod.GET, null);
+        HTTPCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.GET, null);
         HTTPCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
         assertNotNull(response, "Expected response not received");
     }
@@ -75,7 +75,7 @@ public class Http2ClientConnectorBasicTestCase {
     @Test
     public void testHttp2Post() {
         String testValue = "Test Message";
-        HTTPCarbonMessage httpCarbonMessage = RequestGenerator.generateRequest(HttpMethod.POST, testValue);
+        HTTPCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
         HTTPCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
         assertNotNull(response);
         String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientTimeoutTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ClientTimeoutTestCase.java
@@ -41,7 +41,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.util.HTTPConnectorListener;
 import org.wso2.transport.http.netty.util.TestUtil;
-import org.wso2.transport.http.netty.util.client.http2.RequestGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -87,7 +87,7 @@ public class Http2ClientTimeoutTestCase {
 
     @Test
     public void testHttp2ClientTimeout() {
-        HTTPCarbonMessage request = RequestGenerator.generateRequest(HttpMethod.POST, "test");
+        HTTPCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, "test");
         try {
             CountDownLatch latch = new CountDownLatch(1);
             HTTPConnectorListener listener = new HTTPConnectorListener(latch);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2RedirectionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2RedirectionTestCase.java
@@ -93,6 +93,7 @@ public class Http2RedirectionTestCase {
     @AfterClass
     public void cleanUp() {
         senderConfiguration.setHttpVersion(String.valueOf(Constants.HTTP_1_1));
+        senderConfiguration.setFollowRedirect(false);
         httpClientConnector.close();
         serverConnector.stop();
         try {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerConnectorBasicTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerConnectorBasicTestCase.java
@@ -38,8 +38,8 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.TestUtil;
-import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerPushTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerPushTestCase.java
@@ -41,7 +41,7 @@ import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.message.ResponseHandle;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
-import org.wso2.transport.http.netty.util.client.http2.RequestGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -93,7 +93,7 @@ public class Http2ServerPushTestCase {
     public void testHttp2ServerPush() {
         MessageSender msgSender = new MessageSender(httpClientConnector);
 
-        HTTPCarbonMessage request = RequestGenerator.generateRequest(HttpMethod.POST, expectedResource);
+        HTTPCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, expectedResource);
         // Submit a request and get the handle
         ResponseHandle handle = msgSender.submitMessage(request);
         assertNotNull(handle, "Response handle not found");

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerPushTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ServerPushTestCase.java
@@ -40,8 +40,8 @@ import org.wso2.transport.http.netty.message.Http2PushPromise;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.message.ResponseHandle;
 import org.wso2.transport.http.netty.util.TestUtil;
-import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2WithPriorKnowledgeTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2WithPriorKnowledgeTestCase.java
@@ -39,7 +39,7 @@ import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
-import org.wso2.transport.http.netty.util.client.http2.RequestGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -82,7 +82,7 @@ public class Http2WithPriorKnowledgeTestCase {
     @Test
     public void testHttp2WithPriorKnowledge() {
         String testValue = "Test Message";
-        HTTPCarbonMessage httpCarbonMessage = RequestGenerator.generateRequest(HttpMethod.POST, testValue);
+        HTTPCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
         HTTPCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
         assertNotNull(response, "Expected response not received");
         String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2WithPriorKnowledgeTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2WithPriorKnowledgeTestCase.java
@@ -38,8 +38,8 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.TestUtil;
-import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2RedirectListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2RedirectListener.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.listeners;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.contract.HttpConnectorListener;
+import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpCarbonResponse;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * {@code Http2RedirectListener} is a HttpConnectorListener which receives messages and respond back with
+ * redirect response messages.
+ */
+public class Http2RedirectListener implements HttpConnectorListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(Http2RedirectListener.class);
+
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private int numberOfRedirects = 0;
+    private String expectedResponse;
+
+    private int redirectCount = 0;
+    private final String baseLocation = "/resource";
+
+    public Http2RedirectListener(int numberOfRedirects, String expectedResponse) {
+        this.numberOfRedirects = numberOfRedirects;
+        this.expectedResponse = expectedResponse;
+    }
+
+    @Override
+    public void onMessage(HTTPCarbonMessage httpRequest) {
+        executor.execute(() -> {
+            try {
+                if (redirectCount < numberOfRedirects) {
+                    if (redirectCount != 0) {
+                        String url = (String) httpRequest.getProperty(Constants.TO);
+                        if (!url.contains(baseLocation.concat(String.valueOf(redirectCount)))) {
+                            HttpResponseFuture responseFuture =
+                                    httpRequest.respond(MessageGenerator.generateResponse("Error:Incorrect location"));
+                            responseFuture.sync();
+                            return;
+                        }
+                    }
+                    redirectCount++;
+                    HTTPCarbonMessage response =
+                            MessageGenerator.generateResponse(null, HttpResponseStatus.MOVED_PERMANENTLY);
+                    response.setHeader(HttpHeaderNames.LOCATION.toString(),
+                                       baseLocation.concat(String.valueOf(redirectCount)));
+                    HttpResponseFuture responseFuture = httpRequest.respond(response);
+                    responseFuture.sync();
+                } else {
+                    // Send the intended response message
+                    HttpResponseFuture responseFuture =
+                            httpRequest.respond(MessageGenerator.generateResponse(expectedResponse));
+                    responseFuture.sync();
+                    Throwable error = responseFuture.getStatus().getCause();
+                    if (error != null) {
+                        responseFuture.resetStatus();
+                        logger.error("Error occurred while sending the response " + error.getMessage());
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Error occurred while processing message: " + e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2RedirectListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2RedirectListener.java
@@ -19,24 +19,16 @@
 
 package org.wso2.transport.http.netty.http2.listeners;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
-import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2ServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2ServerConnectorListener.java
@@ -19,13 +19,6 @@
 
 package org.wso2.transport.http.netty.http2.listeners;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
@@ -33,11 +26,8 @@ import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.Http2PushPromise;
-import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
@@ -45,6 +45,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.sender.RedirectHandler;
+import org.wso2.transport.http.netty.sender.RedirectUtil;
 import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
@@ -310,8 +311,8 @@ public class HttpClientRedirectTestCase {
     public void relativePathStartsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "/redirect1", createHttpRequest(
@@ -334,8 +335,8 @@ public class HttpClientRedirectTestCase {
     public void relativePathEndsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "redirect1/", createHttpRequest(
@@ -358,8 +359,8 @@ public class HttpClientRedirectTestCase {
     public void justRelativePathName() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "redirect1", createHttpRequest(
@@ -382,8 +383,8 @@ public class HttpClientRedirectTestCase {
     public void requestPathEndsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "/redirect1", createHttpRequest(
@@ -404,8 +405,8 @@ public class HttpClientRedirectTestCase {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0,
                 this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "https://localhost:8888/test?key=value&tt=kk",
@@ -426,8 +427,8 @@ public class HttpClientRedirectTestCase {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0,
                 this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "/test?key=value&tt=kk", createHttpRequest(
@@ -448,8 +449,8 @@ public class HttpClientRedirectTestCase {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0,
                 this.connectionManager);
         try {
-            Method method = RedirectHandler.class
-                    .getDeclaredMethod("getResolvedURI", String.class, HTTPCarbonMessage.class);
+            Method method = RedirectUtil.class
+                    .getDeclaredMethod("getResolvedRedirectURI", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             String redirectUrl = (String) method
                     .invoke(redirectHandler, "/test", createHttpRequest(

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
@@ -45,7 +45,6 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.sender.RedirectHandler;
-import org.wso2.transport.http.netty.sender.RedirectUtil;
 import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
@@ -264,7 +263,7 @@ public class HttpClientRedirectTestCase {
     public void unitTestToDetermineCrossDomainURLs() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectUtil.class
+            Method method = RedirectHandler.class
                     .getDeclaredMethod("isCrossDomain", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             boolean isCrossDomainURL = (boolean) method
@@ -289,7 +288,7 @@ public class HttpClientRedirectTestCase {
     public void unitTestForSameDomain() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectUtil.class
+            Method method = RedirectHandler.class
                     .getDeclaredMethod("isCrossDomain", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             boolean isCrossDomainURL = (boolean) method

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/redirect/HttpClientRedirectTestCase.java
@@ -45,6 +45,7 @@ import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.sender.RedirectHandler;
+import org.wso2.transport.http.netty.sender.RedirectUtil;
 import org.wso2.transport.http.netty.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.sender.channel.TargetChannel;
 import org.wso2.transport.http.netty.sender.channel.pool.ConnectionManager;
@@ -263,7 +264,7 @@ public class HttpClientRedirectTestCase {
     public void unitTestToDetermineCrossDomainURLs() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("isCrossDomain", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             boolean isCrossDomainURL = (boolean) method
@@ -288,7 +289,7 @@ public class HttpClientRedirectTestCase {
     public void unitTestForSameDomain() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("isCrossDomain", String.class, HTTPCarbonMessage.class);
             method.setAccessible(true);
             boolean isCrossDomainURL = (boolean) method
@@ -310,7 +311,7 @@ public class HttpClientRedirectTestCase {
     public void relativePathStartsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("buildRedirectURL", String.class, String.class, String.class, String.class,
                             Integer.class);
             method.setAccessible(true);
@@ -334,7 +335,7 @@ public class HttpClientRedirectTestCase {
     public void relativePathEndsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("buildRedirectURL", String.class, String.class, String.class, String.class,
                             Integer.class);
             method.setAccessible(true);
@@ -358,7 +359,7 @@ public class HttpClientRedirectTestCase {
     public void justRelativePathName() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("buildRedirectURL", String.class, String.class, String.class, String.class,
                             Integer.class);
             method.setAccessible(true);
@@ -382,7 +383,7 @@ public class HttpClientRedirectTestCase {
     public void requestPathEndsWithSlash() {
         RedirectHandler redirectHandler = new RedirectHandler(null, false, 0, this.connectionManager);
         try {
-            Method method = RedirectHandler.class
+            Method method = RedirectUtil.class
                     .getDeclaredMethod("buildRedirectURL", String.class, String.class, String.class, String.class,
                             Integer.class);
             method.setAccessible(true);

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -70,7 +70,6 @@
             <class name="org.wso2.transport.http.netty.http2.Http2ServerPushTestCase" />
             <class name="org.wso2.transport.http.netty.http2.Http2ClientTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.http2.Http2WithPriorKnowledgeTestCase" />
-            <class name="org.wso2.transport.http.netty.http2.Http2RedirectionTestCase" />
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.urilengthvalidation.Status414And413ResponseTest"/>
             <class name="org.wso2.transport.http.netty.http1point0test.HttpOnePointZeroServerConnectorTestCase"/>

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -70,6 +70,7 @@
             <class name="org.wso2.transport.http.netty.http2.Http2ServerPushTestCase" />
             <class name="org.wso2.transport.http.netty.http2.Http2ClientTimeoutTestCase" />
             <class name="org.wso2.transport.http.netty.http2.Http2WithPriorKnowledgeTestCase" />
+            <class name="org.wso2.transport.http.netty.http2.Http2RedirectionTestCase" />
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.urilengthvalidation.Status414And413ResponseTest"/>
             <class name="org.wso2.transport.http.netty.http1point0test.HttpOnePointZeroServerConnectorTestCase"/>


### PR DESCRIPTION
## Purpose
Redirection is not working for HTTP/2 with the existing RedirectionHandler. So need to introduce redirection functionality to HTTP/2

## Goals
Add Redirection support for HTTP/2 

## Approach
Added a new Http2DataEventListener to handle HTTP/2 redirection.

## User stories

## Release note

## Documentation

## Training


## Certification


## Marketing


## Automation tests
 - Unit tests 
  Included in the PR.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
JDK 1.8
 
## Learning
