### PR TITLE
Fix bidirectional streaming issues in http2 transport

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingEntityBody.java
@@ -45,15 +45,15 @@ public class ReceivingEntityBody implements ListenerState {
     private static final Logger LOG = LoggerFactory.getLogger(ReceivingEntityBody.class);
 
     private final Http2MessageStateContext http2MessageStateContext;
-    private boolean headerSent = false;
+    private boolean headerSent;
 
     ReceivingEntityBody(Http2MessageStateContext http2MessageStateContext) {
         this.http2MessageStateContext = http2MessageStateContext;
     }
 
-    ReceivingEntityBody(Http2MessageStateContext http2MessageStateContext, boolean respHeaderSent) {
+    ReceivingEntityBody(Http2MessageStateContext http2MessageStateContext, boolean headerSent) {
         this(http2MessageStateContext);
-        this.headerSent = respHeaderSent;
+        this.headerSent = headerSent;
     }
 
     @Override
@@ -93,6 +93,8 @@ public class ReceivingEntityBody implements ListenerState {
                                           int streamId) throws Http2Exception {
         // When receiving entity body, if payload is not consumed by the server, this method is invoked if server is
         // going to send the response back.
+        // This conditional check is needed because, either to write response headers or response body, response
+        // writer calls this method. So we need to check whether headers sent to change the state.
         if (headerSent) {
             // response header already sent. move the state to SendingEntityBody.
             http2MessageStateContext.setListenerState(

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingEntityBody.java
@@ -107,8 +107,6 @@ public class SendingEntityBody implements ListenerState {
         // receive. In order to handle it. we need to change the states depending on the action.
         http2MessageStateContext.setListenerState(new ReceivingEntityBody(http2MessageStateContext, Boolean.TRUE));
         http2MessageStateContext.getListenerState().readInboundRequestBody(http2SourceHandler, dataFrame);
-        // PREVIOUS: Response is already started to send, hence the incoming data frames need to be released.
-        // PREVIOUS: releaseDataFrame(http2SourceHandler, dataFrame);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingHeaders.java
@@ -86,8 +86,6 @@ public class SendingHeaders implements ListenerState {
         // receive. In order to handle it. we need to change the states depending on the action.
         http2MessageStateContext.setListenerState(new ReceivingEntityBody(http2MessageStateContext, Boolean.TRUE));
         http2MessageStateContext.getListenerState().readInboundRequestBody(http2SourceHandler, dataFrame);
-        // PREVIOUS: Response is already started to send, hence the incoming data frames need to be released.
-        // PREVIOUS: releaseDataFrame(http2SourceHandler, dataFrame);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingHeaders.java
@@ -41,7 +41,6 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
 import static org.wso2.transport.http.netty.contract.Constants.HTTP2_VERSION;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_SCHEME;
-import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.releaseDataFrame;
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.validatePromisedStreamState;
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.writeHttp2Headers;
 
@@ -81,9 +80,14 @@ public class SendingHeaders implements ListenerState {
     }
 
     @Override
-    public void readInboundRequestBody(Http2SourceHandler http2SourceHandler, Http2DataFrame dataFrame) {
-        // Response is already started to send, hence the incoming data frames need to be released.
-        releaseDataFrame(http2SourceHandler, dataFrame);
+    public void readInboundRequestBody(Http2SourceHandler http2SourceHandler, Http2DataFrame dataFrame) throws
+            Http2Exception {
+        // In bidirectional streaming case, while sending the request data frames, server response data frames can
+        // receive. In order to handle it. we need to change the states depending on the action.
+        http2MessageStateContext.setListenerState(new ReceivingEntityBody(http2MessageStateContext, Boolean.TRUE));
+        http2MessageStateContext.getListenerState().readInboundRequestBody(http2SourceHandler, dataFrame);
+        // PREVIOUS: Response is already started to send, hence the incoming data frames need to be released.
+        // PREVIOUS: releaseDataFrame(http2SourceHandler, dataFrame);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -257,7 +257,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         Http2MessageStateContext http2MessageStateContext = getHttp2MessageContext(outboundMsgHolder);
         if (http2MessageStateContext == null) {
             http2MessageStateContext = new Http2MessageStateContext();
-            http2MessageStateContext.setSenderState(new RequestCompleted(this));
+            http2MessageStateContext.setSenderState(new RequestCompleted(this, null));
             outboundMsgHolder.getRequest().setHttp2MessageStateContext(http2MessageStateContext);
         }
         return http2MessageStateContext;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -155,12 +155,13 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
 
         private void writeOutboundRequest(ChannelHandlerContext ctx, HttpContent msg) throws Http2Exception {
             try {
-                http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg);
+                http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg, http2MessageStateContext);
             } catch (RuntimeException ex) {
                 httpOutboundRequest.getHttp2MessageStateContext()
                         .setSenderState(new SendingEntityBody(Http2TargetHandler.this, this));
                 httpOutboundRequest.getHttp2MessageStateContext()
-                        .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent());
+                        .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent(),
+                        http2MessageStateContext);
             }
         }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/EntityBodyReceived.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/EntityBodyReceived.java
@@ -52,7 +52,8 @@ public class EntityBodyReceived implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent) {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
+            http2MessageStateContext) {
         // Response is already received, hence the outgoing data frames need to be released.
         releaseContent(httpContent);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingEntityBody.java
@@ -48,17 +48,13 @@ public class ReceivingEntityBody implements SenderState {
 
     private final Http2TargetHandler http2TargetHandler;
     private final Http2ClientChannel http2ClientChannel;
-    private Http2TargetHandler.Http2RequestWriter http2RequestWriter;
+    private final Http2TargetHandler.Http2RequestWriter http2RequestWriter;
 
-    ReceivingEntityBody(Http2TargetHandler http2TargetHandler) {
+    ReceivingEntityBody(Http2TargetHandler http2TargetHandler,
+                        Http2TargetHandler.Http2RequestWriter http2RequestWriter) {
         this.http2TargetHandler = http2TargetHandler;
-        this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
-    }
-
-    ReceivingEntityBody(Http2TargetHandler http2TargetHandler, Http2TargetHandler.Http2RequestWriter
-            http2RequestWriter) {
-        this(http2TargetHandler);
         this.http2RequestWriter = http2RequestWriter;
+        this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
     }
 
     @Override
@@ -88,7 +84,7 @@ public class ReceivingEntityBody implements SenderState {
                                            OutboundMsgHolder outboundMsgHolder, boolean serverPush,
                                            Http2MessageStateContext http2MessageStateContext) {
         // When trailer headers are going to be received after receiving entity body of the response.
-        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler));
+        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler, http2RequestWriter));
         http2MessageStateContext.getSenderState().readInboundResponseHeaders(ctx, http2HeadersFrame, outboundMsgHolder,
                 serverPush, http2MessageStateContext);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -65,17 +65,13 @@ public class ReceivingHeaders implements SenderState {
 
     private final Http2TargetHandler http2TargetHandler;
     private final Http2ClientChannel http2ClientChannel;
-    private Http2TargetHandler.Http2RequestWriter http2RequestWriter;
+    private final Http2TargetHandler.Http2RequestWriter http2RequestWriter;
 
-    public ReceivingHeaders(Http2TargetHandler http2TargetHandler) {
+    public ReceivingHeaders(Http2TargetHandler http2TargetHandler,
+                            Http2TargetHandler.Http2RequestWriter http2RequestWriter) {
         this.http2TargetHandler = http2TargetHandler;
-        this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
-    }
-
-    public ReceivingHeaders(Http2TargetHandler http2TargetHandler, Http2TargetHandler.Http2RequestWriter
-            http2RequestWriter) {
-        this(http2TargetHandler);
         this.http2RequestWriter = http2RequestWriter;
+        this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -44,15 +44,12 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
 
-import java.io.IOException;
-
 import static org.wso2.transport.http.netty.contract.Constants.DIRECTION;
 import static org.wso2.transport.http.netty.contract.Constants.DIRECTION_RESPONSE;
 import static org.wso2.transport.http.netty.contract.Constants.EXECUTOR_WORKER_POOL;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP2_METHOD;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_STATUS_CODE;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_VERSION_2_0;
-import static org.wso2.transport.http.netty.contract.Constants.INBOUND_RESPONSE_ALREADY_RECEIVED;
 import static org.wso2.transport.http.netty.contract.Constants.POOLED_BYTE_BUFFER_FACTORY;
 
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.releaseContent;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -68,7 +68,7 @@ public class ReceivingHeaders implements SenderState {
 
     private final Http2TargetHandler http2TargetHandler;
     private final Http2ClientChannel http2ClientChannel;
-    private Http2TargetHandler.Http2RequestWriter http2RequestWriter = null;
+    private Http2TargetHandler.Http2RequestWriter http2RequestWriter;
 
     public ReceivingHeaders(Http2TargetHandler http2TargetHandler) {
         this.http2TargetHandler = http2TargetHandler;
@@ -87,10 +87,11 @@ public class ReceivingHeaders implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
-            http2MessageStateContext) throws Http2Exception {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent,
+                                         Http2MessageStateContext http2MessageStateContext) throws Http2Exception {
         // In bidirectional streaming case, while sending the request data frames, server response data frames can
         // receive. In order to handle it. we need to change the states depending on the action.
+        // This is temporary check. Remove the conditional check after reviewing message flow.
         if (http2RequestWriter != null) {
             http2MessageStateContext.setSenderState(new SendingEntityBody(http2TargetHandler, http2RequestWriter));
             http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, httpContent,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -153,13 +153,13 @@ public class ReceivingHeaders implements SenderState {
                 outboundMsgHolder.addPushResponse(streamId, responseMessage);
             }
             http2ClientChannel.removePromisedMessage(streamId);
-            http2MessageStateContext.setSenderState(new EntityBodyReceived(http2TargetHandler));
+            http2MessageStateContext.setSenderState(new EntityBodyReceived(http2TargetHandler, http2RequestWriter));
         } else {
             // Create response carbon message.
             HttpCarbonResponse responseMessage = setupResponseCarbonMessage(ctx, streamId,
                     http2Headers, outboundMsgHolder);
             outboundMsgHolder.addPushResponse(streamId, responseMessage);
-            http2MessageStateContext.setSenderState(new ReceivingEntityBody(http2TargetHandler));
+            http2MessageStateContext.setSenderState(new ReceivingEntityBody(http2TargetHandler, http2RequestWriter));
         }
     }
 
@@ -178,8 +178,7 @@ public class ReceivingHeaders implements SenderState {
                 outboundMsgHolder.setResponse(responseMessage);
             }
             http2ClientChannel.removeInFlightMessage(streamId);
-            outboundMsgHolder.getRequest().setIoException(new IOException(INBOUND_RESPONSE_ALREADY_RECEIVED));
-            http2MessageStateContext.setSenderState(new EntityBodyReceived(http2TargetHandler));
+            http2MessageStateContext.setSenderState(new EntityBodyReceived(http2TargetHandler, http2RequestWriter));
         } else {
             // Create response carbon message.
             HttpCarbonResponse responseMessage = setupResponseCarbonMessage(ctx, streamId,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
@@ -55,8 +55,8 @@ public class RequestCompleted implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
-            http2MessageStateContext) {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent,
+                                         Http2MessageStateContext http2MessageStateContext) {
         LOG.warn("writeOutboundRequestBody is not a dependant action of this state");
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
@@ -55,7 +55,8 @@ public class RequestCompleted implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent) {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
+            http2MessageStateContext) {
         LOG.warn("writeOutboundRequestBody is not a dependant action of this state");
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/RequestCompleted.java
@@ -43,8 +43,11 @@ public class RequestCompleted implements SenderState {
 
     private final Http2TargetHandler http2TargetHandler;
     private final Http2ClientChannel http2ClientChannel;
+    private final Http2TargetHandler.Http2RequestWriter http2RequestWriter;
 
-    public RequestCompleted(Http2TargetHandler http2TargetHandler) {
+    public RequestCompleted(Http2TargetHandler http2TargetHandler,
+                            Http2TargetHandler.Http2RequestWriter http2RequestWriter) {
+        this.http2RequestWriter = http2RequestWriter;
         this.http2TargetHandler = http2TargetHandler;
         this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
     }
@@ -65,7 +68,7 @@ public class RequestCompleted implements SenderState {
                                            OutboundMsgHolder outboundMsgHolder, boolean serverPush,
                                            Http2MessageStateContext http2MessageStateContext) {
         // When the initial frames of the response is to be received after sending the complete request.
-        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler));
+        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler, http2RequestWriter));
         http2MessageStateContext.getSenderState().readInboundResponseHeaders(ctx, http2HeadersFrame, outboundMsgHolder,
                 serverPush, http2MessageStateContext);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SenderState.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SenderState.java
@@ -47,8 +47,10 @@ public interface SenderState {
      *
      * @param ctx         the channel handler context
      * @param httpContent the content of the entity body
+     * @param http2MessageStateContext the message state context
      */
-    void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent) throws Http2Exception;
+    void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
+            http2MessageStateContext) throws Http2Exception;
 
     /**
      * Reads headers of inbound response.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SenderState.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SenderState.java
@@ -49,8 +49,8 @@ public interface SenderState {
      * @param httpContent the content of the entity body
      * @param http2MessageStateContext the message state context
      */
-    void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
-            http2MessageStateContext) throws Http2Exception;
+    void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent,
+                                  Http2MessageStateContext http2MessageStateContext) throws Http2Exception;
 
     /**
      * Reads headers of inbound response.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
@@ -144,7 +144,7 @@ public class SendingEntityBody implements SenderState {
             }
             if (endStream) {
                 outboundMsgHolder.setRequestWritten(true);
-                http2MessageStateContext.setSenderState(new RequestCompleted(http2TargetHandler));
+                http2MessageStateContext.setSenderState(new RequestCompleted(http2TargetHandler, http2RequestWriter));
             }
         } finally {
             if (release) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
@@ -42,9 +42,6 @@ import org.wso2.transport.http.netty.message.Http2DataFrame;
 import org.wso2.transport.http.netty.message.Http2HeadersFrame;
 import org.wso2.transport.http.netty.message.Http2PushPromise;
 
-import java.io.IOException;
-
-import static org.wso2.transport.http.netty.contract.Constants.INBOUND_RESPONSE_ALREADY_RECEIVED;
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.onPushPromiseRead;
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.writeHttp2Headers;
 
@@ -63,6 +60,7 @@ public class SendingEntityBody implements SenderState {
     private final Http2ConnectionEncoder encoder;
     private final Http2ClientChannel http2ClientChannel;
     private final int streamId;
+    private final Http2RequestWriter http2RequestWriter;
 
     public SendingEntityBody(Http2TargetHandler http2TargetHandler, Http2RequestWriter http2RequestWriter) {
         this.http2TargetHandler = http2TargetHandler;
@@ -71,6 +69,7 @@ public class SendingEntityBody implements SenderState {
         this.encoder = http2TargetHandler.getEncoder();
         this.http2ClientChannel = http2TargetHandler.getHttp2ClientChannel();
         this.streamId = http2RequestWriter.getStreamId();
+        this.http2RequestWriter = http2RequestWriter;
     }
 
     @Override
@@ -79,7 +78,8 @@ public class SendingEntityBody implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent) throws Http2Exception {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
+            http2MessageStateContext) throws Http2Exception {
         writeContent(ctx, httpContent);
     }
 
@@ -87,10 +87,12 @@ public class SendingEntityBody implements SenderState {
     public void readInboundResponseHeaders(ChannelHandlerContext ctx, Http2HeadersFrame http2HeadersFrame,
                                            OutboundMsgHolder outboundMsgHolder, boolean serverPush,
                                            Http2MessageStateContext http2MessageStateContext) {
-        // This is an action due to an application error. When the initial frames of the response is being received
-        // before sending the complete request.
-        outboundMsgHolder.getRequest().setIoException(new IOException(INBOUND_RESPONSE_ALREADY_RECEIVED));
-        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler));
+        // PREVIOUS: This is an action due to an application error. When the initial frames of the response is being
+        // received before sending the complete request.
+        // PREVIOUS: outboundMsgHolder.getRequest().setIoException(new IOException(INBOUND_RESPONSE_ALREADY_RECEIVED));
+        // In bidirectional streaming case, while sending the request data frames, server response data frames can
+        // receive. In order to handle it. we need to change the states depending on the action.
+        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler, http2RequestWriter));
         http2MessageStateContext.getSenderState().readInboundResponseHeaders(ctx, http2HeadersFrame, outboundMsgHolder,
                 serverPush, http2MessageStateContext);
     }
@@ -99,7 +101,12 @@ public class SendingEntityBody implements SenderState {
     public void readInboundResponseBody(ChannelHandlerContext ctx, Http2DataFrame http2DataFrame,
                                         OutboundMsgHolder outboundMsgHolder, boolean serverPush,
                                         Http2MessageStateContext http2MessageStateContext) {
-        LOG.warn("readInboundResponseEntityBody is not a dependant action of this state");
+        // In bidirectional streaming case, while sending the request data frames, server response data frames can
+        // receive. In order to handle it. we need to change the states depending on the action.
+        http2MessageStateContext.setSenderState(new ReceivingEntityBody(http2TargetHandler, http2RequestWriter));
+        http2MessageStateContext.getSenderState().readInboundResponseBody(ctx, http2DataFrame, outboundMsgHolder,
+                serverPush, http2MessageStateContext);
+        //PREVIOUS: LOG.warn("readInboundResponseEntityBody is not a dependant action of this state");
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
@@ -78,8 +78,8 @@ public class SendingEntityBody implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
-            http2MessageStateContext) throws Http2Exception {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent,
+                                         Http2MessageStateContext http2MessageStateContext) throws Http2Exception {
         writeContent(ctx, httpContent);
     }
 
@@ -87,9 +87,6 @@ public class SendingEntityBody implements SenderState {
     public void readInboundResponseHeaders(ChannelHandlerContext ctx, Http2HeadersFrame http2HeadersFrame,
                                            OutboundMsgHolder outboundMsgHolder, boolean serverPush,
                                            Http2MessageStateContext http2MessageStateContext) {
-        // PREVIOUS: This is an action due to an application error. When the initial frames of the response is being
-        // received before sending the complete request.
-        // PREVIOUS: outboundMsgHolder.getRequest().setIoException(new IOException(INBOUND_RESPONSE_ALREADY_RECEIVED));
         // In bidirectional streaming case, while sending the request data frames, server response data frames can
         // receive. In order to handle it. we need to change the states depending on the action.
         http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler, http2RequestWriter));
@@ -106,7 +103,6 @@ public class SendingEntityBody implements SenderState {
         http2MessageStateContext.setSenderState(new ReceivingEntityBody(http2TargetHandler, http2RequestWriter));
         http2MessageStateContext.getSenderState().readInboundResponseBody(ctx, http2DataFrame, outboundMsgHolder,
                 serverPush, http2MessageStateContext);
-        //PREVIOUS: LOG.warn("readInboundResponseEntityBody is not a dependant action of this state");
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
@@ -84,7 +84,8 @@ public class SendingHeaders implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent) throws Http2Exception {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
+            http2MessageStateContext) throws Http2Exception {
         writeOutboundRequestHeaders(ctx, httpContent);
     }
 
@@ -128,7 +129,7 @@ public class SendingHeaders implements SenderState {
             http2MessageStateContext.setSenderState(new RequestCompleted(http2TargetHandler));
         } else {
             http2MessageStateContext.setSenderState(new SendingEntityBody(http2TargetHandler, http2RequestWriter));
-            http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg);
+            http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg, http2MessageStateContext);
         }
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
@@ -96,7 +96,7 @@ public class SendingHeaders implements SenderState {
         // This is an action due to an application error. When the initial frames of the response is being received
         // before sending the complete request.
         outboundMsgHolder.getRequest().setIoException(new IOException(INBOUND_RESPONSE_ALREADY_RECEIVED));
-        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler));
+        http2MessageStateContext.setSenderState(new ReceivingHeaders(http2TargetHandler, http2RequestWriter));
         http2MessageStateContext.getSenderState().readInboundResponseHeaders(ctx, http2HeadersFrame, outboundMsgHolder,
                 serverPush, http2MessageStateContext);
     }
@@ -126,7 +126,7 @@ public class SendingHeaders implements SenderState {
         // Write Headers
         writeOutboundRequestHeaders(ctx, httpRequest, endStream);
         if (endStream) {
-            http2MessageStateContext.setSenderState(new RequestCompleted(http2TargetHandler));
+            http2MessageStateContext.setSenderState(new RequestCompleted(http2TargetHandler, http2RequestWriter));
         } else {
             http2MessageStateContext.setSenderState(new SendingEntityBody(http2TargetHandler, http2RequestWriter));
             http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg, http2MessageStateContext);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingHeaders.java
@@ -84,8 +84,8 @@ public class SendingHeaders implements SenderState {
     }
 
     @Override
-    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent, Http2MessageStateContext
-            http2MessageStateContext) throws Http2Exception {
+    public void writeOutboundRequestBody(ChannelHandlerContext ctx, HttpContent httpContent,
+                                         Http2MessageStateContext http2MessageStateContext) throws Http2Exception {
         writeOutboundRequestHeaders(ctx, httpContent);
     }
 


### PR DESCRIPTION
## Purpose
gRPC bidirectional streaming is falling because we not allow to sent any more data frames for the request, when response is received. But in gRPC bidirectional streaming scenario, caller and server can send and receive any number of data frames in same stream before one of the party close it. 

This PR is to fix bidirectional streaming issues in http2 transport.