### PR TITLE
Unify the logger variable name of HTTP/2 classes

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/Http2SourceConnectionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/Http2SourceConnectionHandler.java
@@ -46,7 +46,7 @@ import static org.wso2.transport.http.netty.common.Util.safelyRemoveHandlers;
  */
 public class Http2SourceConnectionHandler extends Http2ConnectionHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(Http2SourceConnectionHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SourceConnectionHandler.class);
 
     private Http2FrameListener http2FrameListener;
     private Http2ConnectionEncoder encoder;
@@ -94,7 +94,7 @@ public class Http2SourceConnectionHandler extends Http2ConnectionHandler {
         Http2Exception embedded = getEmbeddedHttp2Exception(cause);
         if (embedded instanceof Http2Exception.ClosedStreamCreationException) {
             // We will end up here if we try to write to a already rejected stream
-            log.warn("Stream creation failed, {}, {}", Constants.PROMISED_STREAM_REJECTED_ERROR, embedded.getMessage());
+            LOG.warn("Stream creation failed, {}, {}", Constants.PROMISED_STREAM_REJECTED_ERROR, embedded.getMessage());
         } else {
             super.onError(ctx, cause);
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/Http2SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/listener/http2/Http2SourceHandler.java
@@ -61,7 +61,7 @@ import java.util.Map;
  */
 public final class Http2SourceHandler extends ChannelInboundHandlerAdapter {
 
-    private static final Logger log = LoggerFactory.getLogger(Http2SourceHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Http2SourceHandler.class);
 
     // streamIdRequestMap contains mapping of http carbon messages vs stream id to support multiplexing
     private Map<Integer, HttpCarbonMessage> streamIdRequestMap = PlatformDependent.newConcurrentHashMap();
@@ -162,7 +162,7 @@ public final class Http2SourceHandler extends ChannelInboundHandlerAdapter {
                     sourceReqCMsg.addHttpContent(new DefaultHttpContent(data));
                 }
             } else {
-                log.warn("Inconsistent state detected : data has received before headers");
+                LOG.warn("Inconsistent state detected : data has received before headers");
             }
         } else {
             ctx.fireChannelRead(msg);
@@ -208,10 +208,10 @@ public final class Http2SourceHandler extends ChannelInboundHandlerAdapter {
                         remoteAddress));
                 serverConnectorFuture.notifyHttpListener(httpRequestMsg);
             } catch (Exception e) {
-                log.error("Error while notifying listeners", e);
+                LOG.error("Error while notifying listeners", e);
             }
         } else {
-            log.error("Cannot find registered listener to forward the message");
+            LOG.error("Cannot find registered listener to forward the message");
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/TargetHandler.java
@@ -48,7 +48,8 @@ import static org.wso2.transport.http.netty.common.Util.safelyRemoveHandlers;
  * A class responsible for handling responses coming from BE.
  */
 public class TargetHandler extends ChannelInboundHandlerAdapter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TargetHandler.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(TargetHandler.class);
 
     private HttpResponseFuture httpResponseFuture;
     private HttpCarbonMessage inboundResponseMsg;
@@ -80,7 +81,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             }
         } else {
             if (msg instanceof HttpResponse) {
-                LOGGER.warn("Received a response for an obsolete request {}", msg);
+                LOG.warn("Received a response for an obsolete request {}", msg);
             }
             ReferenceCountUtil.release(msg);
         }
@@ -112,7 +113,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         closeChannel(ctx);
-        LOGGER.warn("Exception occurred in TargetHandler : {}", cause.getMessage());
+        LOG.warn("Exception occurred in TargetHandler : {}", cause.getMessage());
     }
 
     @Override
