### PR TITLE
Fix intermittent connection close issue related to reject promise

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -303,6 +303,9 @@ public final class Constants {
     public static final String REMOTE_SERVER_CLOSE_RESPONSE_CONNECTION_AFTER_REQUEST_READ
             = "Remote host closed the connection without sending inbound response";
 
+    public static final String PROMISED_STREAM_REJECTED_ERROR
+            = "Promised stream is already rejected or stream is no longer valid";
+
     public static final String MAXIMUM_WAIT_TIME_EXCEED = "Could not obtain a connection within maximum wait time";
 
     public static final String JMX_AGENT_NAME = "jmx.agent.name";


### PR DESCRIPTION
## Purpose
Since reject promise resets a given steam, if the server tries to write to a already rejected stream, there is a chance of server failed to write and send a GO_AWAY frame which will endup in a connection failure. Need to fix that issue.

## Goals
Fix intermittent connection close issue related to reject promise.