### PR TITLE
Fix for adding multiple last contents at passthrough scenario

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/states/StateUtil.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/states/StateUtil.java
@@ -135,7 +135,9 @@ public class StateUtil {
                                                   String errorMsg) {
         // Response is processing, but inbound request is not completed yet. So removing the read interest
         channel.config().setAutoRead(false);
-        handleIncompleteInboundMessage(outboundResponseListener.getInboundRequestMsg(), errorMsg);
+        if (outboundResponseListener.getInboundRequestMsg().getIoException() == null) {
+            handleIncompleteInboundMessage(outboundResponseListener.getInboundRequestMsg(), errorMsg);
+        }
 
         // It is an application error. Therefore connection needs to be closed once the response is sent.
         outboundResponseListener.setKeepAliveConfig(KeepAliveConfig.NEVER);


### PR DESCRIPTION
## Purpose
This fix for adding multiple last contents at passthrough scenario when the inbound response received while sending the outbound request at passthrough service.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10774