### PR TITLE
 Handle Expect: 100-continue negative scenario

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/Expect100ContinueHeaderReceived.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/Expect100ContinueHeaderReceived.java
@@ -41,6 +41,7 @@ import org.wso2.transport.http.netty.contractimpl.listener.SourceHandler;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
+import static org.wso2.transport.http.netty.contract.Constants.HTTP_STATUS_CODE;
 import static org.wso2.transport.http.netty.contract.Constants
         .IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_100_CONTINUE_RESPONSE;
 import static org.wso2.transport.http.netty.contract.Constants
@@ -89,10 +90,7 @@ public class Expect100ContinueHeaderReceived implements ListenerState {
     @Override
     public void writeOutboundResponseBody(HttpOutboundRespListener outboundResponseListener,
                                           HttpCarbonMessage outboundResponseMsg, HttpContent httpContent) {
-        // During the state, writeOutboundResponseBody can get called with 100-continue response or with
-        // a different code(417 Expectation Failed). Later scenario should follow the usual outbound response
-        // path. So far inbound request body has not been read, therefore no need to handle it.
-        if (outboundResponseMsg.getProperty("HTTP_STATUS_CODE").equals(100)) {
+        if (outboundResponseMsg.getProperty(HTTP_STATUS_CODE).equals(HttpResponseStatus.CONTINUE.code())) {
             messageStateContext.setListenerState(
                     new Response100ContinueSent(outboundResponseListener, sourceHandler, messageStateContext));
         } else {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/Continue100TestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/Continue100TestCase.java
@@ -44,6 +44,7 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http.HttpClient;
 import org.wso2.transport.http.netty.util.server.listeners.Continue100Listener;
 
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 
@@ -73,13 +74,14 @@ public class Continue100TestCase {
     public void test100Continue() {
         HttpClient httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
 
-        DefaultHttpRequest reqHeaders = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
         DefaultLastHttpContent reqPayload = new DefaultLastHttpContent(
                 Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
 
-        reqHeaders.headers().set(HttpHeaderNames.CONTENT_LENGTH, TestUtil.largeEntity.getBytes().length);
+        httpRequest.headers().set(HttpHeaderNames.CONTENT_LENGTH, TestUtil.largeEntity.getBytes().length);
+        httpRequest.headers().set("X-Status", "Positive");
 
-        List<FullHttpResponse> responses = httpClient.sendExpectContinueRequest(reqHeaders, reqPayload);
+        List<FullHttpResponse> responses = httpClient.sendExpectContinueRequest(httpRequest, reqPayload);
 
         Assert.assertFalse(httpClient.waitForChannelClose());
 
@@ -93,6 +95,33 @@ public class Continue100TestCase {
         Assert.assertEquals(responsePayload.getBytes().length, TestUtil.largeEntity.getBytes().length);
         Assert.assertEquals((responses.get(1).headers().get(HttpHeaderNames.TRANSFER_ENCODING)),
                 Constants.CHUNKED);
+    }
+
+    @Test
+    public void test100ContinueNegative() {
+        HttpClient httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
+
+        DefaultHttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        DefaultLastHttpContent reqPayload = new DefaultLastHttpContent(
+                Unpooled.wrappedBuffer(TestUtil.largeEntity.getBytes()));
+
+        httpRequest.headers().set(HttpHeaderNames.CONTENT_LENGTH, TestUtil.largeEntity.getBytes().length);
+        httpRequest.headers().set("X-Status", "Negative");
+
+        List<FullHttpResponse> responses = httpClient.sendExpectContinueRequest(httpRequest, reqPayload);
+
+        Assert.assertFalse(httpClient.waitForChannelClose());
+
+        // 417 Expectation Failed response
+        Assert.assertEquals(responses.get(0).status(), HttpResponseStatus.EXPECTATION_FAILED);
+        int length = Integer.valueOf(responses.get(0).headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        Assert.assertEquals(length, 26);
+
+        Assert.assertEquals(responses.get(0).content()
+                                    .readCharSequence(length, Charset.defaultCharset()).toString(),
+                            "Do not send me any payload");
+        // Actual response
+        Assert.assertEquals(responses.size(), 1); // implies that only 417 response was received
     }
 
     @AfterClass

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/Continue100TestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/headers/Continue100TestCase.java
@@ -116,12 +116,12 @@ public class Continue100TestCase {
         Assert.assertEquals(responses.get(0).status(), HttpResponseStatus.EXPECTATION_FAILED);
         int length = Integer.valueOf(responses.get(0).headers().get(HttpHeaderNames.CONTENT_LENGTH));
         Assert.assertEquals(length, 26);
-
         Assert.assertEquals(responses.get(0).content()
                                     .readCharSequence(length, Charset.defaultCharset()).toString(),
                             "Do not send me any payload");
         // Actual response
-        Assert.assertEquals(responses.size(), 1); // implies that only 417 response was received
+        Assert.assertEquals(responses.size(), 1,
+                            "Multiple responses received when only a 417 response was expected");
     }
 
     @AfterClass


### PR DESCRIPTION
## Purpose
> Handle status codes other than 100 at Expect100ContinueHeaderReceived state.
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12494