### PR TITLE
Allow terminating a connection with a close frame

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
@@ -133,4 +133,9 @@ public interface WebSocketConnection {
      * @return Future to represent the completion of closure asynchronously.
      */
     ChannelFuture terminateConnection();
+
+    /**
+     * Send a close frame and close the connection without waiting for a response.
+     */
+    ChannelFuture terminateConnection(int statusCode, String reason);
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
@@ -185,11 +185,25 @@ public class WebSocketClientFunctionalityTestCase {
     }
 
     @Test(description = "Test connection termination using WebSocketConnection without sending a close frame.")
-    public void testConnectionTermination() throws Throwable {
+    public void testConnectionTerminationWithoutCloseFrame() throws Throwable {
         WebSocketConnection webSocketConnection =
                 getWebSocketConnectionSync(new WebSocketTestClientConnectorListener());
         CountDownLatch countDownLatch = new CountDownLatch(1);
         ChannelFuture closeFuture = webSocketConnection.terminateConnection().addListener(
+                future -> countDownLatch.countDown());
+        countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, SECONDS);
+
+        Assert.assertNull(closeFuture.cause());
+        Assert.assertTrue(closeFuture.isDone());
+        Assert.assertTrue(closeFuture.isSuccess());
+    }
+
+    @Test(description = "Test connection termination using WebSocketConnection with a close frame.")
+    public void testConnectionTerminationWithCloseFrame() throws Throwable {
+        WebSocketConnection webSocketConnection =
+                getWebSocketConnectionSync(new WebSocketTestClientConnectorListener());
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        ChannelFuture closeFuture = webSocketConnection.terminateConnection(1011, "Unexpected failure").addListener(
                 future -> countDownLatch.countDown());
         countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, SECONDS);
 


### PR DESCRIPTION
## Purpose
> Allow terminating a connection with a close frame
>Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/8145

## Goals
> This helps to close a connection by sending a close frame but need not wait for a close frame.

## Approach
> Adds a method that sends a close frame and terminates the connection without waiting for a response.

