### PR TITLE
Throttle READ for inbound entity body

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -39,7 +40,9 @@ import org.wso2.transport.http.netty.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.config.ChunkConfig;
 import org.wso2.transport.http.netty.config.Parameter;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
+import org.wso2.transport.http.netty.message.DefaultListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.Listener;
 
 import java.io.File;
 import java.io.IOException;
@@ -619,5 +622,16 @@ public class Util {
                 outboundRespStatusFuture.notifyHttpListener(throwable);
             }
         });
+    }
+
+    /**
+     * **************************.
+     *
+     * @param httpMessage the future of outbound response write operation
+     * @param ctx            the channel future related to response write operation
+     */
+    public static HTTPCarbonMessage createHTTPCarbonMessage(HttpMessage httpMessage, ChannelHandlerContext ctx) {
+        Listener contentListener = new DefaultListener(ctx);
+        return new HTTPCarbonMessage(httpMessage, contentListener);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketInitMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketInitMessage.java
@@ -156,6 +156,7 @@ public class DefaultWebSocketInitMessage extends WebSocketMessageImpl implements
                 pipeline.addLast(Constants.WEBSOCKET_SOURCE_HANDLER, webSocketSourceHandler);
                 pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
                 setProperty(Constants.SRC_HANDLER, webSocketSourceHandler);
+                pipeline.fireChannelActive();
                 handshakeFuture.notifySuccess(webSocketSourceHandler.getChannelSession());
             });
             handshakeStarted = true;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -44,6 +44,7 @@ import org.wso2.transport.http.netty.common.Util;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.Http2OutboundRespListener;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
+import org.wso2.transport.http.netty.message.DefaultListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonRequest;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
@@ -220,7 +221,7 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
      * @return the CarbonRequest Message created from given HttpRequest
      */
     private HttpCarbonRequest setupCarbonRequest(HttpRequest httpRequest) {
-        HttpCarbonRequest sourceReqCMsg = new HttpCarbonRequest(httpRequest, ctx);
+        HttpCarbonRequest sourceReqCMsg = new HttpCarbonRequest(httpRequest, new DefaultListener(ctx));
         sourceReqCMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
         sourceReqCMsg.setProperty(Constants.CHNL_HNDLR_CTX, this.ctx);
         HttpVersion protocolVersion = httpRequest.protocolVersion();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/Http2SourceHandler.java
@@ -220,7 +220,7 @@ public final class Http2SourceHandler extends Http2ConnectionHandler {
      * @return the CarbonRequest Message created from given HttpRequest
      */
     private HttpCarbonRequest setupCarbonRequest(HttpRequest httpRequest) {
-        HttpCarbonRequest sourceReqCMsg = new HttpCarbonRequest(httpRequest);
+        HttpCarbonRequest sourceReqCMsg = new HttpCarbonRequest(httpRequest, ctx);
         sourceReqCMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
         sourceReqCMsg.setProperty(Constants.CHNL_HNDLR_CTX, this.ctx);
         HttpVersion protocolVersion = httpRequest.protocolVersion();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/MaxEntityBodyValidator.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/MaxEntityBodyValidator.java
@@ -60,6 +60,7 @@ public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
                 if (isContentLengthInvalid(inboundRequest, maxEntityBodySize)) {
                     sendEntityTooLargeResponse(ctx);
                 }
+                ctx.channel().read();
             } else {
                 HttpContent inboundContent = (HttpContent) msg;
                 this.currentSize += inboundContent.content().readableBytes();
@@ -72,6 +73,8 @@ public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
                         while (!this.fullContent.isEmpty()) {
                             super.channelRead(ctx, this.fullContent.pop());
                         }
+                    } else {
+                        ctx.channel().read();
                     }
                 }
             }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
