### PR TITLE
Remove request entry from map when response is completed

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/SourceHandler.java
@@ -308,8 +308,11 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
         return serverName;
     }
 
-    public void resetInboundRequestMsg(HttpCarbonMessage inboundRequestMsg) {
-        requestSet.remove(inboundRequestMsg.hashCode());
+    public void removeRequestEntry(HttpCarbonMessage inboundRequestMsg) {
+        this.requestSet.remove(inboundRequestMsg.hashCode());
+    }
+
+    public void resetInboundRequestMsg() {
         this.inboundRequestMsg = null;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ReceivingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ReceivingEntityBody.java
@@ -86,7 +86,7 @@ public class ReceivingEntityBody implements ListenerState {
                     if (isDiffered(inboundRequestMsg)) {
                         serverConnectorFuture.notifyHttpListener(inboundRequestMsg);
                     }
-                    sourceHandler.resetInboundRequestMsg(inboundRequestMsg);
+                    sourceHandler.resetInboundRequestMsg();
                     messageStateContext.setListenerState(
                             new EntityBodyReceived(messageStateContext, sourceHandler, httpVersion));
                 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ResponseCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/states/listener/ResponseCompleted.java
@@ -50,6 +50,7 @@ public class ResponseCompleted implements ListenerState {
         this.sourceHandler = sourceHandler;
         this.messageStateContext = messageStateContext;
         this.inboundRequestMsg = inboundRequestMsg;
+        this.sourceHandler.removeRequestEntry(inboundRequestMsg);
     }
 
     @Override
@@ -91,6 +92,7 @@ public class ResponseCompleted implements ListenerState {
     }
 
     private void cleanupSourceHandler(HttpCarbonMessage inboundRequestMsg) {
-        sourceHandler.resetInboundRequestMsg(inboundRequestMsg);
+        sourceHandler.removeRequestEntry(inboundRequestMsg);
+        sourceHandler.resetInboundRequestMsg();
     }
 }


### PR DESCRIPTION
## Purpose
> Request are added to a concurrent Hash Map and removed when response is completed. Due to a recent change, the request has been removed before the completion of response. This PR fixes the bug
