### PR TITLE
Remove message future automatically 

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -155,7 +155,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
             if (handlerExecutor != null) {
                 handlerExecutor.executeAtSourceResponseSending(outboundResponseMsg);
             }
-            resetState(outboundResponseMsg);
+            resetState();
         } else {
             if ((chunkConfig == ChunkConfig.ALWAYS || chunkConfig == ChunkConfig.AUTO) && (
                     isVersionCompatibleForChunking(requestDataHolder.getHttpVersion()) ||
@@ -206,8 +206,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
         addResponseWriteFailureListener(outboundRespStatusFuture, outboundHeaderFuture);
     }
 
-    private void resetState(HTTPCarbonMessage outboundResponseMsg) {
-        outboundResponseMsg.removeHttpContentAsyncFuture();
+    private void resetState() {
         contentList.clear();
         contentLength = 0;
         headerWritten = false;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/channel/TargetChannel.java
@@ -228,7 +228,7 @@ public class TargetChannel {
 
             writeOutboundRequestBody(httpContent);
 
-            resetState(httpOutboundRequest);
+            resetState();
 
             if (handlerExecutor != null) {
                 handlerExecutor.executeAtTargetRequestSending(httpOutboundRequest);
@@ -274,8 +274,7 @@ public class TargetChannel {
         });
     }
 
-    public void resetState(HTTPCarbonMessage httpOutboundRequest) {
-        httpOutboundRequest.removeHttpContentAsyncFuture();
+    public void resetState() {
         contentList.clear();
         contentLength = 0;
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientOutboundHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientOutboundHandler.java
@@ -253,7 +253,6 @@ public class ClientOutboundHandler extends ChannelOutboundHandlerAdapter {
          * This should be called after writing the {@code LastHttpContent}.
          */
         private void markWriteCompletion() {
-            httpOutboundRequest.removeHttpContentAsyncFuture();
         }
     }
 


### PR DESCRIPTION
## Purpose
> At the moment, we manually have to remove the aforementioned future upon completed the life-cycle of the message. With this PR we do that automatically. 