@@ -121,12 +121,14 @@ public class ServerConnectorBootstrap {
         serverBootstrap.childOption(ChannelOption.TCP_NODELAY, serverBootstrapConfiguration.isTcpNoDelay());
         serverBootstrap.childOption(ChannelOption.SO_RCVBUF, serverBootstrapConfiguration.getReceiveBufferSize());
         serverBootstrap.childOption(ChannelOption.SO_SNDBUF, serverBootstrapConfiguration.getSendBufferSize());
+        serverBootstrap.childOption(ChannelOption.AUTO_READ, false);
 
         log.debug("Netty Server Socket BACKLOG " + serverBootstrapConfiguration.getSoBackLog());
         log.debug("Netty Server Socket TCP_NODELAY " + serverBootstrapConfiguration.isTcpNoDelay());
         log.debug("Netty Server Socket CONNECT_TIMEOUT_MILLIS " + serverBootstrapConfiguration.getConnectTimeOut());
         log.debug("Netty Server Socket SO_RCVBUF " + serverBootstrapConfiguration.getReceiveBufferSize());
         log.debug("Netty Server Socket SO_SNDBUF " + serverBootstrapConfiguration.getSendBufferSize());
+        log.debug("Netty Server Socket AUTO_READ " + false);
     }
 
     public void addSecurity(SSLConfig sslConfig) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/ServerConnectorBootstrap.java
@@ -74,19 +74,6 @@ public class ServerConnectorBootstrap {
 
         return serverBootstrap
                 .bind(new InetSocketAddress(serverConnector.getHost(), serverConnector.getPort()));
-
-        // TODO: Fix this with HTTP2
-//            ListenerConfiguration listenerConfiguration = serverConnector.getListenerConfiguration();
-//            SslContext http2sslContext = null;
-//            // Create HTTP/2 ssl context during interface binding.
-//            if (listenerConfiguration.isHttp2() && listenerConfiguration.getSSLConfig() != null) {
-//                http2sslContext = new SSLHandlerFactory(listenerConfiguration.getSSLConfig())
-//                        .createHttp2TLSContext();
-//            }
-
-//            httpServerChannelInitializer.registerListenerConfig(listenerConfiguration, http2sslContext);
-//            httpServerChannelInitializer.setSslContext(http2sslContext);
-//            httpServerChannelInitializer.setServerConnectorFuture(serverConnector.getServerConnectorFuture());
     }
 
     private boolean unBindInterface(HTTPServerConnector serverConnector) throws InterruptedException {
@@ -121,14 +108,17 @@ public class ServerConnectorBootstrap {
         serverBootstrap.childOption(ChannelOption.TCP_NODELAY, serverBootstrapConfiguration.isTcpNoDelay());
         serverBootstrap.childOption(ChannelOption.SO_RCVBUF, serverBootstrapConfiguration.getReceiveBufferSize());
         serverBootstrap.childOption(ChannelOption.SO_SNDBUF, serverBootstrapConfiguration.getSendBufferSize());
-        serverBootstrap.childOption(ChannelOption.AUTO_READ, false);
 
-        log.debug("Netty Server Socket BACKLOG " + serverBootstrapConfiguration.getSoBackLog());
-        log.debug("Netty Server Socket TCP_NODELAY " + serverBootstrapConfiguration.isTcpNoDelay());
-        log.debug("Netty Server Socket CONNECT_TIMEOUT_MILLIS " + serverBootstrapConfiguration.getConnectTimeOut());
-        log.debug("Netty Server Socket SO_RCVBUF " + serverBootstrapConfiguration.getReceiveBufferSize());
-        log.debug("Netty Server Socket SO_SNDBUF " + serverBootstrapConfiguration.getSendBufferSize());
-        log.debug("Netty Server Socket AUTO_READ " + false);
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Netty Server Socket BACKLOG %d", serverBootstrapConfiguration.getSoBackLog()));
+            log.debug(String.format("Netty Server Socket TCP_NODELAY %s", serverBootstrapConfiguration.isTcpNoDelay()));
+            log.debug(String.format("Netty Server Socket CONNECT_TIMEOUT_MILLIS %d",
+                                    serverBootstrapConfiguration.getConnectTimeOut()));
+            log.debug(String.format("Netty Server Socket SO_RCVBUF %d",
+                                    serverBootstrapConfiguration.getReceiveBufferSize()));
+            log.debug(String.format("Netty Server Socket SO_SNDBUF %d",
+                                    serverBootstrapConfiguration.getSendBufferSize()));
+        }
     }
 
     public void addSecurity(SSLConfig sslConfig) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -104,6 +104,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         }
         this.ctx = ctx;
         this.remoteAddress = ctx.channel().remoteAddress();
+        ctx.channel().read();
     }
 
     @SuppressWarnings("unchecked")

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -97,7 +97,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         allChannels.add(ctx.channel());
-        System.out.println("Channel active");
         // Start the server connection Timer
         this.handlerExecutor = HTTPTransportContextHolder.getInstance().getHandlerExecutor();
         if (this.handlerExecutor != null) {
@@ -105,15 +104,12 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         }
         this.ctx = ctx;
         this.remoteAddress = ctx.channel().remoteAddress();