@@ -133,18 +134,18 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
             }
             ctx.fireUserEventTriggered(evt);
         } else if (evt instanceof Http2ConnectionPrefaceAndSettingsFrameWrittenEvent) {
-            LOGGER.debug("Connection Preface and Settings frame written");
+            LOG.debug("Connection Preface and Settings frame written");
         } else if (evt instanceof SslCloseCompletionEvent) {
-            LOGGER.debug("SSL close completion event received");
+            LOG.debug("SSL close completion event received");
         } else if (evt instanceof ChannelInputShutdownReadComplete) {
             // When you try to read from a channel which has already been closed by the peer,
             // 'java.io.IOException: Connection reset by peer' is thrown and it is a harmless exception.
             // We can ignore this most of the time. see 'https://github.com/netty/netty/issues/2332'.
             // As per the code, when an IOException is thrown when reading from a channel, it closes the channel.
             // When closing the channel, if it is already closed it will trigger this event. So we can ignore this.
-            LOGGER.debug("Input side of the connection is already shutdown");
+            LOG.debug("Input side of the connection is already shutdown");
         } else {
-            LOGGER.warn("Unexpected user event {} triggered", evt);
+            LOG.warn("Unexpected user event {} triggered", evt);
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientFrameListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/ClientFrameListener.java
@@ -39,14 +39,14 @@ import org.wso2.transport.http.netty.message.Http2Reset;
  */
 public class ClientFrameListener extends Http2EventAdapter {
 
-    private static final Logger log = LoggerFactory.getLogger(ClientFrameListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ClientFrameListener.class);
 
     private Http2ClientChannel http2ClientChannel;
 
     @Override
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream) {
-        if (log.isDebugEnabled()) {
-            log.debug("Reading data on channel: {} with stream id: {}, isEndOfStream: {}", http2ClientChannel, streamId,
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Reading data on channel: {} with stream id: {}, isEndOfStream: {}", http2ClientChannel, streamId,
                     endOfStream);
         }
 
@@ -70,8 +70,8 @@ public class ClientFrameListener extends Http2EventAdapter {
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
                               boolean endStream) {
-        if (log.isDebugEnabled()) {
-            log.debug("Reading Http2 headers on channel: {} with stream id: {}, isEndOfStream: {}", http2ClientChannel,
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Reading Http2 headers on channel: {} with stream id: {}, isEndOfStream: {}", http2ClientChannel,
                     streamId, endStream);
         }
 
@@ -87,14 +87,14 @@ public class ClientFrameListener extends Http2EventAdapter {
     @Override
     public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
             throws Http2Exception {
-        log.debug("Http2FrameListenAdapter.onSettingRead()");
+        LOG.debug("Http2FrameListenAdapter.onSettingRead()");
         ctx.fireChannelRead(settings);
         super.onSettingsRead(ctx, settings);
     }
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {
-        log.warn("RST received on channel: {} for streamId: {} errorCode: {}", http2ClientChannel, streamId, errorCode);
+        LOG.warn("RST received on channel: {} for streamId: {} errorCode: {}", http2ClientChannel, streamId, errorCode);
         Http2Reset http2Reset = new Http2Reset(streamId, Http2Error.valueOf(errorCode));
         ctx.fireChannelRead(http2Reset);
     }
@@ -102,8 +102,8 @@ public class ClientFrameListener extends Http2EventAdapter {
     @Override
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
                                   Http2Headers headers, int padding) throws Http2Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("Received a push promise on channel: {} over stream id: {}, promisedStreamId: {}",
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received a push promise on channel: {} over stream id: {}, promisedStreamId: {}",
                     http2ClientChannel, streamId, promisedStreamId);
         }
         for (Http2DataEventListener listener : http2ClientChannel.getDataEventListeners()) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2ClientChannel.java
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Http2ClientChannel {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Http2ClientChannel.class);
+
     private ConcurrentHashMap<Integer, OutboundMsgHolder> inFlightMessages;
     private ConcurrentHashMap<Integer, OutboundMsgHolder> promisedMessages;
     private Channel channel;
@@ -57,8 +59,6 @@ public class Http2ClientChannel {
     private int socketIdleTimeout = Constants.ENDPOINT_TIMEOUT;
     private Map<String, Http2DataEventListener> dataEventListeners;
     private StreamCloseListener streamCloseListener;
-
-    private static final Logger log = LoggerFactory.getLogger(Http2ClientChannel.class);
 
     public Http2ClientChannel(Http2ConnectionManager http2ConnectionManager, Http2Connection connection,
                               HttpRoute httpRoute, Channel channel) {
@@ -125,8 +125,8 @@ public class Http2ClientChannel {
      * @param inFlightMessage {@link OutboundMsgHolder} which holds the in-flight message
      */
     public void putInFlightMessage(int streamId, OutboundMsgHolder inFlightMessage) {
-        if (log.isDebugEnabled()) {
-            log.debug("In flight message added to channel: {} with stream id: {}  ", this, streamId);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("In flight message added to channel: {} with stream id: {}  ", this, streamId);
         }
         inFlightMessages.put(streamId, inFlightMessage);
     }
@@ -138,8 +138,8 @@ public class Http2ClientChannel {
      * @return in-flight message associated with the a particular stream id
      */
     public OutboundMsgHolder getInFlightMessage(int streamId) {
-        if (log.isDebugEnabled()) {
-            log.debug("Getting in flight message for stream id: {} from channel: {}", streamId, this);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Getting in flight message for stream id: {} from channel: {}", streamId, this);
         }
         return inFlightMessages.get(streamId);
     }
@@ -150,8 +150,8 @@ public class Http2ClientChannel {
      * @param streamId stream id
      */
     void removeInFlightMessage(int streamId) {
-        if (log.isDebugEnabled()) {
-            log.debug("In flight message for stream id: {} removed from channel: {}", streamId, this);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("In flight message for stream id: {} removed from channel: {}", streamId, this);
         }
         inFlightMessages.remove(streamId);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/Http2TargetHandler.java
@@ -63,7 +63,8 @@ import java.util.Locale;
  */
 public class Http2TargetHandler extends ChannelDuplexHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(Http2TargetHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Http2TargetHandler.class);
+
     private Http2Connection connection;
     // Encoder associated with the HTTP2ConnectionHandler
     private Http2ConnectionEncoder encoder;
@@ -140,7 +141,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                                 } catch (Exception ex) {
                                     String errorMsg = "Failed to send the request : " +
                                             ex.getMessage().toLowerCase(Locale.ENGLISH);
-                                    log.error(errorMsg, ex);
+                                    LOG.error(errorMsg, ex);
                                     outboundMsgHolder.getResponseFuture().notifyHttpListener(ex);
                                 }
                             })));
@@ -198,7 +199,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                     outboundMsgHolder.setRequestWritten(true);
                 }
             } catch (Exception ex) {
-                log.error("Error while writing request", ex);
+                LOG.error("Error while writing request", ex);
             } finally {
                 if (release) {
                     ReferenceCountUtil.release(msg);
@@ -222,7 +223,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         private synchronized int getNextStreamId() throws Http2Exception {
             int nextStreamId = connection.local().incrementAndGetNextStreamId();
             connection.local().createStream(nextStreamId, false);
-            log.debug("Stream created streamId: {}", nextStreamId);
+            LOG.debug("Stream created streamId: {}", nextStreamId);
             return nextStreamId;
         }
 
@@ -293,7 +294,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
             if (outboundMsgHolder != null) {
                 isServerPush = true;
             } else {
-                log.warn("Header Frame received on channel: {} with invalid stream id: {} ", http2ClientChannel,
+                LOG.warn("Header Frame received on channel: {} with invalid stream id: {} ", http2ClientChannel,
                         streamId);
                 return;
             }
@@ -370,7 +371,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
             if (outboundMsgHolder != null) {
                 isServerPush = true;
             } else {
-                log.warn("Data Frame received on channel: {} with invalid stream id: {}", http2ClientChannel, streamId);
+                LOG.warn("Data Frame received on channel: {} with invalid stream id: {}", http2ClientChannel, streamId);
                 return;
             }
         }
@@ -397,14 +398,14 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         int streamId = pushPromise.getStreamId();
         int promisedStreamId = pushPromise.getPromisedStreamId();
 
-        if (log.isDebugEnabled()) {
-            log.debug("Received a push promise on channel: {} over stream id: {}, promisedStreamId: {}",
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Received a push promise on channel: {} over stream id: {}, promisedStreamId: {}",
                     http2ClientChannel, streamId, promisedStreamId);
         }
 
         OutboundMsgHolder outboundMsgHolder = http2ClientChannel.getInFlightMessage(streamId);
         if (outboundMsgHolder == null) {
-            log.warn("Push promise received in channel: {} over invalid stream id : {}", http2ClientChannel, streamId);
+            LOG.warn("Push promise received in channel: {} over invalid stream id : {}", http2ClientChannel, streamId);
             return;
         }
         http2ClientChannel.putPromisedMessage(promisedStreamId, outboundMsgHolder);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/TimeoutHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/sender/http2/TimeoutHandler.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TimeoutHandler implements Http2DataEventListener {
 
-    private static final Logger log = LoggerFactory.getLogger(TimeoutHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TimeoutHandler.class);
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 
     private long idleTimeNanos;
@@ -138,7 +138,7 @@ public class TimeoutHandler implements Http2DataEventListener {
         if (msgHolder != null) {
             msgHolder.setLastReadWriteTime(ticksInNanos());
         } else {
-            log.debug("OutboundMsgHolder may have already removed for streamId: {}", streamId);
+            LOG.debug("OutboundMsgHolder may have already removed for streamId: {}", streamId);
         }
     }
 
@@ -184,7 +184,7 @@ public class TimeoutHandler implements Http2DataEventListener {
             lastHttpContent.setDecoderResult(DecoderResult.failure(new DecoderException(
                     Constants.IDLE_TIMEOUT_TRIGGERED_WHILE_READING_INBOUND_RESPONSE_BODY)));
             msgHolder.getResponse().addHttpContent(lastHttpContent);
-            log.warn(Constants.IDLE_TIMEOUT_TRIGGERED_WHILE_READING_INBOUND_RESPONSE_BODY);
+            LOG.warn(Constants.IDLE_TIMEOUT_TRIGGERED_WHILE_READING_INBOUND_RESPONSE_BODY);
         }
 
         private void closeStream(int streamId, ChannelHandlerContext ctx) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -57,11 +57,12 @@ import static org.wso2.transport.http.netty.common.Constants.HTTPS_SCHEME;
  */
 public class CipherSuitesTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CipherSuitesTest.class);
+
     private static HttpClientConnector httpClientConnector;
     private List<Parameter> clientParams;
     private ServerConnector serverConnector;
     private HttpWsConnectorFactory factory;
-    private static Logger logger = LoggerFactory.getLogger(CipherSuitesTest.class);
 
     @DataProvider(name = "ciphers")
 
@@ -173,7 +174,7 @@ public class CipherSuitesTest {
             httpClientConnector.close();
             factory.shutdown();
         } catch (Exception e) {
-            logger.warn("Interrupted while waiting for response", e);
+            LOG.warn("Interrupted while waiting for response", e);
         }
     }
  }


### PR DESCRIPTION
## Purpose
- Use LOG as logger variable name
- Fixes ballerina-platform/ballerina-lang#10370