### PR TITLE
Send back response when timeout

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -313,6 +313,8 @@ public final class Constants {
     public static final String REMOTE_SERVER_CLOSE_RESPONSE_CONNECTION_AFTER_REQUEST_READ
             = "Remote host closed the connection without sending inbound response";
 
+    public static final String CHANNEL_CLOSED = "Connection closed while writing outbound response";
+
     public static final String PROMISED_STREAM_REJECTED_ERROR
             = "Promised stream is already rejected or stream is no longer valid";
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.wso2.transport.http.netty.common.Constants.CHANNEL_CLOSED;
 import static org.wso2.transport.http.netty.common.Constants.CHUNKING_CONFIG;
 import static org.wso2.transport.http.netty.common.Constants.REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.ENTITY_BODY_SENT;
@@ -267,7 +268,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
             Throwable throwable = writeOperationPromise.cause();
             if (throwable != null) {
                 if (throwable instanceof ClosedChannelException) {
-                    throwable = new IOException(REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE);
+                    throwable = new IOException(CHANNEL_CLOSED);
                 }
                 outboundRespStatusFuture.notifyHttpListener(throwable);
             } else {


### PR DESCRIPTION
When there is a connection timeout currently the channel is closed. In this PR if the timeout is during the reception of a request or after completion of the reception of the request a response is sent back to inform the client. If it is the timeout when reading the request 408 Request Timeout is sent. If it is the timeout before writing a response a 500 internal server error is sent.

Resolve ballerina-platform/ballerina-lang#3794