### PR TITLE
Add outbound throttling

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -195,6 +195,7 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                             || protocol.equalsIgnoreCase(Constants.HTTP2_TLS_PROTOCOL)) {
                         prepareTargetChannelForHttp2();
                     } else {
+                        httpOutboundRequest.setChannel(channelFuture.channel());
                         // Response for the upgrade request will arrive in stream 1,
                         // so use 1 as the stream id.
                         prepareTargetChannelForHttp(channelFuture);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ReceivingHeaders.java
@@ -93,7 +93,7 @@ public class ReceivingHeaders implements ListenerState {
                 ServerConnectorFuture outboundRespFuture = httpRequestMsg.getHttpResponseFuture();
                 outboundRespFuture.setHttpConnectorListener(
                         new HttpOutboundRespListener(httpRequestMsg, sourceHandler));
-                httpRequestMsg.setSourceContext(sourceHandler.getInboundChannelContext());
+                httpRequestMsg.setChannel(sourceHandler.getInboundChannelContext().channel());
                 sourceHandler.getServerConnectorFuture().notifyHttpListener(httpRequestMsg);
             } catch (Exception e) {
                 log.error("Error while notifying listeners", e);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/sender/ReceivingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/sender/ReceivingEntityBody.java
@@ -76,6 +76,7 @@ public class ReceivingEntityBody implements SenderState {
             messageStateContext.setSenderState(new EntityBodyReceived());
 
             if (!isKeepAlive(targetHandler.getKeepAliveConfig(), targetHandler.getOutboundRequestMsg())) {
+                targetHandler.releaseWritingBlocker();
                 targetHandler.closeChannel(ctx);
             }
             targetHandler.getConnectionManager().returnChannel(targetHandler.getTargetChannel());

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -19,7 +19,7 @@
 package org.wso2.transport.http.netty.message;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -43,6 +43,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Semaphore;
 
 /**
  * HTTP based representation for HttpCarbonMessage.
@@ -57,12 +58,13 @@ public class HttpCarbonMessage {
     private final ServerConnectorFuture httpOutboundRespFuture = new HttpWsServerConnectorFuture();
     private final DefaultHttpResponseFuture httpOutboundRespStatusFuture = new DefaultHttpResponseFuture();
     private final Observable contentObservable = new DefaultObservable();
+    private final Semaphore writingBlocker = new Semaphore(0);
     private IOException ioException;
     private MessageStateContext messageStateContext;
 
 
     private long sequenceId; //Keep track of request/response order
-    private ChannelHandlerContext sourceContext;
+    private Channel channel;
     private HttpPipeliningFuture pipeliningFuture;
     private boolean keepAlive;
     private boolean pipeliningNeeded;
@@ -414,12 +416,12 @@ public class HttpCarbonMessage {
         this.sequenceId = sequenceId;
     }
 
-    public ChannelHandlerContext getSourceContext() {
-        return sourceContext;
+    public Channel getChannel() {
+        return channel;
     }
 
-    public void setSourceContext(ChannelHandlerContext sourceContext) {
-        this.sourceContext = sourceContext;
+    public void setChannel(Channel channel) {
+        this.channel = channel;
     }
 
     public boolean isKeepAlive() {
@@ -444,5 +446,9 @@ public class HttpCarbonMessage {
 
     public void setPipeliningFuture(HttpPipeliningFuture pipeliningFuture) {
         this.pipeliningFuture = pipeliningFuture;
+    }
+
+    public Semaphore getWritingBlocker() {
+        return writingBlocker;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/httppipelining/HttpPipeliningListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/httppipelining/HttpPipeliningListener.java
@@ -18,6 +18,7 @@
 
 package org.wso2.transport.http.netty.httppipelining;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
@@ -58,8 +59,8 @@ public class HttpPipeliningListener implements HttpConnectorListener {
                 httpResponse.setProperty(Constants.HTTP_STATUS_CODE, HttpResponseStatus.OK.code());
                 httpResponse.setSequenceId(httpRequest.getSequenceId());
                 httpResponse.setPipeliningNeeded(httpRequest.isPipeliningNeeded());
-                ChannelHandlerContext sourceContext = httpRequest.getSourceContext();
-                Long nextSequenceNumber = sourceContext.channel().attr(Constants.NEXT_SEQUENCE_NUMBER).get();
+                Channel channel = httpRequest.getChannel();
+                Long nextSequenceNumber = channel.attr(Constants.NEXT_SEQUENCE_NUMBER).get();
                 httpResponse.setHeader("x-sequence-number", nextSequenceNumber.toString());
                 do {
                     HttpContent httpContent = httpRequest.getHttpContent();


### PR DESCRIPTION
## Purpose
Client can go OOM if the server is slow during a send operation because of data collecting in the netty buffer. Similarly server can go OOM if the client is slow during a respond operation. Outbound throttling fixes this issue.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/8767