### PR TITLE
Fix incorrect behavior for lacking statusCode in close

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnection.java
@@ -139,6 +139,15 @@ public interface WebSocketConnection {
     ChannelFuture initiateConnectionClosure(int statusCode, String reason);
 
     /**
+     * Initiates connection closure. {@link ChannelFuture} will complete operation successfully if and only if it
+     * receives back a echoed close WebSocket frame from the remote endpoint with the same status code as was written.
+     * Also {@link ChannelFuture} will not reach operationComplete state until it receives a close WebSocket frame
+     * from the remote endpoint. If user does not need to wait for the echoed back WebSocket frame from the remote
+     * endpoint, user need to handle it separately.
+     */
+    ChannelFuture initiateConnectionClosure();
+
+    /**
      * Finish the connection closure if a close frame has been received without this connection sending a close frame.
      *
      * @param statusCode Status code to indicate the reason of closure
@@ -147,6 +156,11 @@ public interface WebSocketConnection {
      * @return Future to represent the completion of asynchronous frame sending
      */
     ChannelFuture finishConnectionClosure(int statusCode, String reason);
+
+    /**
+     * Finish the connection closure if a close frame has been received without this connection sending a close frame.
+     */
+    ChannelFuture finishConnectionClosure();
 
     /**
      * Terminate connection without close frame.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnection.java
@@ -165,13 +165,23 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
 
     @Override
     public ChannelFuture initiateConnectionClosure(int statusCode, String reason) {
+        return initiateConnectionClosure(new CloseWebSocketFrame(statusCode, reason));
+    }
+
+    @Override
+    public ChannelFuture initiateConnectionClosure() {
+        return initiateConnectionClosure(new CloseWebSocketFrame());
+    }
+
+    private ChannelFuture initiateConnectionClosure(CloseWebSocketFrame closeWebSocketFrame) {
         if (closeFrameSent) {
             throw new IllegalStateException("Close frame already sent. Cannot send close frame again.");
         }
         closeFrameSent = true;
-        closeInitiatedStatusCode = statusCode;
+        closeInitiatedStatusCode = closeWebSocketFrame.statusCode();
+        closeInitiatedStatusCode = closeInitiatedStatusCode == -1 ? 1005 : closeInitiatedStatusCode;
         ChannelPromise closePromise = ctx.newPromise();
-        ctx.writeAndFlush(new CloseWebSocketFrame(statusCode, reason)).addListener(future -> {
+        ctx.writeAndFlush(closeWebSocketFrame).addListener(future -> {
             frameHandler.setClosePromise(closePromise);
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
@@ -183,11 +193,20 @@ public class DefaultWebSocketConnection implements WebSocketConnection {
 
     @Override
     public ChannelFuture finishConnectionClosure(int statusCode, String reason) {
+        return finishConnectionClosure(new CloseWebSocketFrame(statusCode, reason));
+    }
+
+    @Override
+    public ChannelFuture finishConnectionClosure() {
+        return finishConnectionClosure(new CloseWebSocketFrame());
+    }
+
+    private ChannelFuture finishConnectionClosure(CloseWebSocketFrame closeWebSocketFrame) {
         if (!frameHandler.isCloseFrameReceived()) {
             throw new IllegalStateException("Cannot finish a connection closure without receiving a close frame");
         }
         ChannelPromise channelPromise = ctx.newPromise();
-        ctx.writeAndFlush(new CloseWebSocketFrame(statusCode, reason)).addListener(future -> {
+        ctx.writeAndFlush(closeWebSocketFrame).addListener(future -> {
             Throwable cause = future.cause();
             if (!future.isSuccess() && cause != null) {
                 ctx.close().addListener(closeFuture -> channelPromise.setFailure(cause));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -211,16 +211,19 @@ public class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
     private void notifyCloseMessage(CloseWebSocketFrame closeWebSocketFrame) throws WebSocketConnectorException {
         String reasonText = closeWebSocketFrame.reasonText();
         int statusCode = closeWebSocketFrame.statusCode();
+        if (statusCode == -1) {
+            statusCode = 1005;
+        }
         // closePromise == null means that WebSocketConnection has not yet initiated a connection closure.
         if (closePromise == null) {
             DefaultWebSocketMessage webSocketCloseMessage = new DefaultWebSocketCloseMessage(statusCode, reasonText);
             setupCommonProperties(webSocketCloseMessage);
             connectorFuture.notifyWebSocketListener((WebSocketCloseMessage) webSocketCloseMessage);
         } else {
-            if (webSocketConnection.getCloseInitiatedStatusCode() != closeWebSocketFrame.statusCode()) {
+            if (webSocketConnection.getCloseInitiatedStatusCode() != statusCode) {
                 String errMsg = String.format(
                         "Expected status code %d but found %d in echoed close frame from remote endpoint",
-                        webSocketConnection.getCloseInitiatedStatusCode(), closeWebSocketFrame.statusCode());
+                        webSocketConnection.getCloseInitiatedStatusCode(), statusCode);
                 closePromise.setFailure(new IllegalStateException(errMsg));
                 return;
             }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/websocket/WebSocketRemoteServerFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/websocket/WebSocketRemoteServerFrameHandler.java
@@ -40,6 +40,7 @@ public class WebSocketRemoteServerFrameHandler extends SimpleChannelInboundHandl
     private static final Logger log = LoggerFactory.getLogger(WebSocketRemoteServerFrameHandler.class);
     private static final String PING = "ping";
     private static final String CLOSE = "close";
+    private static final String CLOSE_WITHOUT_STATUS_CODE = "close-without-status-code";
     private static final String CLOSE_WITHOUT_FRAME = "close-without-frame";
     private static final String SEND_CORRUPTED_FRAME = "send-corrupted-frame";
 
@@ -64,6 +65,9 @@ public class WebSocketRemoteServerFrameHandler extends SimpleChannelInboundHandl
                 case CLOSE:
                     ctx.writeAndFlush(new CloseWebSocketFrame(Constants.WEBSOCKET_STATUS_CODE_NORMAL_CLOSURE,
                                                               "Close on request"));
+                    break;
+                case CLOSE_WITHOUT_STATUS_CODE:
+                    ctx.writeAndFlush(new CloseWebSocketFrame());
                     break;
                 case CLOSE_WITHOUT_FRAME:
                     ctx.close();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
@@ -335,6 +335,21 @@ public class WebSocketClientFunctionalityTestCase {
     }
 
     @Test
+    public void testConnectionClosureWithoutCloseCodeFromServerSide() throws Throwable {
+        WebSocketTestClientConnectorListener connectorListener = new WebSocketTestClientConnectorListener();
+        WebSocketConnection webSocketConnection = getWebSocketConnection(connectorListener);
+        sendTextMessageAndReceiveResponse("close-without-status-code", connectorListener, webSocketConnection);
+        WebSocketCloseMessage closeMessage = connectorListener.getCloseMessage();
+
+        Assert.assertTrue(connectorListener.isClosed());
+        Assert.assertEquals(closeMessage.getCloseCode(), 1005);
+        Assert.assertEquals(closeMessage.getCloseReason(), "");
+
+        webSocketConnection.finishConnectionClosure().sync();
+        Assert.assertFalse(webSocketConnection.isOpen());
+    }
+
+    @Test
     public void testConnectionClosureFromServerSideWithoutCloseFrame() throws Throwable {
         WebSocketTestClientConnectorListener connectorListener = new WebSocketTestClientConnectorListener();
         WebSocketConnection webSocketConnection = getWebSocketConnection(connectorListener);
@@ -392,11 +407,11 @@ public class WebSocketClientFunctionalityTestCase {
     }
 
     @Test
-    public void testFinishClosure() throws Throwable {
+    public void testClientInitiatedClosureWithoutCloseCode() throws Throwable {
         WebSocketConnection webSocketConnection =
                 getWebSocketConnection(new WebSocketTestClientConnectorListener());
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        ChannelFuture closeFuture = webSocketConnection.initiateConnectionClosure(1001, "Going away").addListener(
+        ChannelFuture closeFuture = webSocketConnection.initiateConnectionClosure().addListener(
                 future -> countDownLatch.countDown());
         countDownLatch.await(WEBSOCKET_TEST_IDLE_TIMEOUT, SECONDS);
 


### PR DESCRIPTION
## Purpose
> Netty returns -1 if statusCode is lacking in close. This PR displays it to the user as 1005 based on WebSocket spec. Also the PR allows for initiating and finishing close without a close status code.

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/10135