-        ctx.channel().config().setAutoRead(false);
-        ctx.channel().read();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpRequest) {
-            System.out.println("Channel Read request");
             HttpRequest httpRequest = (HttpRequest) msg;
             sourceReqCmsg = setupCarbonMessage(httpRequest, ctx);
             notifyRequestListener(sourceReqCmsg, ctx);
@@ -121,12 +117,10 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             if (httpRequest.decoderResult().isFailure()) {
                 log.warn(httpRequest.decoderResult().cause().getMessage());
             }
-            ctx.channel().read();
         } else {
             if (sourceReqCmsg != null) {
                 if (msg instanceof HttpContent) {
                     HttpContent httpContent = (HttpContent) msg;
-                    System.out.println("Channel Read content");
                     sourceReqCmsg.addHttpContent(httpContent);
                     if (Util.isLastHttpContent(httpContent)) {
                         if (handlerExecutor != null) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -147,7 +147,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             handlerExecutor.executeAtSourceRequestReceiving(sourceReqCmsg);
         }
 
-        sourceReqCmsg = new HttpCarbonRequest((HttpRequest) httpMessage);
+        sourceReqCmsg = new HttpCarbonRequest((HttpRequest) httpMessage, ctx);
         sourceReqCmsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
 
         HttpRequest httpRequest = (HttpRequest) httpMessage;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -47,6 +47,7 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contractimpl.HttpOutboundRespListener;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
+import org.wso2.transport.http.netty.message.DefaultListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonRequest;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
@@ -146,7 +147,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             handlerExecutor.executeAtSourceRequestReceiving(sourceReqCmsg);
         }
 
-        sourceReqCmsg = new HttpCarbonRequest((HttpRequest) httpMessage, ctx);
+        sourceReqCmsg = new HttpCarbonRequest((HttpRequest) httpMessage, new DefaultListener(ctx));
         sourceReqCmsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
 
         HttpRequest httpRequest = (HttpRequest) httpMessage;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -64,8 +64,10 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
             String httpMethod = httpRequest.method().name();
             if (httpMethod.equalsIgnoreCase("GET") && isConnectionUpgrade(headers) &&
                     Constants.WEBSOCKET_UPGRADE.equalsIgnoreCase(headers.get(HttpHeaderNames.UPGRADE))) {
-                log.debug("Upgrading the connection from Http to WebSocket for " +
-                                  "channel : " + ctx.channel());
+                if (log.isDebugEnabled()) {
+                    log.debug("Upgrading the connection from Http to WebSocket for " +
+                                      "channel : " + ctx.channel());
+                }
                 ChannelPipeline pipeline = ctx.pipeline();
                 ChannelHandlerContext decoderCtx = pipeline.context(HttpRequestDecoder.class);
                 String aggregatorName = "aggregate";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
@@ -101,7 +101,6 @@ public class WebSocketSourceHandler extends ChannelInboundHandlerAdapter {
         if (this.handlerExecutor != null) {
             this.handlerExecutor.executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
         }
-        ctx.channel().read();
     }
 
     /**
@@ -167,7 +166,6 @@ public class WebSocketSourceHandler extends ChannelInboundHandlerAdapter {
         } else if (msg instanceof PongWebSocketFrame) {
             notifyPongMessage((PongWebSocketFrame) msg);
         }
-        ctx.channel().read();
     }
 
     private void notifyTextMessage(TextWebSocketFrame textWebSocketFrame) throws ServerConnectorException {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
@@ -101,6 +101,7 @@ public class WebSocketSourceHandler extends ChannelInboundHandlerAdapter {
         if (this.handlerExecutor != null) {
             this.handlerExecutor.executeAtSourceConnectionInitiation(Integer.toString(ctx.hashCode()));
         }
+        ctx.channel().read();
     }
 
     /**
@@ -166,6 +167,7 @@ public class WebSocketSourceHandler extends ChannelInboundHandlerAdapter {
         } else if (msg instanceof PongWebSocketFrame) {
             notifyPongMessage((PongWebSocketFrame) msg);
         }
+        ctx.channel().read();
     }
 
     private void notifyTextMessage(TextWebSocketFrame textWebSocketFrame) throws ServerConnectorException {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.handler.codec.http.HttpContent;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Default implementation of the message Listener.
+ */
+public class DefaultListener implements Listener {
+
+    private static final int MAXIMUM_BYTE_SIZE = 2;
+    private int cumulativeQuantity = 0;
+//    private Semaphore executionWaitSem;
+
+    @Override
+    public void onAdd(HttpContent httpContent) {
+        this.cumulativeQuantity += httpContent.content().readableBytes();
+        if (this.cumulativeQuantity > MAXIMUM_BYTE_SIZE) {
+            //stop reading
+//            executionWaitSem = new Semaphore(0);
+//            try {
+//                executionWaitSem.acquire();
+//            } catch (InterruptedException e) {
+//                e.printStackTrace();
+//            }
+        }
+    }
+
+    @Override
+    public void onRemove(HttpContent httpContent) {
+        this.cumulativeQuantity -= httpContent.content().readableBytes();
+        if (this.cumulativeQuantity < MAXIMUM_BYTE_SIZE) {
+            // start reading
+//            if (executionWaitSem != null) {
+//                executionWaitSem.release();
+//            }
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
@@ -29,7 +29,6 @@ public class DefaultObservable implements Observable {
 
     @Override
     public void setListener(Listener listener) {
-        System.out.println("setListener");
         this.listener = listener;
     }
 
@@ -40,22 +39,14 @@ public class DefaultObservable implements Observable {
 
     @Override
     public void notifyAddListener(HttpContent httpContent) {
-        System.out.println("onAdd---------------");
-
         if (listener != null) {
-            System.out.println("onAdd within if");
-
             listener.onAdd(httpContent);
         }
     }
 
     @Override
     public void notifyGetListener(HttpContent httpContent) {
-        System.out.println("onRemove---------------");
-
         if (listener != null) {
-            System.out.println("onRemove within if");
-
             listener.onRemove(httpContent);
         }
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
@@ -29,6 +29,7 @@ public class DefaultObservable implements Observable {
 
     @Override
     public void setListener(Listener listener) {
+        System.out.println("setListener");
         this.listener = listener;
     }
 
@@ -39,14 +40,22 @@ public class DefaultObservable implements Observable {
 
     @Override
     public void notifyAddListener(HttpContent httpContent) {
+        System.out.println("onAdd---------------");
+
         if (listener != null) {
+            System.out.println("onAdd within if");
+
             listener.onAdd(httpContent);
         }
     }
 
     @Override
     public void notifyGetListener(HttpContent httpContent) {
+        System.out.println("onRemove---------------");
+
         if (listener != null) {
+            System.out.println("onRemove within if");
+
             listener.onRemove(httpContent);
         }
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultObservable.java
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * Default implementation of the message observer.
+ */
+public class DefaultObservable implements Observable {
+
+    private Listener listener;
+
+    @Override
+    public void setListener(Listener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void removeListener() {
+        this.listener = null;
+    }
+
+    @Override
+    public void notifyAddListener(HttpContent httpContent) {
+        if (listener != null) {
+            listener.onAdd(httpContent);
+        }
+    }
+
+    @Override
+    public void notifyGetListener(HttpContent httpContent) {
+        if (listener != null) {
+            listener.onRemove(httpContent);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -52,15 +52,18 @@ public class HTTPCarbonMessage {
     private final ServerConnectorFuture httpOutboundRespFuture = new HttpWsServerConnectorFuture();
     private final DefaultHttpResponseFuture httpOutboundRespStatusFuture = new DefaultHttpResponseFuture();
     private final Observable contentObservable = new DefaultObservable();
+    private final Listener contentListener = new DefaultListener();
 
     public HTTPCarbonMessage(HttpMessage httpMessage) {
         this.httpMessage = httpMessage;
         setBlockingEntityCollector(new BlockingEntityCollector(Constants.ENDPOINT_TIMEOUT));
+        this.contentObservable.setListener(contentListener);
     }
 
     public HTTPCarbonMessage(HttpMessage httpMessage, int maxWaitTime) {
         this.httpMessage = httpMessage;
         setBlockingEntityCollector(new BlockingEntityCollector(maxWaitTime));
+        this.contentObservable.setListener(contentListener);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -52,18 +52,22 @@ public class HTTPCarbonMessage {
     private final ServerConnectorFuture httpOutboundRespFuture = new HttpWsServerConnectorFuture();
     private final DefaultHttpResponseFuture httpOutboundRespStatusFuture = new DefaultHttpResponseFuture();
     private final Observable contentObservable = new DefaultObservable();
-    private final Listener contentListener = new DefaultListener();
 
-    public HTTPCarbonMessage(HttpMessage httpMessage) {
+    public HTTPCarbonMessage(HttpMessage httpMessage, Listener contentListener) {
         this.httpMessage = httpMessage;
         setBlockingEntityCollector(new BlockingEntityCollector(Constants.ENDPOINT_TIMEOUT));
         this.contentObservable.setListener(contentListener);
     }
 
-    public HTTPCarbonMessage(HttpMessage httpMessage, int maxWaitTime) {
+    public HTTPCarbonMessage(HttpMessage httpMessage, int maxWaitTime, Listener contentListener) {
         this.httpMessage = httpMessage;
         setBlockingEntityCollector(new BlockingEntityCollector(maxWaitTime));
         this.contentObservable.setListener(contentListener);
+    }
+
+    public HTTPCarbonMessage(HttpMessage httpMessage) {
+        this.httpMessage = httpMessage;
+        setBlockingEntityCollector(new BlockingEntityCollector(Constants.ENDPOINT_TIMEOUT));
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonRequest.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonRequest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.message;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
@@ -31,6 +32,11 @@ public class HttpCarbonRequest extends HTTPCarbonMessage {
 
     public HttpCarbonRequest(HttpRequest httpRequest) {
         super(httpRequest);
+        this.httpRequest = (HttpRequest) this.httpMessage;
+    }
+
+    public HttpCarbonRequest(HttpRequest httpRequest, ChannelHandlerContext ctx) {
+        super(httpRequest, new DefaultListener(ctx));
         this.httpRequest = (HttpRequest) this.httpMessage;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonRequest.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonRequest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
@@ -35,8 +34,8 @@ public class HttpCarbonRequest extends HTTPCarbonMessage {
         this.httpRequest = (HttpRequest) this.httpMessage;
     }
 
-    public HttpCarbonRequest(HttpRequest httpRequest, ChannelHandlerContext ctx) {
-        super(httpRequest, new DefaultListener(ctx));
+    public HttpCarbonRequest(HttpRequest httpRequest, Listener listener) {
+        super(httpRequest, listener);
         this.httpRequest = (HttpRequest) this.httpMessage;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonResponse.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonResponse.java
@@ -18,7 +18,6 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -34,8 +33,8 @@ public class HttpCarbonResponse extends HTTPCarbonMessage {
         this.httpResponse = (HttpResponse) this.httpMessage;
     }
 
-    public HttpCarbonResponse(HttpResponse httpResponse, ChannelHandlerContext ctx) {
-        super(httpResponse, new DefaultListener(ctx));
+    public HttpCarbonResponse(HttpResponse httpResponse, Listener listener) {
+        super(httpResponse, listener);
         this.httpResponse = (HttpResponse) this.httpMessage;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonResponse.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonResponse.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.message;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -30,6 +31,11 @@ public class HttpCarbonResponse extends HTTPCarbonMessage {
 
     public HttpCarbonResponse(HttpResponse httpResponse) {
         super(httpResponse);
+        this.httpResponse = (HttpResponse) this.httpMessage;
+    }
+
+    public HttpCarbonResponse(HttpResponse httpResponse, ChannelHandlerContext ctx) {
+        super(httpResponse, new DefaultListener(ctx));
         this.httpResponse = (HttpResponse) this.httpMessage;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/Listener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/Listener.java
@@ -1,0 +1,37 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * Get notified upon receiving new messages.
+ */
+public interface Listener {
+
+    /**
+     * Get notified when content are added to the message.
+     */
+    void onAdd(HttpContent httpContent);
+
+    /**
+     * Get notified when content is removed from the the message.
+     */
+    void onRemove(HttpContent httpContent);
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/Observable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/Observable.java
@@ -1,0 +1,48 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * Allows listeners to register and get notified.
+ */
+public interface Observable {
+
+    /**
+     * Set listener interested for message events.
+     * @param listener for message
+     */
+    void setListener(Listener listener);
+
+    /**
+     * Remove listener from the observable.
+     */
+    void removeListener();
+
+    /**
+     * Notify when content is added to message.
+     */
+    void notifyAddListener(HttpContent content);
+
+    /**
+     * Notify when content is removed from message.
+     */
+    void notifyGetListener(HttpContent content);
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -39,6 +39,7 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.exception.EndpointTimeOutException;
 import org.wso2.transport.http.netty.internal.HTTPTransportContextHolder;
 import org.wso2.transport.http.netty.internal.HandlerExecutor;
+import org.wso2.transport.http.netty.message.DefaultListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
@@ -129,7 +130,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     }
 
     private HTTPCarbonMessage setUpCarbonMessage(ChannelHandlerContext ctx, Object msg) {
-        targetRespMsg = new HttpCarbonResponse((HttpResponse) msg, ctx);
+        targetRespMsg = new HttpCarbonResponse((HttpResponse) msg, new DefaultListener(ctx));
         targetRespMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
 
         targetRespMsg.setProperty(Constants.DIRECTION, Constants.DIRECTION_RESPONSE);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -72,8 +72,6 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         }
 
         super.channelActive(ctx);
-        ctx.channel().config().setAutoRead(false);
-        ctx.channel().read();
     }
 
     @SuppressWarnings("unchecked")
@@ -102,7 +100,6 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                 if (httpInboundResponse.decoderResult().isFailure()) {
                     log.warn(httpInboundResponse.decoderResult().cause().getMessage());
                 }
-                ctx.channel().read();
             } else {
                 if (targetRespMsg != null) {
                     HttpContent httpContent = (HttpContent) msg;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -129,7 +129,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     }
 
     private HTTPCarbonMessage setUpCarbonMessage(ChannelHandlerContext ctx, Object msg) {
-        targetRespMsg = new HttpCarbonResponse((HttpResponse) msg);
+        targetRespMsg = new HttpCarbonResponse((HttpResponse) msg, ctx);
         targetRespMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));
 
         targetRespMsg.setProperty(Constants.DIRECTION, Constants.DIRECTION_RESPONSE);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -72,6 +72,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
         }
 
         super.channelActive(ctx);
+        ctx.channel().config().setAutoRead(false);
+        ctx.channel().read();
     }
 
     @SuppressWarnings("unchecked")
@@ -100,6 +102,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
                 if (httpInboundResponse.decoderResult().isFailure()) {
                     log.warn(httpInboundResponse.decoderResult().cause().getMessage());
                 }
+                ctx.channel().read();
             } else {
                 if (targetRespMsg != null) {
                     HttpContent httpContent = (HttpContent) msg;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.common.Constants;
 import org.wso2.transport.http.netty.common.Util;
+import org.wso2.transport.http.netty.message.DefaultListener;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
 import org.wso2.transport.http.netty.message.Http2PushPromise;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
@@ -216,7 +217,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
                     notifyHttpListener(new Exception("Error while setting http headers", e));
         }
         // Create HTTP Carbon Response
-        HttpCarbonResponse responseCarbonMsg = new HttpCarbonResponse(httpResponse, ctx);
+        HttpCarbonResponse responseCarbonMsg = new HttpCarbonResponse(httpResponse, new DefaultListener(ctx));
 
         // Setting properties of the HTTP Carbon Response
         responseCarbonMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientInboundHandler.java
@@ -216,7 +216,7 @@ public class ClientInboundHandler extends Http2EventAdapter {
                     notifyHttpListener(new Exception("Error while setting http headers", e));
         }
         // Create HTTP Carbon Response
-        HttpCarbonResponse responseCarbonMsg = new HttpCarbonResponse(httpResponse);
+        HttpCarbonResponse responseCarbonMsg = new HttpCarbonResponse(httpResponse, ctx);
 
         // Setting properties of the HTTP Carbon Response
         responseCarbonMsg.setProperty(Constants.POOLED_BYTE_BUFFER_FACTORY, new PooledDataStreamerFactory(ctx.alloc()));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/forwardedextension/ForwardedClientTemplate.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/forwardedextension/ForwardedClientTemplate.java
@@ -77,7 +77,7 @@ public class ForwardedClientTemplate {
         httpMessageDataStreamer.getOutputStream().write("test".getBytes());
         httpMessageDataStreamer.getOutputStream().close();
 
-        latch.await(5, TimeUnit.SECONDS);
+        latch.await(15, TimeUnit.SECONDS);
 
         HTTPCarbonMessage response = listener.getHttpResponseMessage();
         TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/7291
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/7371
> Set a threshold of MAXIMUM_BYTE_SIZE = 2MB when reading the content to the carbon message.

## Goals
> Prevent OOM error occurs due to unlimited reading

## Approach
> Observe carbon message content add/remove through a listener and pause channel read when the upper limit is reached. 