### PR TITLE
Handle channelInactive scenario in WebSocket

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketInitMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketInitMessage.java
@@ -189,7 +189,6 @@ public class DefaultWebSocketInitMessage extends DefaultWebSocketMessage impleme
         }
         pipeline.addLast(Constants.MESSAGE_QUEUE_HANDLER, messageQueueHandler);
         pipeline.addLast(Constants.WEBSOCKET_FRAME_HANDLER, frameHandler);
-        pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
         pipeline.fireChannelActive();
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -77,6 +77,7 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
                                           "channel : " + ctx.channel());
                     }
                     ChannelPipeline pipeline = ctx.pipeline();
+                    pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
                     ChannelHandlerContext decoderCtx = pipeline.context(HttpRequestDecoder.class);
                     pipeline.addAfter(decoderCtx.name(), HTTP_OBJECT_AGGREGATOR,
                             new HttpObjectAggregator(maxContentLength));
@@ -113,6 +114,11 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
             }
         }
         ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        ctx.close();
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When the channelInactive scenario is not handled in the `WebSocketServerHandshakeHandler` it propagated to the Http `SourceHandler`. This was observed in the case of cancelling the WebSocket handshake.

## Approach
>  Http `SourceHandler` is initially removed from the WebSocket pipeline and `channelInactive` use case is handled in the `WebSocketServerHandshakeHandler`.