### PR TITLE
Add outbound throttling

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -230,6 +230,7 @@ public final class Constants {
     public static final String HTTP2_TARGET_HANDLER = "http2TargetHandler";
     public static final String TARGET_HANDLER = "targetHandler";
     public static final String HTTP2_TIMEOUT_HANDLER = "Http2TimeoutHandler";
+    public static final String BACK_PRESSURE_HANDLER = "BackPressureHandler";
     public static final String HTTP2_UPGRADE_HANDLER = "Http2UpgradeHandler";
     public static final String HTTP2_TO_HTTP_FALLBACK_HANDLER = "Http2ToHttpFallbackHandler";
     public static final String DECOMPRESSOR_HANDLER = "deCompressor";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/HttpOutboundRespListener.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
+import org.wso2.transport.http.netty.contractimpl.common.BackPressureHandler;
+import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.states.MessageStateContext;
 import org.wso2.transport.http.netty.contractimpl.listener.RequestDataHolder;
 import org.wso2.transport.http.netty.contractimpl.listener.SourceHandler;
@@ -69,23 +71,25 @@ public class HttpOutboundRespListener implements HttpConnectorListener {
 
     @Override
     public void onMessage(HttpCarbonMessage outboundResponseMsg) {
-        sourceContext.channel().eventLoop().execute(() -> {
+        BackPressureHandler backpressureHandler = Util.getBackPressureHandler(sourceContext);
+        Util.setBackPressureListener(outboundResponseMsg.isPassthrough(), backpressureHandler,
+                                     outboundResponseMsg.getTargetContext());
+        if (handlerExecutor != null) {
+            handlerExecutor.executeAtSourceResponseReceiving(outboundResponseMsg);
+        }
 
-            if (handlerExecutor != null) {
-                handlerExecutor.executeAtSourceResponseReceiving(outboundResponseMsg);
-            }
-
-            outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent ->
-                    this.sourceContext.channel().eventLoop().execute(() -> {
-                        try {
-                            writeOutboundResponse(outboundResponseMsg, httpContent);
-                        } catch (Exception exception) {
-                            String errorMsg = "Failed to send the outbound response : "
-                                    + exception.getMessage().toLowerCase(Locale.ENGLISH);
-                            LOG.error(errorMsg, exception);
-                            inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(exception);
-                        }
-                    }));
+        outboundResponseMsg.getHttpContentAsync().setMessageListener(httpContent -> {
+            Util.checkUnWritabilityAndNotify(sourceContext, backpressureHandler);
+            this.sourceContext.channel().eventLoop().execute(() -> {
+                try {
+                    writeOutboundResponse(outboundResponseMsg, httpContent);
+                } catch (Exception exception) {
+                    String errorMsg = "Failed to send the outbound response : "
+                            + exception.getMessage().toLowerCase(Locale.ENGLISH);
+                    LOG.error(errorMsg, exception);
+                    inboundRequestMsg.getHttpOutboundRespStatusFuture().notifyHttpListener(exception);
+                }
+            });
         });
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/BackPressureHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/BackPressureHandler.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.common;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.wso2.transport.http.netty.message.BackPressureObservable;
+import org.wso2.transport.http.netty.message.DefaultBackPressureObservable;
+
+/**
+ * Handles backpressure.
+ * Overrides the channelWritabilityChanged method to check the writability of the channel which is needed for
+ * handling backpressure.
+ */
+public class BackPressureHandler extends ChannelInboundHandlerAdapter {
+
+    private final BackPressureObservable backPressureObservable = new DefaultBackPressureObservable();
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+        if (ctx.channel().isWritable()) {
+            backPressureObservable.notifyWritable();
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        backPressureObservable.notifyWritable();
+        ctx.fireChannelInactive();
+    }
+
+    /**
+     * @return the observable that could be used to set/notify the listeners.
+     */
+    public BackPressureObservable getBackPressureObservable() {
+        return backPressureObservable;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -46,6 +46,7 @@ import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
+import org.wso2.transport.http.netty.contractimpl.common.BackPressureHandler;
 import org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.CertificateVerificationException;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLHandlerFactory;
@@ -207,6 +208,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
         serverPipeline.addLast(Constants.WEBSOCKET_SERVER_HANDSHAKE_HANDLER,
                          new WebSocketServerHandshakeHandler(this.serverConnectorFuture, this.interfaceId));
+        serverPipeline.addLast(Constants.BACK_PRESSURE_HANDLER, new BackPressureHandler());
         serverPipeline.addLast(Constants.HTTP_SOURCE_HANDLER,
                                new SourceHandler(this.serverConnectorFuture, this.interfaceId, this.chunkConfig,
                                                  keepAliveConfig, this.serverName, this.allChannels,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
@@ -77,6 +77,9 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
                         LOG.debug("Upgrading the connection from Http to WebSocket for channel : {}", ctx.channel());
                     }
                     ChannelPipeline pipeline = ctx.pipeline();
+                    if (pipeline.get(Constants.BACK_PRESSURE_HANDLER) != null) {
+                        pipeline.remove(Constants.BACK_PRESSURE_HANDLER);
+                    }
                     pipeline.remove(Constants.HTTP_SOURCE_HANDLER);
                     ChannelHandlerContext decoderCtx = pipeline.context(HttpRequestDecoder.class);
                     pipeline.addAfter(decoderCtx.name(), HTTP_OBJECT_AGGREGATOR,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -42,6 +42,7 @@ import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contractimpl.common.BackPressureHandler;
 import org.wso2.transport.http.netty.contractimpl.common.FrameLogger;
 import org.wso2.transport.http.netty.contractimpl.common.HttpRoute;
 import org.wso2.transport.http.netty.contractimpl.common.Util;
@@ -235,6 +236,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     public void configureHttpPipeline(ChannelPipeline pipeline, TargetHandler targetHandler) {
         pipeline.addLast(Constants.HTTP_CLIENT_CODEC, new HttpClientCodec());
         addCommonHandlers(pipeline);
+        pipeline.addLast(Constants.BACK_PRESSURE_HANDLER, new BackPressureHandler());
         pipeline.addLast(Constants.TARGET_HANDLER, targetHandler);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
@@ -59,6 +59,12 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     private HandlerExecutor handlerExecutor;
     private KeepAliveConfig keepAliveConfig;
     private boolean idleTimeoutTriggered;
+    private ChannelHandlerContext context;
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        context = ctx;
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -231,5 +237,14 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     public ConnectionManager getConnectionManager() {
         return connectionManager;
+    }
+
+    /**
+     * Gets the {@link ChannelHandlerContext} of the {@link TargetHandler}.
+     *
+     * @return the {@link ChannelHandlerContext} of this handler.
+     */
+    public ChannelHandlerContext getContext() {
+        return context;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/ReceivingHeaders.java
@@ -71,7 +71,9 @@ public class ReceivingHeaders implements SenderState {
             msgHolder.markNoPromisesReceived();
         }
         if (targetHandler.getHttpResponseFuture() != null) {
-            targetHandler.getHttpResponseFuture().notifyHttpListener(targetHandler.getInboundResponseMsg());
+            HttpCarbonMessage inboundResponseMsg = targetHandler.getInboundResponseMsg();
+            inboundResponseMsg.setTargetContext(targetHandler.getContext());
+            targetHandler.getHttpResponseFuture().notifyHttpListener(inboundResponseMsg);
         } else {
             LOG.error("Cannot notify the response to client as there is no associated responseFuture");
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BackPressureListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BackPressureListener.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+/**
+ * Gets notified to acquire or release during backpressure handling.
+ */
+public interface BackPressureListener {
+
+    /**
+     * Get notified to start throttling.
+     */
+    void onUnWritable();
+
+    /**
+     * Get notified to release throttling.
+     */
+    void onWritable();
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BackPressureObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/BackPressureObservable.java
@@ -18,27 +18,29 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.handler.codec.http.HttpContent;
-
 /**
- * Get notified upon receiving new messages.
+ * Allows listeners to register and get notified.
  */
-public interface Listener {
+public interface BackPressureObservable {
 
     /**
-     * Get notified when content are added to the message.
-     * @param httpContent of the message
+     * Set listener interested for message events.
+     * @param listener for message
      */
-    void onAdd(HttpContent httpContent);
+    void setListener(BackPressureListener listener);
 
     /**
-     * Get notified when content is removed from the the message.
-     * @param httpContent of the message
+     * Remove listener from the observable.
      */
-    void onRemove(HttpContent httpContent);
+    void removeListener();
 
     /**
-     * Since the listener removes readInterest this method resumes it if required.
+     * Notify to start throttling.
      */
-    void resumeReadInterest();
+    void notifyUnWritable();
+
+    /**
+     * Notify to release throttling.
+     */
+    void notifyWritable();
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultBackPressureListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultBackPressureListener.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Default implementation of the {@link BackPressureListener}.
+ */
+public class DefaultBackPressureListener implements BackPressureListener {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultBackPressureListener.class);
+
+    private Semaphore semaphore;
+
+    /**
+     * Creates the semaphore and sets the source or target channel.
+     */
+    public DefaultBackPressureListener() {
+
+        this.semaphore = new Semaphore(0);
+    }
+
+    @Override
+    public void onUnWritable() {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Semaphore acquired.");
+        }
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void onWritable() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Semaphore released.");
+        }
+        semaphore.release();
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultBackPressureObservable.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultBackPressureObservable.java
@@ -18,39 +18,37 @@
 
 package org.wso2.transport.http.netty.message;
 
-import io.netty.handler.codec.http.HttpContent;
-
 /**
- * Default implementation of the message observer.
+ * Default implementation of the {@link BackPressureObservable}.
  */
-public class DefaultObservable implements Observable {
+public class DefaultBackPressureObservable implements BackPressureObservable {
 
-    private Listener listener;
+    private BackPressureListener listener;
 
     @Override
-    public void setListener(Listener listener) {
+    public void setListener(BackPressureListener listener) {
         this.listener = listener;
     }
 
     @Override
     public void removeListener() {
         if (listener != null) {
-            listener.resumeReadInterest();
+            listener.onWritable();
             listener = null;
         }
     }
 
     @Override
-    public void notifyAddListener(HttpContent httpContent) {
+    public void notifyUnWritable() {
         if (listener != null) {
-            listener.onAdd(httpContent);
+            listener.onUnWritable();
         }
     }
 
     @Override
-    public void notifyGetListener(HttpContent httpContent) {
+    public void notifyWritable() {
         if (listener != null) {
-            listener.onRemove(httpContent);
+            listener.onWritable();
         }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/DefaultListener.java
@@ -65,4 +65,9 @@ public class DefaultListener implements Listener {
             this.ctx.channel().read();
         }
     }
+
+    @Override
+    public void resumeReadInterest() {
+        ctx.channel().config().setAutoRead(true);
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/MessageFuture.java
@@ -47,6 +47,12 @@ public class MessageFuture {
                     return;
                 }
             }
+
+            // Removes Inbound throttling listener during passthrough so that only backpressure handling would be
+            // present.
+            if (httpCarbonMessage.isPassthrough()) {
+                httpCarbonMessage.removeInboundContentListener();
+            }
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/PassthroughBackPressureListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/PassthroughBackPressureListener.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.message;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the {@link BackPressureListener} for the passthrough scenario.
+ */
+public class PassthroughBackPressureListener implements BackPressureListener {
+    private static final Logger LOG = LoggerFactory.getLogger(PassthroughBackPressureListener.class);
+
+    private Channel inChannel;
+
+    /**
+     * Sets the incoming and outgoing message channels.
+     *
+     * @param inContext  This will be used to block and resume read interest of the incoming channel.
+     */
+    public PassthroughBackPressureListener(ChannelHandlerContext inContext) {
+        inChannel = inContext.channel();
+    }
+
+    @Override
+    public void onUnWritable() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Read disabled for inChannel {}", inChannel.id());
+        }
+        inChannel.config().setAutoRead(false);
+    }
+
+    @Override
+    public void onWritable() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Read enabled for inChannel {}", inChannel.id());
+        }
+        inChannel.config().setAutoRead(true);
+    }
+}


### PR DESCRIPTION
## Purpose

Client can go OOM if the server is slow during a send operation because of data collecting in the netty buffer. Similarly server can go OOM if the client is slow during a respond operation. Outbound throttling fixes this issue.

The following scenarios require outbound throttling and are addressed in this PR:
- Server responding with a large file.
- Client sending a large file to server.
- Passthrough of a large request file.
- Passthrough of a large response file.