### PR TITLE
Add common exception handler to listener channelPipeline

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -238,6 +238,7 @@ public final class Constants {
     public static final String HTTP_ACCESS_LOG_HANDLER = "http-access-logger";
     public static final String WEBSOCKET_SERVER_HANDSHAKE_HANDLER = "websocket-server-handshake-handler";
     public static final String WEBSOCKET_CLIENT_HANDSHAKE_HANDLER = "websocket-client-handshake-handler";
+    public static final String EXCEPTION_HANDLER = "exception-handler";
 
     public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf("REDIRECT_COUNT");
     public static final AttributeKey<String> RESOLVED_REQUESTED_URI_ATTR = AttributeKey

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ExceptionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ExceptionHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.listener;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A class responsible for handling exceptions occurred in inbound pipeline. This should be placed at the tail
+ * of the pipeline. When engaged channel handlers have not implemented exceptionCaught method, this class
+ * handle them generally.
+ */
+public class ExceptionHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandler.class);
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        if (ctx != null && ctx.channel().isActive()) {
+            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+        }
+        LOG.warn("Exception occurred in inbound channel pipeline : {}", cause.getMessage());
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ExceptionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ExceptionHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A class responsible for handling exceptions occurred in inbound pipeline. This should be placed at the tail
  * of the pipeline. When engaged channel handlers have not implemented exceptionCaught method, this class
- * handle them generally.
+ * handles them generally.
  */
 public class ExceptionHandler extends ChannelInboundHandlerAdapter {
 
@@ -43,6 +43,6 @@ public class ExceptionHandler extends ChannelInboundHandlerAdapter {
                     HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR))
                     .addListener(ChannelFutureListener.CLOSE);
         }
-        LOG.warn("Exception occurred in inbound channel pipeline : {}", cause.getMessage());
+        LOG.error("Exception occurred in inbound channel pipeline : {}", cause.getMessage());
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -257,7 +257,6 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
            large upgrade requests. Requests will be propagated to next handlers if no upgrade has been attempted */
         pipeline.addLast(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER,
                          new Http2ToHttpFallbackHandler(this));
-        pipeline.addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
     }
 
     public void setServerConnectorFuture(ServerConnectorFuture serverConnectorFuture) {
@@ -376,7 +375,6 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         Constants.HTTP2_SOURCE_CONNECTION_HANDLER,
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, channelInitializer).build());
-                ctx.pipeline().addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
             } else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
                 // handles pipeline for HTTP/1.x requests after SSL handshake
                 configureHttpPipeline(ctx.pipeline(), Constants.HTTP_SCHEME);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -172,6 +172,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         }
         serverPipeline.addLast(Constants.SSL_COMPLETION_HANDLER,
                 new SslHandshakeCompletionHandlerForServer(this, serverPipeline));
+        serverPipeline.addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
     }
 
     /**
@@ -215,6 +216,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             serverPipeline.addBefore(Constants.HTTP_SOURCE_HANDLER, Constants.IDLE_STATE_HANDLER,
                                      new IdleStateHandler(0, 0, socketIdleTimeout, TimeUnit.MILLISECONDS));
         }
+        serverPipeline.addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
     }
 
     /**
@@ -256,6 +258,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
            large upgrade requests. Requests will be propagated to next handlers if no upgrade has been attempted */
         pipeline.addLast(Constants.HTTP2_TO_HTTP_FALLBACK_HANDLER,
                          new Http2ToHttpFallbackHandler(this));
+        pipeline.addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
     }
 
     public void setServerConnectorFuture(ServerConnectorFuture serverConnectorFuture) {
@@ -374,6 +377,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                         Constants.HTTP2_SOURCE_CONNECTION_HANDLER,
                         new Http2SourceConnectionHandlerBuilder(
                                 interfaceId, serverConnectorFuture, serverName, channelInitializer).build());
+                ctx.pipeline().addLast(Constants.EXCEPTION_HANDLER, new ExceptionHandler());
             } else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
                 // handles pipeline for HTTP/1.x requests after SSL handshake
                 configureHttpPipeline(ctx.pipeline(), Constants.HTTP_SCHEME);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -19,9 +19,7 @@
 
 package org.wso2.transport.http.netty.contractimpl.listener;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
@@ -177,14 +175,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
                 LOG.error("Couldn't close target channel socket connections", e);
             }
         });
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        if (ctx != null && ctx.channel().isActive()) {
-            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
-        }
-        LOG.warn("Exception occurred in SourceHandler : {}", cause.getMessage());
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerHandshakeHandler.java
@@ -19,12 +19,10 @@
 
 package org.wso2.transport.http.netty.contractimpl.listener;
 
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -115,13 +113,6 @@ public class WebSocketServerHandshakeHandler extends ChannelInboundHandlerAdapte
             }
         }
         ctx.fireChannelRead(msg);
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        ctx.writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR))
-                .addListener(ChannelFutureListener.CLOSE);
-        LOG.error("Error during WebSocket server handshake", cause);
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -458,4 +458,12 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                 outboundMsgHolder.getRequest().getProperty(Constants.EXECUTOR_WORKER_POOL));
         return responseCarbonMsg;
     }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        if (ctx != null && ctx.channel().isActive()) {
+            ctx.close();
+        }
+        LOG.warn("Exception occurred in HTTP/2 TargetHandler : {}", cause.getMessage());
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -464,6 +464,6 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         if (ctx != null && ctx.channel().isActive()) {
             ctx.close();
         }
-        LOG.warn("Exception occurred in HTTP/2 TargetHandler : {}", cause.getMessage());
+        LOG.error("Exception occurred in HTTP/2 TargetHandler : {}", cause.getMessage());
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/message/DefaultWebSocketHandshaker.java
@@ -218,7 +218,7 @@ public class DefaultWebSocketHandshaker implements WebSocketHandshaker {
         } else {
             pipeline.remove(Constants.IDLE_STATE_HANDLER);
         }
-        pipeline.addLast(Constants.WEBSOCKET_FRAME_HANDLER, frameHandler);
+        pipeline.addBefore(Constants.EXCEPTION_HANDLER, Constants.WEBSOCKET_FRAME_HANDLER, frameHandler);
         frameHandler.getWebSocketConnection().stopReadingFrames();
         pipeline.fireChannelActive();
     }


### PR DESCRIPTION
## Purpose
> The exceptions occurred in channelPipeline during inbound events like channelRead(), channelActive()
 are handled via exceptionCaught() method. According to Netty behavior, the exceptions are handled by the first handler which has implemented that method regardless the relativity. Therefore this PR will introduce common Channel-handler to handle exceptions. 

> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/9756