### PR TITLE
Fix overriding channelInactive before SourceHandler

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
@@ -22,6 +22,7 @@ package org.wso2.transport.http.netty.contractimpl.websocket.message;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -144,6 +145,7 @@ public class DefaultWebSocketHandshaker implements WebSocketHandshaker {
                 responseFuture = ctx.writeAndFlush(new DefaultFullHttpResponse(
                         HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(responseStatusCode)));
             }
+            responseFuture.addListener((ChannelFutureListener) future -> ctx.close());
             return responseFuture;
         } finally {
             cancelled = true;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/WebSocketServerHandshakeHandler.java
@@ -118,11 +118,6 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) {
-        ctx.close();
-    }
-
-    @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         ctx.writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR))
                 .addListener(ChannelFutureListener.CLOSE);


### PR DESCRIPTION
## Purpose
> This fixes the `channelInactive` of `SourceHandler` not being called because it is overridden at the `WebSocketServerHandshakeHandler`. Now the channel becoming inactive at the cancelling of handshake would be handled as soon as the canclled response is sent to the client by closing the `ChannelHandlerContext`


Fix https://github.com/ballerina-platform/ballerina-lang/issues/10043