### PR TITLE
Remove unnecessary state change

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/ResponseCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/ResponseCompleted.java
@@ -86,6 +86,5 @@ public class ResponseCompleted implements ListenerState {
 
     private void cleanupSourceHandler(HttpCarbonMessage inboundRequestMsg) {
         sourceHandler.removeRequestEntry(inboundRequestMsg);
-        sourceHandler.setConnectedState(true);
     }
 }


### PR DESCRIPTION
## Purpose
> State changing to connected stated once the response is complete is not necessary. It results an extra log printed in the log when the connection is closed.

