### PR TITLE
Add 100-continue specific states

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -119,7 +119,8 @@ public final class Constants {
     public static final String X_FORWARDED_BY = "x-forwarded-by";
     public static final String X_FORWARDED_HOST = "x-forwarded-host";
     public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
-    public static final String CONTINUE = "100-continue";
+
+    public static final String HEADER_VAL_100_CONTINUE = "100-continue";
 
     public static final String HTTP_GET_METHOD = "GET";
     public static final String HTTP_POST_METHOD = "POST";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/Constants.java
@@ -119,6 +119,7 @@ public final class Constants {
     public static final String X_FORWARDED_BY = "x-forwarded-by";
     public static final String X_FORWARDED_HOST = "x-forwarded-host";
     public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
+    public static final String CONTINUE = "100-continue";
 
     public static final String HTTP_GET_METHOD = "GET";
     public static final String HTTP_POST_METHOD = "POST";
@@ -282,6 +283,10 @@ public final class Constants {
             = "Idle timeout triggered before initiating outbound response";
     public static final String IDLE_TIMEOUT_TRIGGERED_WHILE_WRITING_OUTBOUND_RESPONSE
                 = "Idle timeout triggered while writing outbound response";
+    public static final String IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_100_CONTINUE_RESPONSE
+            = "Idle timeout triggered before initiating 100 continue response";
+    public static final String IDLE_TIMEOUT_TRIGGERED_WHILE_WRITING_100_CONTINUE_RESPONSE
+            = "Idle timeout triggered while writing 100 continue response";
 
     public static final String IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_OUTBOUND_REQUEST
             = "Idle timeout triggered before initiating outbound request";
@@ -306,6 +311,10 @@ public final class Constants {
             = "Remote client closed the connection before initiating outbound response";
     public static final String REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE
             = "Remote client closed the connection while writing outbound response";
+    public static final String REMOTE_CLIENT_CLOSED_BEFORE_INITIATING_100_CONTINUE_RESPONSE
+            = "Remote client closed the connection before initiating 100 continue response";
+    public static final String REMOTE_CLIENT_CLOSED_WHILE_WRITING_100_CONTINUE_RESPONSE
+            = "Remote client closed the connection while writing 100 continue response";
 
     // Server connection closure error scenarios
     public static final String REMOTE_SERVER_CLOSED_BEFORE_INITIATING_OUTBOUND_REQUEST

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/SourceInteractiveState.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/SourceInteractiveState.java
@@ -22,8 +22,8 @@ package org.wso2.transport.http.netty.common;
  * Inbound request and outbound response state.
  *
  * CONNECTED - State between connection creation and start of payload read
- * EXPECT_CONTINUE_HEADER_RECEIVED - Special state of receiving request with expect continue header
- * HEADER_100_CONTINUE_SENT - Special state of sending response with 100-continue header
+ * EXPECT_100_CONTINUE_HEADER_RECEIVED - Special state of receiving request with expect:100-continue header
+ * RESPONSE_100_CONTINUE_SENT - Special state of sending 100-continue response
  * RECEIVING_ENTITY_BODY - State between start and end of payload read
  * ENTITY_BODY_RECEIVED - State between end of payload read and start of response write
  * SENDING_ENTITY_BODY - State between start and end of response write
@@ -31,8 +31,8 @@ package org.wso2.transport.http.netty.common;
  */
 public enum SourceInteractiveState {
     CONNECTED,
-    EXPECT_CONTINUE_HEADER_RECEIVED,
-    HEADER_100_CONTINUE_SENT,
+    EXPECT_100_CONTINUE_HEADER_RECEIVED,
+    RESPONSE_100_CONTINUE_SENT,
     RECEIVING_ENTITY_BODY,
     ENTITY_BODY_RECEIVED,
     SENDING_ENTITY_BODY,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/SourceInteractiveState.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/common/SourceInteractiveState.java
@@ -22,6 +22,8 @@ package org.wso2.transport.http.netty.common;
  * Inbound request and outbound response state.
  *
  * CONNECTED - State between connection creation and start of payload read
+ * EXPECT_CONTINUE_HEADER_RECEIVED - Special state of receiving request with expect continue header
+ * HEADER_100_CONTINUE_SENT - Special state of sending response with 100-continue header
  * RECEIVING_ENTITY_BODY - State between start and end of payload read
  * ENTITY_BODY_RECEIVED - State between end of payload read and start of response write
  * SENDING_ENTITY_BODY - State between start and end of response write
@@ -29,6 +31,8 @@ package org.wso2.transport.http.netty.common;
  */
 public enum SourceInteractiveState {
     CONNECTED,
+    EXPECT_CONTINUE_HEADER_RECEIVED,
+    HEADER_100_CONTINUE_SENT,
     RECEIVING_ENTITY_BODY,
     ENTITY_BODY_RECEIVED,
     SENDING_ENTITY_BODY,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -48,7 +48,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.wso2.transport.http.netty.common.Constants.CHUNKING_CONFIG;
-import static org.wso2.transport.http.netty.common.SourceInteractiveState.HEADER_100_CONTINUE_SENT;
+import static org.wso2.transport.http.netty.common.SourceInteractiveState.RESPONSE_100_CONTINUE_SENT;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.SENDING_ENTITY_BODY;
 import static org.wso2.transport.http.netty.common.Util.createFullHttpResponse;
 import static org.wso2.transport.http.netty.common.Util.createHttpResponse;
@@ -139,7 +139,7 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
             this.setChunkConfig(responseChunkConfig);
         }
         if (continueRequest) {
-            sourceErrorHandler.setState(HEADER_100_CONTINUE_SENT);
+            sourceErrorHandler.setState(RESPONSE_100_CONTINUE_SENT);
             continueRequest = false;
         } else {
             if (sourceErrorHandler.getState().equals(SourceInteractiveState.RECEIVING_ENTITY_BODY)) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceErrorHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceErrorHandler.java
@@ -85,7 +85,6 @@ public class SourceErrorHandler {
 
     void handleErrorCloseScenario(HTTPCarbonMessage inboundRequestMsg) {
         this.inboundRequestMsg = inboundRequestMsg;
-        System.out.println("state----------------" + state.toString());
         try {
             switch (state) {
                 case CONNECTED:
@@ -204,8 +203,6 @@ public class SourceErrorHandler {
             } else {
                 outboundRespStatusFuture.notifyHttpListener(inboundRequestMsg);
                 this.setState(ENTITY_BODY_SENT);
-                System.out.println(ENTITY_BODY_SENT);
-
             }
         });
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceErrorHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceErrorHandler.java
@@ -93,11 +93,11 @@ public class SourceErrorHandler {
                     // Error is notified to server connector. Debug log is to make transport layer aware
                     log.debug(REMOTE_CLIENT_CLOSED_BEFORE_INITIATING_INBOUND_REQUEST);
                     break;
-                case EXPECT_CONTINUE_HEADER_RECEIVED:
+                case EXPECT_100_CONTINUE_HEADER_RECEIVED:
                     serverConnectorFuture.notifyErrorListener(
                             new ServerConnectorException(REMOTE_CLIENT_CLOSED_BEFORE_INITIATING_100_CONTINUE_RESPONSE));
                     break;
-                case HEADER_100_CONTINUE_SENT:
+                case RESPONSE_100_CONTINUE_SENT:
                     // OutboundResponseStatusFuture will be notified asynchronously via OutboundResponseListener.
                     log.error(REMOTE_CLIENT_CLOSED_WHILE_WRITING_100_CONTINUE_RESPONSE);
                     break;
@@ -133,7 +133,7 @@ public class SourceErrorHandler {
                     // Error is notified to server connector. Debug log is to make transport layer aware
                     log.debug(IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_INBOUND_REQUEST);
                     break;
-                case HEADER_100_CONTINUE_SENT:
+                case RESPONSE_100_CONTINUE_SENT:
                     // OutboundResponseStatusFuture will be notified asynchronously via OutboundResponseListener.
                     log.error(IDLE_TIMEOUT_TRIGGERED_WHILE_WRITING_100_CONTINUE_RESPONSE);
                     break;
@@ -141,7 +141,7 @@ public class SourceErrorHandler {
                     //408 Request Timeout is sent if the idle timeout triggered when reading request
                     return sendRequestTimeoutResponse(ctx, HttpResponseStatus.REQUEST_TIMEOUT, Unpooled.EMPTY_BUFFER,
                                                       0);
-                case EXPECT_CONTINUE_HEADER_RECEIVED:
+                case EXPECT_100_CONTINUE_HEADER_RECEIVED:
                 case ENTITY_BODY_RECEIVED:
                     // This means we have received the complete inbound request. But nothing happened after that.
                     if (evt.state() != IdleState.READER_IDLE) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -115,7 +115,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         this.ctx = ctx;
         this.remoteAddress = ctx.channel().remoteAddress();
         sourceErrorHandler.setState(CONNECTED);
-        System.out.println(CONNECTED);
     }
 
     @Override
@@ -145,16 +144,11 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpRequest) {
-            System.out.println("headers receiving");
-
             sourceErrorHandler.setState(CONNECTED);
-            System.out.println(CONNECTED);
             HttpRequest httpRequest = (HttpRequest) msg;
             inboundRequestMsg = setupCarbonMessage(httpRequest, ctx);
             if (is100ContinueRequest(inboundRequestMsg)) {
                 sourceErrorHandler.setState(EXPECT_CONTINUE_HEADER_RECEIVED);
-                System.out.println(EXPECT_CONTINUE_HEADER_RECEIVED);
-
             }
             notifyRequestListener(inboundRequestMsg, ctx);
 
@@ -165,7 +159,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             if (inboundRequestMsg != null) {
                 if (msg instanceof HttpContent) {
                     sourceErrorHandler.setState(RECEIVING_ENTITY_BODY);
-                    System.out.println(RECEIVING_ENTITY_BODY);
                     HttpContent httpContent = (HttpContent) msg;
                     try {
                         inboundRequestMsg.addHttpContent(httpContent);
@@ -178,7 +171,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
                             }
                             inboundRequestMsg = null;
                             sourceErrorHandler.setState(ENTITY_BODY_RECEIVED);
-                            System.out.println(ENTITY_BODY_RECEIVED);
                         }
                     } catch (RuntimeException ex) {
                         httpContent.release();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -56,12 +56,12 @@ import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.wso2.transport.http.netty.common.Constants.CONTINUE;
+import static org.wso2.transport.http.netty.common.Constants.HEADER_VAL_100_CONTINUE;
 import static org.wso2.transport.http.netty.common.Constants.IDLE_TIMEOUT_TRIGGERED_WHILE_READING_INBOUND_REQUEST;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.CONNECTED;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.ENTITY_BODY_RECEIVED;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.ENTITY_BODY_SENT;
-import static org.wso2.transport.http.netty.common.SourceInteractiveState.EXPECT_CONTINUE_HEADER_RECEIVED;
+import static org.wso2.transport.http.netty.common.SourceInteractiveState.EXPECT_100_CONTINUE_HEADER_RECEIVED;
 import static org.wso2.transport.http.netty.common.SourceInteractiveState.RECEIVING_ENTITY_BODY;
 
 /**
@@ -148,7 +148,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             HttpRequest httpRequest = (HttpRequest) msg;
             inboundRequestMsg = setupCarbonMessage(httpRequest, ctx);
             if (is100ContinueRequest(inboundRequestMsg)) {
-                sourceErrorHandler.setState(EXPECT_CONTINUE_HEADER_RECEIVED);
+                sourceErrorHandler.setState(EXPECT_100_CONTINUE_HEADER_RECEIVED);
             }
             notifyRequestListener(inboundRequestMsg, ctx);
 
@@ -184,8 +184,8 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
     }
 
     private boolean is100ContinueRequest(HTTPCarbonMessage inboundRequestMsg) {
-        String expectHeader = inboundRequestMsg.getHeader(HttpHeaderNames.EXPECT.toString());
-        continueRequest = expectHeader != null && expectHeader.equalsIgnoreCase(CONTINUE);
+        continueRequest = HEADER_VAL_100_CONTINUE.equalsIgnoreCase(
+                inboundRequestMsg.getHeader(HttpHeaderNames.EXPECT.toString()));
         return continueRequest;
     }
 


### PR DESCRIPTION
## Purpose
> Add EXPECT_100_CONTINUE_HEADER_RECEIVED and RESPONSE_100_CONTINUE_SENT special states to sourceErrorHandler to indicate states of 100 continue requests.

> Address application layer problem of responding to a request which has not been read completely. In that instance, states are changed from RECEIVING_ENTITY_BODY to SENDING_ENTITY_BODY. Since user doesn't consume the inbound request payload, the connection is closed after checking this state inconsistent transition.