### PR TITLE
Include ultimate request url in the response when redirect is on

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -140,6 +140,7 @@ public final class Constants {
     public static final String TLS_STORE_TYPE = "tlsStoreType";
 
     public static final String HTTP_STATUS_CODE = "HTTP_STATUS_CODE";
+    public static final String RESOLVED_REQUESTED_URI = "RESOLVED_REQUESTED_URI";
 
     public static final String HTTP_REASON_PHRASE = "HTTP_REASON_PHRASE";
 
@@ -232,24 +233,20 @@ public final class Constants {
     public static final String HTTP_ACCESS_LOG_HANDLER = "http-access-logger";
     public static final String WEBSOCKET_SERVER_HANDSHAKE_HANDLER = "websocket-server-handshake-handler";
 
-    public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf
-            ("REDIRECT_COUNT");
-    public static final AttributeKey<HTTPCarbonMessage> ORIGINAL_REQUEST = AttributeKey.valueOf
-            ("ORIGINAL_REQUEST");
+    public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf("REDIRECT_COUNT");
+    public static final AttributeKey<String> RESOLVED_REQUESTED_URI_ATTR = AttributeKey
+            .valueOf("RESOLVED_REQUESTED_URI_ATTR");
+    public static final AttributeKey<HTTPCarbonMessage> ORIGINAL_REQUEST = AttributeKey.valueOf("ORIGINAL_REQUEST");
     public static final AttributeKey<HttpResponseFuture> RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL = AttributeKey
-            .valueOf
-            ("RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL");
+            .valueOf("RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL");
     public static final AttributeKey<Long> ORIGINAL_CHANNEL_START_TIME = AttributeKey
-            .valueOf
-                    ("ORIGINAL_CHANNEL_START_TIME");
+            .valueOf("ORIGINAL_CHANNEL_START_TIME");
     public static final AttributeKey<Integer> ORIGINAL_CHANNEL_TIMEOUT = AttributeKey
-            .valueOf
-                    ("ORIGINAL_CHANNEL_TIMEOUT");
+            .valueOf("ORIGINAL_CHANNEL_TIMEOUT");
     public static final AttributeKey<TargetChannel> TARGET_CHANNEL_REFERENCE = AttributeKey
-            .valueOf
-                    ("TARGET_CHANNEL_REFERENCE");
-    public static final AttributeKey<DefaultHttpClientConnector> CLIENT_CONNECTOR =
-            AttributeKey.valueOf("CLIENT_CONNECTOR");
+            .valueOf("TARGET_CHANNEL_REFERENCE");
+    public static final AttributeKey<DefaultHttpClientConnector> CLIENT_CONNECTOR = AttributeKey
+            .valueOf("CLIENT_CONNECTOR");
 
     public static final String UTF8 = "UTF-8";
     public static final String URL_AUTHORITY = "://";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Util.java
@@ -547,6 +547,7 @@ public class Util {
         ctx.channel().attr(Constants.RESPONSE_FUTURE_OF_ORIGINAL_CHANNEL).set(null);
         ctx.channel().attr(Constants.ORIGINAL_REQUEST).set(null);
         ctx.channel().attr(Constants.REDIRECT_COUNT).set(null);
+        ctx.channel().attr(Constants.RESOLVED_REQUESTED_URI_ATTR).set(null);
         ctx.channel().attr(Constants.ORIGINAL_CHANNEL_START_TIME).set(null);
         ctx.channel().attr(Constants.ORIGINAL_CHANNEL_TIMEOUT).set(null);
     }


### PR DESCRIPTION
## Purpose
Retrieve the ultimate url of the server, from which the response came from and include it in the response.

## Approach
A new property called "resolvedRequestedURI"  is included as a field to the HTTP response object.

## Automation tests
 - Integration tests
   > Contains an integration test.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Fixes : https://github.com/ballerina-platform/ballerina-lang/issues/7346