### PR TITLE
[WebSocket] Fix protocol violation of connection closure

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -172,24 +172,13 @@ public final class Constants {
     public static final String LOCALHOST = "localhost";
 
 
-    public static final String WEBSOCKET_SERVER_SESSION = "WEBSOCKET_SERVER_SESSION";
-    public static final String WEBSOCKET_CLIENT_SESSION = "WEBSOCKET_CLIENT_SESSION";
-    public static final String WEBSOCKET_CLIENT_SESSIONS_LIST = "WEBSOCKET_CLIENT_SESSIONS_LIST";
     public static final String WEBSOCKET_PROTOCOL = "ws";
     public static final String WEBSOCKET_PROTOCOL_SECURED = "wss";
     public static final String WEBSOCKET_UPGRADE = "websocket";
-    public static final String WEBSOCKET_CLIENT_ID = "WEBSOCKET_CLIENT_ID";
-    public static final String IS_WEBSOCKET_SERVER = "IS_WEBSOCKET_SERVER";
-    public static final String WEBSOCKET_SUBPROTOCOLS = "WEBSOCKET_SUBPROTOCOLS";
-    public static final String WEBSOCKET_ALLOW_EXTENSIONS = "WEBSOCKET_ALLOW_EXTENSIONS";
-    public static final String WEBSOCKET_CLOSE_CODE = "WEBSOCKET_CLOSE_CODE";
-    public static final String WEBSOCKET_CLOSE_REASON = "WEBSOCKET_CLOSE_REASON";
-    public static final String WEBSOCKET_TARGET = "WEBSOCKET_TARGET";
-    public static final String WEBSOCKET_MESSAGE = "WEBSOCKET_MESSAGE";
-    public static final String WEBSOCKET_HEADER_SUBPROTOCOL = "Sec-WebSocket-Protocol";
-
+    public static final String WEBSOCKET_SOURCE_HANDLER = "ws_handler";
     public static final int WEBSOCKET_STATUS_CODE_NORMAL_CLOSURE = 1000;
     public static final int WEBSOCKET_STATUS_CODE_GOING_AWAY = 1001;
+    public static final int WEBSOCKET_STATUS_CODE_ABNORMAL_CLOSURE = 1006;
 
     // Callback related parameters
     public static final String HTTP_CONNECTION_CLOSE = "close";
@@ -218,7 +207,6 @@ public final class Constants {
     public static final String HTTP_DECODER = "decoder";
     public static final String HTTP_CLIENT_CODEC = "codec";
     public static final String HTTP_SERVER_CODEC = "ServerCodec";
-    public static final String WEBSOCKET_SOURCE_HANDLER = "ws_handler";
     public static final String HTTP2_SOURCE_HANDLER = "Http2SourceHandler";
     public static final String HTTP2_ALPN_HANDLER = "Http2ALPNHandler";
     public static final String PROXY_HANDLER = "proxyServerHandler";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
@@ -104,21 +104,35 @@ public interface WebSocketConnection {
     ChannelFuture pong(ByteBuffer data);
 
     /**
-     * Close connection with close frame.
+     * Initiate connection closure.
+     *
+     * @param statusCode Status code to indicate the reason of closure
+     *                   @see <a href="https://tools.ietf.org/html/rfc6455">WebSocket Protocol</a>
+     * @param reason Reason to close the connection.
+     * @param timeoutInSecs timeout which waits for the close frame from remote endpoint to close the connection.
+     *                      <p>If the timeout exceeds then the connection will be terminated even though a close frame
+     *                      is not received from the remote backend. If the value is -1 the connection will wait until
+     *                      a close frame is received.</p>
+     * @return Future to represent the completion of asynchronous frame sending.
+     */
+    ChannelFuture initiateConnectionClosure(int statusCode, String reason, int timeoutInSecs);
+
+    /**
+     * Finish the connection closure if a close frame has been received without this connection sending a close frame.
      *
      * @param statusCode Status code to indicate the reason of closure
      *                   @see <a href="https://tools.ietf.org/html/rfc6455">WebSocket Protocol</a>
      * @param reason Reason to close the connection.
      * @return Future to represent the completion of asynchronous frame sending.
      */
-    ChannelFuture close(int statusCode, String reason);
+    ChannelFuture finishConnectionClosure(int statusCode, String reason);
 
     /**
      * Close connection without close frame.
      *
      * @return Future to represent the completion of closure asynchronously.
      */
-    ChannelFuture close();
+    ChannelFuture closeForcefully();
 
     /**
      * Check whether a close frame is sent.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketInitMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketInitMessage.java
@@ -86,7 +86,7 @@ public interface WebSocketInitMessage extends WebSocketMessage {
                               HttpHeaders responseHeaders, int maxFramePayloadLength);
 
     /**
-     * Cancel the handshake.
+     * Cancel the handshake with HTTP response.
      *
      * @param closeCode close code for cancelling the handshake.
      * @param closeReason reason for canceling the handshake.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
@@ -33,7 +33,7 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
 
     public DefaultWebSocketConnection(WebSocketInboundFrameHandler frameHandler, DefaultWebSocketSession session) {
         this.frameHandler = frameHandler;
-        this.ctx = frameHandler.getCtx();
+        this.ctx = frameHandler.getChannelHandlerContext();
         this.session = session;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
@@ -15,6 +15,8 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketFrameType;
 import org.wso2.transport.http.netty.internal.websocket.DefaultWebSocketSession;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javax.websocket.Session;
 
 /**
@@ -22,14 +24,16 @@ import javax.websocket.Session;
  */
 public class DefaultWebSocketConnection implements WebSocketConnection {
 
+    private final WebSocketInboundFrameHandler frameHandler;
     private final ChannelHandlerContext ctx;
     private final DefaultWebSocketSession session;
     private WebSocketFrameType continuationFrameType = null;
     private boolean closeFrameSent = false;
     private boolean closeFrameReceived = false;
 
-    public DefaultWebSocketConnection(ChannelHandlerContext ctx, DefaultWebSocketSession session) {
-        this.ctx = ctx;
+    public DefaultWebSocketConnection(WebSocketInboundFrameHandler frameHandler, DefaultWebSocketSession session) {
+        this.frameHandler = frameHandler;
+        this.ctx = frameHandler.getCtx();
         this.session = session;
     }
 
@@ -96,7 +100,6 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
         if (closeFrameSent) {
             throw new IllegalStateException("Already sent close frame. Cannot push binary data!");
         }
-
         if (continuationFrameType != null) {
             if (finalFrame) {
                 continuationFrameType = null;
@@ -120,13 +123,39 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
     }
 
     @Override
-    public ChannelFuture close(int statusCode, String reason) {
+    public ChannelFuture initiateConnectionClosure(int statusCode, String reason, int timeoutInSecs) {
+        if (closeFrameSent) {
+            throw new IllegalStateException("Already sent close frame. Cannot send close frame again!");
+        }
         closeFrameSent = true;
-        return ctx.writeAndFlush(new CloseWebSocketFrame(statusCode, reason));
+        CountDownLatch closeCountDownLatch = new CountDownLatch(1);
+        frameHandler.setCloseCountDownLatch(closeCountDownLatch);
+        return ctx.writeAndFlush(new CloseWebSocketFrame(statusCode, reason)).addListener(future -> {
+            if (timeoutInSecs == -1) {
+                closeCountDownLatch.await();
+            } else if (timeoutInSecs > 0) {
+                closeCountDownLatch.await(timeoutInSecs, TimeUnit.SECONDS);
+            }
+            if (ctx.channel().isOpen()) {
+                ctx.channel().close();
+            }
+        });
     }
 
     @Override
-    public ChannelFuture close() {
+    public ChannelFuture finishConnectionClosure(int statusCode, String reason) {
+        if (!frameHandler.isCloseFrameReceived()) {
+            throw new IllegalStateException("Cannot finish a connection closure without receiving a close frame");
+        }
+        return ctx.channel().writeAndFlush(new CloseWebSocketFrame(statusCode, reason)).addListener(future -> {
+            if (ctx.channel().isOpen()) {
+                ctx.channel().close();
+            }
+        });
+    }
+
+    @Override
+    public ChannelFuture closeForcefully() {
         return ctx.close();
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -1,0 +1,43 @@
+package org.wso2.transport.http.netty.contractimpl.websocket;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Abstract WebSocket frame handler for WebSocket server and client.
+ */
+public abstract class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
+
+    /**
+     * Set countdown latch for WebSocket connection close.
+     *
+     * @param closeCountDownLatch {@link CountDownLatch} to wait for WebSocket connection closure.
+     */
+    public abstract void setCloseCountDownLatch(CountDownLatch closeCountDownLatch);
+
+    /**
+     * Retrieve the WebSocket connection associated with the frame handler.
+     *
+     * @return the WebSocket connection associated with the frame handler.
+     */
+    public abstract DefaultWebSocketConnection getWebSocketConnection();
+
+    /**
+     * Check whether a close frame is received without the relevant connection to this Frame handler sending a close
+     * frame.
+     *
+     * @return true if a close frame is received without the relevant connection to this Frame handler sending a close
+     * frame.
+     */
+    public abstract boolean isCloseFrameReceived();
+
+    /**
+     * Retrieve the {@link ChannelHandlerContext} of the {@link WebSocketInboundFrameHandler}.
+     *
+     * @return the {@link ChannelHandlerContext} of the {@link WebSocketInboundFrameHandler}.
+     */
+    public abstract ChannelHandlerContext getCtx();
+
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.wso2.transport.http.netty.contractimpl.websocket;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -38,6 +56,6 @@ public abstract class WebSocketInboundFrameHandler extends ChannelInboundHandler
      *
      * @return the {@link ChannelHandlerContext} of the {@link WebSocketInboundFrameHandler}.
      */
-    public abstract ChannelHandlerContext getCtx();
+    public abstract ChannelHandlerContext getChannelHandlerContext();
 
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/WebSocketCloseMessageImpl.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/WebSocketCloseMessageImpl.java
@@ -30,6 +30,10 @@ public class WebSocketCloseMessageImpl extends WebSocketMessageImpl implements W
     private final int closeCode;
     private final String closeReason;
 
+    public WebSocketCloseMessageImpl(int closeCode) {
+        this(closeCode, null);
+    }
+
     public WebSocketCloseMessageImpl(int closeCode, String closeReason) {
         this.closeCode = closeCode;
         this.closeReason = closeReason;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketUtil.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketControlMessage;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketControlSignal;
 import org.wso2.transport.http.netty.contractimpl.websocket.DefaultWebSocketConnection;
+import org.wso2.transport.http.netty.contractimpl.websocket.WebSocketInboundFrameHandler;
 import org.wso2.transport.http.netty.contractimpl.websocket.WebSocketMessageImpl;
 import org.wso2.transport.http.netty.contractimpl.websocket.message.WebSocketBinaryMessageImpl;
 import org.wso2.transport.http.netty.contractimpl.websocket.message.WebSocketControlMessageImpl;
@@ -42,10 +43,12 @@ public class WebSocketUtil {
         return ctx.channel().id().asLongText();
     }
 
-    public static DefaultWebSocketConnection getWebSocketConnection(ChannelHandlerContext ctx, boolean isSecured,
+    public static DefaultWebSocketConnection getWebSocketConnection(WebSocketInboundFrameHandler frameHandler,
+                                                                    boolean isSecured,
                                                                     String uri) throws URISyntaxException {
+        ChannelHandlerContext ctx = frameHandler.getCtx();
         DefaultWebSocketSession session = new DefaultWebSocketSession(ctx, isSecured, uri, getSessionID(ctx));
-        return new DefaultWebSocketConnection(ctx, session);
+        return new DefaultWebSocketConnection(frameHandler, session);
     }
 
     public static WebSocketControlMessage getWebsocketControlMessage(WebSocketFrame webSocketFrame,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/internal/websocket/WebSocketUtil.java
@@ -46,7 +46,7 @@ public class WebSocketUtil {
     public static DefaultWebSocketConnection getWebSocketConnection(WebSocketInboundFrameHandler frameHandler,
                                                                     boolean isSecured,
                                                                     String uri) throws URISyntaxException {
-        ChannelHandlerContext ctx = frameHandler.getCtx();
+        ChannelHandlerContext ctx = frameHandler.getChannelHandlerContext();
         DefaultWebSocketSession session = new DefaultWebSocketSession(ctx, isSecured, uri, getSessionID(ctx));
         return new DefaultWebSocketConnection(frameHandler, session);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -133,15 +133,16 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
             isSecured = true;
         }
         String uri = fullHttpRequest.uri();
-        DefaultWebSocketConnection webSocketConnection = WebSocketUtil.getWebSocketConnection(ctx, isSecured, uri);
 
         Map<String, String> headers = new HashMap<>();
         fullHttpRequest.headers().forEach(
                 header -> headers.put(header.getKey(), header.getValue())
         );
         WebSocketSourceHandler webSocketSourceHandler =
-                new WebSocketSourceHandler(serverConnectorFuture, isSecured, webSocketConnection, fullHttpRequest,
+                new WebSocketSourceHandler(serverConnectorFuture, isSecured, fullHttpRequest,
                                            headers, ctx, interfaceId);
+        DefaultWebSocketConnection webSocketConnection = WebSocketUtil.getWebSocketConnection(webSocketSourceHandler,
+                                                                                              isSecured, uri);
         DefaultWebSocketInitMessage initMessage = new DefaultWebSocketInitMessage(ctx, fullHttpRequest,
                                                                                   webSocketSourceHandler, headers);
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketSourceHandler.java
@@ -73,7 +73,7 @@ public class WebSocketSourceHandler extends WebSocketInboundFrameHandler {
     private WebSocketFrameType continuationFrameType;
     private CountDownLatch closeCountDownLatch = null;
     private DefaultWebSocketConnection webSocketConnection;
-    private boolean closeFrameReceived = false;
+    private boolean closeFrameReceived;
 
     /**
      * @param connectorFuture {@link ServerConnectorFuture} to notify messages to application.
@@ -118,7 +118,7 @@ public class WebSocketSourceHandler extends WebSocketInboundFrameHandler {
     }
 
     @Override
-    public ChannelHandlerContext getCtx() {
+    public ChannelHandlerContext getChannelHandlerContext() {
         return this.ctx;
     }
 
@@ -158,7 +158,7 @@ public class WebSocketSourceHandler extends WebSocketInboundFrameHandler {
         if (!(this.closeFrameReceived || webSocketConnection.closeFrameSent())) {
             // Notify abnormal closure.
             WebSocketMessageImpl webSocketCloseMessage =
-                    new WebSocketCloseMessageImpl(1006, null);
+                    new WebSocketCloseMessageImpl(Constants.WEBSOCKET_STATUS_CODE_ABNORMAL_CLOSURE);
             setupCommonProperties(webSocketCloseMessage);
             connectorFuture.notifyWSListener((WebSocketCloseMessage) webSocketCloseMessage);
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/websocket/WebSocketTargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/websocket/WebSocketTargetHandler.java
@@ -23,7 +23,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
@@ -48,6 +47,7 @@ import org.wso2.transport.http.netty.contract.websocket.WebSocketControlSignal;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketFrameType;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketTextMessage;
 import org.wso2.transport.http.netty.contractimpl.websocket.DefaultWebSocketConnection;
+import org.wso2.transport.http.netty.contractimpl.websocket.WebSocketInboundFrameHandler;
 import org.wso2.transport.http.netty.contractimpl.websocket.WebSocketMessageImpl;
 import org.wso2.transport.http.netty.contractimpl.websocket.message.WebSocketCloseMessageImpl;
 import org.wso2.transport.http.netty.contractimpl.websocket.message.WebSocketControlMessageImpl;
@@ -56,6 +56,7 @@ import org.wso2.transport.http.netty.internal.websocket.WebSocketUtil;
 
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * WebSocket Client Handler. This class responsible for handling the inbound messages for the WebSocket Client.
@@ -63,7 +64,7 @@ import java.net.URISyntaxException;
  * <b>{@link Constants}.IS_WEBSOCKET_SERVER</b> property to identify whether the message is coming from the client
  * or the server in the application level.</i>
  */
-public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
+public class WebSocketTargetHandler extends WebSocketInboundFrameHandler {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketClient.class);
 
@@ -76,6 +77,8 @@ public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
     private ChannelPromise handshakeFuture;
     private ChannelHandlerContext ctx;
     private WebSocketFrameType continuationFrameType;
+    private boolean closeFrameReceived = false;
+    private CountDownLatch closeCountDownLatch = null;
 
     public WebSocketTargetHandler(WebSocketClientHandshaker handshaker, boolean isSecure, String requestedUri,
                                   WebSocketConnectorListener webSocketConnectorListener) {
@@ -90,16 +93,28 @@ public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
         return handshakeFuture;
     }
 
-    public DefaultWebSocketConnection getWebSocketConnection() {
-        return webSocketConnection;
-    }
-
     public void setActualSubProtocol(String actualSubProtocol) {
         this.actualSubProtocol = actualSubProtocol;
     }
 
+    @Override
     public ChannelHandlerContext getCtx() {
         return this.ctx;
+    }
+
+    @Override
+    public DefaultWebSocketConnection getWebSocketConnection() {
+        return webSocketConnection;
+    }
+
+    @Override
+    public boolean isCloseFrameReceived() {
+        return closeFrameReceived;
+    }
+
+    @Override
+    public void setCloseCountDownLatch(CountDownLatch closeCountDownLatch) {
+        this.closeCountDownLatch = closeCountDownLatch;
     }
 
     @Override
@@ -111,7 +126,7 @@ public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
     public void channelActive(ChannelHandlerContext ctx) throws URISyntaxException {
         this.ctx = ctx;
         handshaker.handshake(ctx.channel());
-        webSocketConnection = WebSocketUtil.getWebSocketConnection(ctx, isSecure, requestedUri);
+        webSocketConnection = WebSocketUtil.getWebSocketConnection(this, isSecure, requestedUri);
     }
 
     @Override
@@ -143,7 +158,7 @@ public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
             log.debug("WebSocket Client connected!");
             handshakeFuture.setSuccess();
             fullHttpResponse.release();
-            webSocketConnection = WebSocketUtil.getWebSocketConnection(ctx, isSecure, requestedUri);
+            webSocketConnection = WebSocketUtil.getWebSocketConnection(this, isSecure, requestedUri);
             return;
         }
 
@@ -213,10 +228,16 @@ public class WebSocketTargetHandler extends ChannelInboundHandlerAdapter {
         if (webSocketConnection == null) {
             throw new ServerConnectorException("Cannot find initialized channel session");
         }
-        WebSocketMessageImpl webSocketCloseMessage = new WebSocketCloseMessageImpl(statusCode, reasonText);
+        if (closeCountDownLatch == null) {
+            WebSocketMessageImpl webSocketCloseMessage = new WebSocketCloseMessageImpl(statusCode, reasonText);
+            setupCommonProperties(webSocketCloseMessage, ctx);
+            connectorListener.onMessage((WebSocketCloseMessage) webSocketCloseMessage);
+            closeFrameReceived = true;
+        } else {
+            ctx.writeAndFlush(new CloseWebSocketFrame(statusCode, reasonText)).addListener(
+                    future -> closeCountDownLatch.countDown());
+        }
         closeWebSocketFrame.release();
-        setupCommonProperties(webSocketCloseMessage, ctx);
-        connectorListener.onMessage((WebSocketCloseMessage) webSocketCloseMessage);
     }
 
     private void notifyCloseMessage(int statusCode, String reasonText, ChannelHandlerContext ctx)

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWebSocketProtocolSwitchTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWebSocketProtocolSwitchTestCase.java
@@ -67,12 +67,28 @@ public class HttpToWebSocketProtocolSwitchTestCase {
         urlConn.setRequestProperty("upgrade", "websocket");
         urlConn.setRequestProperty("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
         urlConn.setRequestProperty("Sec-WebSocket-Version", "13");
+        urlConn.setRequestProperty("Command", "handshake");
 
         Assert.assertEquals(urlConn.getResponseCode(), 101);
         Assert.assertEquals(urlConn.getResponseMessage(), "Switching Protocols");
         Assert.assertEquals(urlConn.getHeaderField("upgrade"), "websocket");
         Assert.assertEquals(urlConn.getHeaderField("connection"), "upgrade");
         Assert.assertTrue(urlConn.getHeaderField("sec-websocket-accept") != null);
+    }
+
+    @Test
+    public void testWebSocketGetUpgradeFail() throws IOException {
+        URL url = baseURI.resolve("/websocket").toURL();
+        HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+        urlConn.setRequestMethod("GET");
+        urlConn.setRequestProperty("connection", "upgrade");
+        urlConn.setRequestProperty("upgrade", "websocket");
+        urlConn.setRequestProperty("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+        urlConn.setRequestProperty("Sec-WebSocket-Version", "13");
+        urlConn.setRequestProperty("Command", "fail");
+
+        Assert.assertEquals(urlConn.getResponseCode(), 404);
+        Assert.assertEquals(urlConn.getResponseMessage(), "Not Found");
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchWebSocketListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchWebSocketListener.java
@@ -19,7 +19,6 @@
 
 package org.wso2.transport.http.netty.websocket;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchWebSocketListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/HttpToWsProtocolSwitchWebSocketListener.java
@@ -19,6 +19,7 @@
 
 package org.wso2.transport.http.netty.websocket;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketBinaryMessage;
@@ -37,7 +38,11 @@ public class HttpToWsProtocolSwitchWebSocketListener implements WebSocketConnect
 
     @Override
     public void onMessage(WebSocketInitMessage initMessage) {
-        initMessage.handshake();
+        if ("handshake".equals(initMessage.getHeader("Command"))) {
+            initMessage.handshake();
+        } else if ("fail".equals(initMessage.getHeader("Command"))) {
+            initMessage.cancelHandShake(404, "Not Found");
+        }
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketPassthroughServerConnectorListener.java
@@ -107,7 +107,7 @@ public class WebSocketPassthroughServerConnectorListener implements WebSocketCon
     public void onMessage(WebSocketCloseMessage closeMessage) {
         WebSocketConnection clientConnection = WebSocketPassThroughTestConnectionManager.getInstance()
                 .getClientConnection(closeMessage.getWebSocketConnection());
-        clientConnection.close();
+        clientConnection.closeForcefully();
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/WebSocketTestServerConnectorListener.java
@@ -129,7 +129,7 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
     public void onIdleTimeout(WebSocketControlMessage controlMessage) {
         this.isIdleTimeout = true;
         WebSocketConnection webSocketConnection = controlMessage.getWebSocketConnection();
-        webSocketConnection.close(1001, "Connection timeout").addListener(future -> {
+        webSocketConnection.initiateConnectionClosure(1001, "Connection timeout", -1).addListener(future -> {
            if (!future.isSuccess()) {
                log.error("Error occurred while closing the connection: " + future.cause().getMessage());
            }


### PR DESCRIPTION
## Purpose
> To fix the protocol violation addressed by issue https://github.com/ballerina-platform/ballerina-lang/issues/7893

## Goals
> Resolve the WebSocket protocol violation when closing the connection

## Approach
> Change the implementation of WebSocketConnection to match the protocol connection closing description.

## Automation tests
 - Unit tests 
   > No
   > Added an issue https://github.com/wso2/transport-http/issues/115 to address this separately since this needs different test clients to test different scenarios.
 - Integration tests
   > No

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes