### PR TITLE
Remove the SslHandshakeCompletion handler after creating pipeline

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SslHandshakeCompletionHandlerForServer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SslHandshakeCompletionHandlerForServer.java
@@ -43,13 +43,13 @@ public class SslHandshakeCompletionHandlerForServer extends ChannelInboundHandle
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof SslHandshakeCompletionEvent) {
-            ctx.pipeline().remove(this);
 
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
 
             if (event.isSuccess()) {
                 this.httpServerChannelInitializer.configureHttpPipeline(serverPipeline, Constants.HTTP_SCHEME);
-                serverPipeline.fireChannelActive();
+                ctx.pipeline().remove(this);
+                ctx.fireChannelActive();
             } else {
                 ctx.close();
             }


### PR DESCRIPTION
## Purpose
Remove the SslHandshakeCompletion handler after configuring the http pipeline.
And then fireChannelActive from the ctx without giving the entire serverPipeline.

