### PR TITLE
Release not consuming outbound request contents

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/EntityBodyReceived.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/EntityBodyReceived.java
@@ -43,7 +43,9 @@ public class EntityBodyReceived implements SenderState {
 
     @Override
     public void writeOutboundRequestEntity(HttpCarbonMessage httpOutboundRequest, HttpContent httpContent) {
-        LOG.warn("writeOutboundRequestEntity {}", ILLEGAL_STATE_ERROR);
+        // This method might get called when inbound response is received but outbound response is not yet completed.
+        // In that instance, remote host doesn't require request content anymore, Therefore contents are released.
+        httpContent.release();
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> WriteOutboundRequestEntity method of EntityBodyReceived class might get called when inbound response is received but outbound request is not yet completed.In that instance, remote host doesn't require request content anymore, Therefore contents are released using this PR.

