### PR TITLE
Fix response path for HEAD method

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -229,7 +229,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     }
 
     private ChannelFuture writeAndFlush(HttpResponse fullOutboundResponse, String httpMethod) {
-        if (headRequest(httpMethod)) {
+        if (isHeadRequest(httpMethod)) {
             ((DefaultFullHttpResponse) fullOutboundResponse).release();
 
             CompositeByteBuf emptyContent = Unpooled.compositeBuffer();
@@ -254,14 +254,14 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     }
 
     public void setChunkConfig(ChunkConfig chunkConfig) {
-        if (headRequest(requestDataHolder.getHttpMethod())) {
+        if (isHeadRequest(requestDataHolder.getHttpMethod())) {
             this.chunkConfig = ChunkConfig.NEVER;
         } else {
             this.chunkConfig = chunkConfig;
         }
     }
 
-    private boolean headRequest(String httpMethod) {
+    private boolean isHeadRequest(String httpMethod) {
         return httpMethod.equalsIgnoreCase(Constants.HTTP_HEAD_METHOD);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -120,8 +120,10 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
     private void writeOutboundResponse(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive,
             HttpContent httpContent) {
         ChannelFuture outboundChannelFuture;
+        HttpResponseFuture outboundRespStatusFuture = inboundRequestMsg.getHttpOutboundRespStatusFuture();
         ChunkConfig responseChunkConfig = outboundResponseMsg.getProperty(CHUNKING_CONFIG) != null ?
                 (ChunkConfig) outboundResponseMsg.getProperty(CHUNKING_CONFIG) : null;
+
         if (responseChunkConfig != null) {
             this.setChunkConfig(responseChunkConfig);
         }
@@ -132,8 +134,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                         Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion()) || Util
                                 .shouldEnforceChunkingforHttpOneZero(chunkConfig,
                                         requestDataHolder.getHttpVersion()))) {
-                    Util.setupChunkedRequest(outboundResponseMsg);
-                    writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+                    writeHeaders(outboundResponseMsg, keepAlive, outboundRespStatusFuture);
                     outboundChannelFuture = writeOutboundResponseBody(httpContent);
                 } else {
                     contentLength += httpContent.content().readableBytes();
@@ -157,11 +158,8 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
                     Util.isVersionCompatibleForChunking(requestDataHolder.getHttpVersion()) || Util
                             .shouldEnforceChunkingforHttpOneZero(chunkConfig, requestDataHolder.getHttpVersion()))) {
                 if (!headerWritten) {
-                    Util.setupChunkedRequest(outboundResponseMsg);
-                    writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+                    writeHeaders(outboundResponseMsg, keepAlive, outboundRespStatusFuture);
                 }
-                HttpResponseFuture outboundRespStatusFuture =
-                        inboundRequestMsg.getHttpOutboundRespStatusFuture();
                 ChannelFuture outboundResponseChannelFuture = sourceContext.writeAndFlush(httpContent);
                 Util.addResponseWriteFailureListener(outboundRespStatusFuture, outboundResponseChannelFuture);
             } else {
@@ -198,6 +196,13 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
         return outboundChannelFuture;
     }
 
+    private void writeHeaders(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive,
+                              HttpResponseFuture outboundRespStatusFuture) {
+        Util.setupChunkedRequest(outboundResponseMsg);
+        ChannelFuture outHeaderChannelFuture = writeOutboundResponseHeaders(outboundResponseMsg, keepAlive);
+        Util.addResponseWriteFailureListener(outboundRespStatusFuture, outHeaderChannelFuture);
+    }
+
     private void resetState(HTTPCarbonMessage outboundResponseMsg) {
         outboundResponseMsg.removeHttpContentAsyncFuture();
         contentList.clear();
@@ -221,11 +226,11 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
         }
     }
 
-    private void writeOutboundResponseHeaders(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive) {
+    private ChannelFuture writeOutboundResponseHeaders(HTTPCarbonMessage outboundResponseMsg, boolean keepAlive) {
         HttpResponse response = Util.createHttpResponse(outboundResponseMsg, requestDataHolder.getHttpVersion(),
                 serverName, keepAlive);
         headerWritten = true;
-        sourceContext.write(response);
+        return sourceContext.write(response);
     }
 
     private ChannelFuture writeAndFlush(HttpResponse fullOutboundResponse, String httpMethod) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpTestCase.java
@@ -103,6 +103,18 @@ public class PassThroughHttpTestCase {
         }
     }
 
+    @Test
+    public void passthroughHeadTest() {
+        try {
+            HttpURLConnection urlConn = TestUtil.request(baseURI, "/", HttpMethod.HEAD.name(), true);
+            String content = TestUtil.getContent(urlConn);
+            assertEquals("", content);
+            urlConn.disconnect();
+        } catch (IOException e) {
+            TestUtil.handleException("IOException occurred while running passthroughHeadTest", e);
+        }
+    }
+
     @AfterClass
     public void cleanUp() throws ServerConnectorException {
         try {


### PR DESCRIPTION
## Purpose
> Fix response path for HEAD method. 
> Head response doesn't contain any entity body.
> It always contains content-length header. (Chunking = NEVER)
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/7619
> Notify outbound response header write failures

## Goals
> Remove entity body from the response.

## Approach
> Release entity body and close the connection.
