### PR TITLE
Fix response for HEAD method

### DIFF
--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/method/head/HeadRequestMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/method/head/HeadRequestMessageProcessorListener.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.method.head;
+
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.common.Constants;
+import org.wso2.transport.http.netty.contract.HttpConnectorListener;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpCarbonResponse;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Listener to process the HEAD request related test cases.
+ */
+public class HeadRequestMessageProcessorListener implements HttpConnectorListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HeadRequestMessageProcessorListener.class);
+
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Override public void onMessage(HTTPCarbonMessage httpRequest) {
+        executor.execute(() -> {
+            try {
+                HTTPCarbonMessage httpResponse = new HttpCarbonResponse(new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                        HttpResponseStatus.OK));
+                httpResponse.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), Constants.TEXT_PLAIN);
+                HttpMessageDataStreamer httpMessageDataStreamer = new HttpMessageDataStreamer(httpResponse);
+                httpRequest.respond(httpResponse);
+                if (Boolean.valueOf(httpRequest.getHeader("x-large-payload"))) {
+                    log.info("Request for large payload");
+                    httpMessageDataStreamer.getOutputStream().write(TestUtil.largeEntity.getBytes());
+                } else {
+                    httpMessageDataStreamer.getOutputStream().write(TestUtil.smallEntity.getBytes());
+                }
+                httpMessageDataStreamer.getOutputStream().close();
+            } catch (Exception e) {
+                log.error("Error occurred during message notification: " + e.getMessage());
+            }
+        });
+    }
+
+    @Override public void onError(Throwable throwable) {
+        log.error("Error while receiving the request", throwable);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/method/head/HeadRequestTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/method/head/HeadRequestTestCase.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.method.head;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.listener.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.net.URI;
+import java.util.HashMap;
+
+/**
+ * This tests head request handling of the HTTP server.
+ */
+public class HeadRequestTestCase {
+
+    private HttpWsConnectorFactory httpWsConnectorFactory;
+    private ServerConnector serverConnector;
+    private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
+
+    @BeforeClass
+    public void setup() throws InterruptedException {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+        ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
+        serverConnector = httpWsConnectorFactory.createServerConnector(serverBootstrapConfig, listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(new HeadRequestMessageProcessorListener());
+        serverConnectorFuture.sync();
+    }
+
+    @Test
+    public void testHeadRequestForSmallPayload() throws UnirestException {
+        HttpResponse<String> response = Unirest.head(baseURI.resolve("/").toString()).asString();
+        assertBasicResponse(response);
+        Assert.assertEquals(response.getHeaders().getFirst("content-length"),
+                String.valueOf(TestUtil.smallEntity.length()));
+    }
+
+    @Test(description = "By x-large-payload custom header, client ask server to respond with a large payload")
+    public void testHeadRequestForLargePayload() throws UnirestException {
+        HttpResponse<String> response = Unirest.head(baseURI.resolve("/").toString())
+                .header("x-large-payload", "true").asString();
+        assertBasicResponse(response);
+        Assert.assertEquals(response.getHeaders().getFirst("transfer-encoding"), "chunked");
+    }
+
+    private void assertBasicResponse(HttpResponse<String> response) {
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(response.getHeaders().getFirst("content-type"), "text/plain");
+        Assert.assertNull(response.getBody());
+    }
+
+    @AfterClass
+    public void cleanup() throws InterruptedException {
+        serverConnector.stop();
+        httpWsConnectorFactory.shutdown();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -73,6 +73,8 @@
             <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedEnableTestCase" />
             <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedTransitionTestCase" />
             <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedDisableTestCase" />
+
+            <class name="org.wso2.transport.http.netty.method.head.HeadRequestTestCase"/>
         </classes>
     </test>
     <test name="WebSocket Tests" parallel="false">


### PR DESCRIPTION
## Purpose
> Fix https://github.com/ballerina-platform/ballerina-lang/issues/7619

## Goals
> Discard entity body correctly and construct response for HEAD request.

## Approach
> Add necessary parts to discard the entity body and construct response in HttpOutboundResListener

## Automation tests
 - Unit tests 
   > Yes
 - Integration tests
   > No

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes