### PR TITLE
Fix idle timeout to use only ALL_IDLE

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -213,8 +213,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                                        this.pipeliningNeeded, this.pipeliningLimit));
         if (socketIdleTimeout >= 0) {
             serverPipeline.addBefore(Constants.HTTP_SOURCE_HANDLER, Constants.IDLE_STATE_HANDLER,
-                    new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, socketIdleTimeout,
-                            TimeUnit.MILLISECONDS));
+                                     new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS));
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2ConnectionPrefaceAndSettingsFrameWrittenEvent;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
-import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
@@ -118,14 +117,11 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof IdleStateEvent) {
-            IdleStateEvent event = (IdleStateEvent) evt;
-            if (event.state() == IdleState.READER_IDLE || event.state() == IdleState.WRITER_IDLE) {
-                targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
-                this.idleTimeoutTriggered = true;
-                ctx.close();
-                outboundRequestMsg.getMessageStateContext().getSenderState().handleIdleTimeoutConnectionClosure(
-                        httpResponseFuture, ctx.channel().id().asLongText());
-            }
+            targetChannel.getChannel().pipeline().remove(Constants.IDLE_STATE_HANDLER);
+            this.idleTimeoutTriggered = true;
+            ctx.close();
+            outboundRequestMsg.getMessageStateContext().getSenderState().handleIdleTimeoutConnectionClosure(
+                    httpResponseFuture, ctx.channel().id().asLongText());
         } else if (evt instanceof HttpClientUpgradeHandler.UpgradeEvent) {
             HttpClientUpgradeHandler.UpgradeEvent upgradeEvent = (HttpClientUpgradeHandler.UpgradeEvent) evt;
             if (HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL.name().equals(upgradeEvent.name())) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
@@ -153,8 +153,7 @@ public class TargetChannel {
 
     public void setEndPointTimeout(int socketIdleTimeout) {
         this.getChannel().pipeline().addBefore(Constants.TARGET_HANDLER, Constants.IDLE_STATE_HANDLER,
-                                               new IdleStateHandler(socketIdleTimeout, socketIdleTimeout, 0,
-                                                                    TimeUnit.MILLISECONDS));
+                                               new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS));
         http2ClientChannel.setSocketIdleTimeout(socketIdleTimeout);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
@@ -148,8 +148,7 @@ public class WebSocketClient {
         pipeline.addLast(new HttpObjectAggregator(8192));
         pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
         if (idleTimeout > 0) {
-            pipeline.addLast(new IdleStateHandler(idleTimeout, idleTimeout,
-                    idleTimeout, TimeUnit.MILLISECONDS));
+            pipeline.addLast(new IdleStateHandler(0, 0, idleTimeout, TimeUnit.MILLISECONDS));
         }
         pipeline.addLast(Constants.WEBSOCKET_CLIENT_HANDSHAKE_HANDLER, clientHandshakeHandler);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -122,10 +122,7 @@ public class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws WebSocketConnectorException {
         if (evt instanceof IdleStateEvent) {
-            IdleStateEvent idleStateEvent = (IdleStateEvent) evt;
-            if (idleStateEvent.state() == IdleStateEvent.ALL_IDLE_STATE_EVENT.state()) {
-                notifyIdleTimeout();
-            }
+            notifyIdleTimeout();
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
@@ -211,8 +211,7 @@ public class DefaultWebSocketHandshaker implements WebSocketHandshaker {
         pipeline.remove(Constants.WEBSOCKET_SERVER_HANDSHAKE_HANDLER);
         if (idleTimeout > 0) {
             pipeline.replace(Constants.IDLE_STATE_HANDLER, Constants.IDLE_STATE_HANDLER,
-                             new IdleStateHandler(idleTimeout, idleTimeout, idleTimeout,
-                                                  TimeUnit.MILLISECONDS));
+                             new IdleStateHandler(0, 0, idleTimeout, TimeUnit.MILLISECONDS));
         } else {
             pipeline.remove(Constants.IDLE_STATE_HANDLER);
         }


### PR DESCRIPTION
## Purpose
Makes sure connection is closed only for ALL_IDLE event. Earlier the connection was closed for READER_IDLE or WRITER_IDLE events as well.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/10381