### PR TITLE
Handle sslCompletionEvent from Target handler and Source handler

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.timeout.IdleStateEvent;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.slf4j.Logger;
@@ -268,6 +269,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             log.warn("Idle timeout has reached hence closing the connection {}", ctx.channel().id().asShortText());
         } else if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
             log.debug("Server upgrade event received");
+        } else if (evt instanceof SslCloseCompletionEvent) {
+            log.debug("SSL close completion event received");
         } else {
             log.warn("Unexpected user event {} triggered", evt.toString());
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2ConnectionPrefaceAndSettingsFrameWrittenEvent;
+import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -211,6 +212,8 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             ctx.fireUserEventTriggered(evt);
         } else if (evt instanceof Http2ConnectionPrefaceAndSettingsFrameWrittenEvent) {
             log.debug("Connection Preface and Settings frame written");
+        } else if (evt instanceof SslCloseCompletionEvent) {
+            log.debug("SSL close completion event received");
         } else {
             log.warn("Unexpected user event {} triggered", evt.toString());
         }


### PR DESCRIPTION
## Purpose
Currently when a SslCloseCompletionEvent event triggers, it is shown to the user as a warning message. Since this is confusing to the user we should avoid notifying them as warning messages.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

