### PR TITLE
Fix an HTTP/2 to HTTP/1.1 fallback scenario

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -377,6 +377,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
             } else if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
                 // handles pipeline for HTTP/1.x requests after SSL handshake
                 configureHttpPipeline(ctx.pipeline(), Constants.HTTP_SCHEME);
+                ctx.pipeline().fireChannelActive();
             } else {
                 throw new IllegalStateException("unknown protocol: " + protocol);
             }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
@@ -50,8 +50,8 @@ public class TestHttp2WithALPN {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestHttp2WithALPN.class);
     private ServerConnector serverConnector;
-    private HttpClientConnector httpClientConnectorForHttp2;
-    private HttpClientConnector httpClientConnectorForHttp1;
+    private HttpClientConnector http1ClientConnector;
+    private HttpClientConnector http2ClientConnector;
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
@@ -65,20 +65,26 @@ public class TestHttp2WithALPN {
         future.sync();
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
-        httpClientConnectorForHttp2 = connectorFactory
+        http2ClientConnector = connectorFactory
                 .createHttpClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_2_0)));
-        httpClientConnectorForHttp1 = connectorFactory
+        http1ClientConnector = connectorFactory
                 .createHttpClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_1_1)));
     }
 
+    /**
+     * This test case will have ALPN negotiation for HTTP/2 request.
+     */
     @Test
     public void testHttp2Post() {
-        TestUtil.testHttpsPost(httpClientConnectorForHttp2, TestUtil.SERVER_PORT1);
+        TestUtil.testHttpsPost(http2ClientConnector, TestUtil.SERVER_PORT1);
     }
 
+    /**
+     * This test case will have ALPN negotiation for HTTP/1.1 request.
+     */
     @Test
     public void testHttp1_1Post() {
-        TestUtil.testHttpsPost(httpClientConnectorForHttp1, TestUtil.SERVER_PORT1);
+        TestUtil.testHttpsPost(http1ClientConnector, TestUtil.SERVER_PORT1);
     }
 
     private ListenerConfiguration getListenerConfigs() {
@@ -110,8 +116,8 @@ public class TestHttp2WithALPN {
 
     @AfterClass
     public void cleanUp() throws ServerConnectorException {
-        httpClientConnectorForHttp2.close();
-        httpClientConnectorForHttp1.close();
+        http2ClientConnector.close();
+        http1ClientConnector.close();
         serverConnector.stop();
         try {
             connectorFactory.shutdown();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.Constants.HTTP_1_1;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_2_0;
 
 /**
@@ -49,7 +50,8 @@ public class TestHttp2WithALPN {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestHttp2WithALPN.class);
     private ServerConnector serverConnector;
-    private HttpClientConnector httpClientConnector;
+    private HttpClientConnector httpClientConnectorForHttp2;
+    private HttpClientConnector httpClientConnectorForHttp1;
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
@@ -63,12 +65,20 @@ public class TestHttp2WithALPN {
         future.sync();
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
-        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnectorForHttp2 = connectorFactory
+                .createHttpClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_2_0)));
+        httpClientConnectorForHttp1 = connectorFactory
+                .createHttpClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_1_1)));
     }
 
     @Test
     public void testHttp2Post() {
-        TestUtil.testHttpsPost(httpClientConnector, TestUtil.SERVER_PORT1);
+        TestUtil.testHttpsPost(httpClientConnectorForHttp2, TestUtil.SERVER_PORT1);
+    }
+
+    @Test
+    public void testHttp1_1Post() {
+        TestUtil.testHttpsPost(httpClientConnectorForHttp1, TestUtil.SERVER_PORT1);
     }
 
     private ListenerConfiguration getListenerConfigs() {
@@ -85,7 +95,7 @@ public class TestHttp2WithALPN {
         return listenerConfiguration;
     }
 
-    private SenderConfiguration getSenderConfigs() {
+    private SenderConfiguration getSenderConfigs(String httpVersion) {
         Parameter paramClientCiphers = new Parameter("ciphers", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256");
         List<Parameter> clientParams = new ArrayList<>(1);
         clientParams.add(paramClientCiphers);
@@ -93,14 +103,15 @@ public class TestHttp2WithALPN {
         senderConfiguration.setParameters(clientParams);
         senderConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         senderConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
-        senderConfiguration.setHttpVersion(String.valueOf(HTTP_2_0));
+        senderConfiguration.setHttpVersion(httpVersion);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         return senderConfiguration;
     }
 
     @AfterClass
     public void cleanUp() throws ServerConnectorException {
-        httpClientConnector.close();
+        httpClientConnectorForHttp2.close();
+        httpClientConnectorForHttp1.close();
         serverConnector.stop();
         try {
             connectorFactory.shutdown();


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/10936

This PR fixes a scenario of HTTP/2 to HTTP/1.1 fallback. The following ballerina program acts as a backend service and it can be invoked by 
`$ curl -k https://localhost:9191/nyseStock/stocks`.
The PR fixes this scenario while removing the NPE occurred at `OutboundRespListener.java` class.

```ballerina
endpoint http:Listener passthroughEP {
    port: 9191,
    httpVersion: "2.0",
    secureSocket: {
        keyStore: {
            path: "${ballerina.home}/bre/security/ballerinaKeystore.p12",
            password: "ballerina"
        }
    }
};

@http:ServiceConfig { basePath: "/nyseStock" }
service<http:Service> nyseStockQuote bind passthroughEP {

    @http:ResourceConfig {
        path: "/stocks"
    }
    stocks(endpoint outboundEP, http:Request clientRequest) {
        http:Response res = new;
        json payload = {"foo":"bar"};
        res.setJsonPayload(untaint payload);
        _ = outboundEP->respond(res);
    }
}
```