### PR TITLE
Fix pass-through hanging issue due to auto read false

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HTTPCarbonMessage.java
@@ -78,6 +78,7 @@ public class HTTPCarbonMessage {
     public synchronized void addHttpContent(HttpContent httpContent) {
         if (this.messageFuture != null) {
             this.messageFuture.notifyMessageListener(httpContent);
+            this.contentObservable.notifyAddListener(httpContent);
             this.contentObservable.notifyGetListener(httpContent);
         } else {
             this.blockingEntityCollector.addHttpContent(httpContent);


### PR DESCRIPTION
## Purpose
> During the pass-through case, getContent is called at first. PR fixed the hanging issue by calling adding content first.

