### PR TITLE
Add onClose method to the ConnectorListener

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnectorFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnectorFuture.java
@@ -63,12 +63,20 @@ public interface WebSocketConnectorFuture {
     void notifyWebSocketListener(WebSocketControlMessage controlMessage) throws WebSocketConnectorException;
 
     /**
-     * Notify incoming WebSocket connection closure for the listener.
+     * Notify WebSocket close message to the user.
      *
      * @param closeMessage {@link WebSocketCloseMessage} to notify incoming WebSocket connection closure
      * @throws WebSocketConnectorException if any error occurred during the notification
      */
     void notifyWebSocketListener(WebSocketCloseMessage closeMessage) throws WebSocketConnectorException;
+
+    /**
+     * Notify incoming WebSocket connection closure for the listener.
+     *
+     * @param webSocketConnection {@link WebSocketConnection} to notify incoming WebSocket connection closure
+     * @throws WebSocketConnectorException if any error occurred during the notification
+     */
+    void notifyWebSocketListener(WebSocketConnection webSocketConnection) throws WebSocketConnectorException;
 
     /**
      * Notify any error occurred in transport for the listener.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketConnectorListener.java
@@ -61,6 +61,16 @@ public interface WebSocketConnectorListener {
     void onMessage(WebSocketCloseMessage closeMessage);
 
     /**
+     * This lets the listener know when the connection closes. This method will be called only after the user is
+     * notified of a close message or an error message if one is available. It is also possible that this method is
+     * called without a close message or an error message. Also note that this method will be called only after the
+     * futures of connection closure methods return.
+     *
+     * @param webSocketConnection {@link WebSocketConnection} which gets closed.
+     */
+    void onClose(WebSocketConnection webSocketConnection);
+
+    /**
      * Trigger any transport error.
      *
      * @param webSocketConnection {@link WebSocketConnection} which causes the error.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnectorFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketConnectorFuture.java
@@ -83,6 +83,12 @@ public class DefaultWebSocketConnectorFuture implements WebSocketConnectorFuture
         wsConnectorListener.onIdleTimeout(controlMessage);
     }
 
+    @Override
+    public void notifyWebSocketListener(WebSocketConnection webSocketConnection) throws WebSocketConnectorException {
+        checkConnectorState();
+        wsConnectorListener.onClose(webSocketConnection);
+    }
+
     private void checkConnectorState() throws WebSocketConnectorException {
         if (wsConnectorListener == null) {
             throw new WebSocketConnectorException("WebSocket connector listener is not set");

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -128,7 +128,7 @@ public class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws WebSocketConnectorException {
-        if (!caughtException && webSocketConnection != null && !this.isCloseFrameReceived() && closePromise == null &&
+        if (!caughtException && webSocketConnection != null && !closeFrameReceived && closePromise == null &&
                 !closeInitialized) {
             // Notify abnormal closure.
             DefaultWebSocketMessage webSocketCloseMessage =
@@ -142,6 +142,7 @@ public class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
             String errMsg = "Connection is closed by remote endpoint without echoing a close frame";
             ctx.close().addListener(closeFuture -> closePromise.setFailure(new IllegalStateException(errMsg)));
         }
+        connectorFuture.notifyWebSocketListener(webSocketConnection);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketTestClientConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketTestClientConnectorListener.java
@@ -113,6 +113,11 @@ public class WebSocketTestClientConnectorListener implements WebSocketConnectorL
     }
 
     @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        //Do nothing
+    }
+
+    @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
         errorsQueue.add(throwable);
         LOG.error("Error handler received: " + throwable.getMessage());

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/passthrough/WebSocketPassThroughClientConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/passthrough/WebSocketPassThroughClientConnectorListener.java
@@ -67,6 +67,11 @@ public class WebSocketPassThroughClientConnectorListener implements WebSocketCon
     }
 
     @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        //Do nothing
+    }
+
+    @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/passthrough/WebSocketPassThroughServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/passthrough/WebSocketPassThroughServerConnectorListener.java
@@ -118,6 +118,11 @@ public class WebSocketPassThroughServerConnectorListener implements WebSocketCon
     }
 
     @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        //Do nothing
+    }
+
+    @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
 
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityListener.java
@@ -135,6 +135,11 @@ public class WebSocketServerHandshakeFunctionalityListener implements WebSocketC
     }
 
     @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        //Do nothing
+    }
+
+    @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
 
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketTestServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketTestServerConnectorListener.java
@@ -142,6 +142,11 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
     }
 
     @Override
+    public void onClose(WebSocketConnection webSocketConnection) {
+        //Do nothing
+    }
+
+    @Override
     public void onError(WebSocketConnection webSocketConnection, Throwable throwable) {
         handleError(throwable);
     }


### PR DESCRIPTION
## Purpose
The onClose method for the WebSocketConnectorListener has been introduced in order to let the listener know when the connection closes. This method will be called only after the user is notified of a close message or an error message. Also note that this method will be called only after the futures of connection closure methods return.

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/10667