### PR TITLE
Resolve spec violations in WebSocket

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -180,6 +180,7 @@ public final class Constants {
     public static final String LOCALHOST = "localhost";
 
     public static final String HTTP_OBJECT_AGGREGATOR = "HTTP_OBJECT_AGGREGATOR";
+    public static final String WEBSOCKET_COMPRESSION_HANDLER = "websocket-compression-handler";
     public static final String WS_SCHEME = "ws";
     public static final String WSS_SCHEME = "wss";
     public static final String WEBSOCKET_UPGRADE = "websocket";
@@ -189,6 +190,7 @@ public final class Constants {
     public static final int WEBSOCKET_STATUS_CODE_GOING_AWAY = 1001;
     public static final int WEBSOCKET_STATUS_CODE_PROTOCOL_ERROR = 1002;
     public static final int WEBSOCKET_STATUS_CODE_ABNORMAL_CLOSURE = 1006;
+    public static final int WEBSOCKET_STATUS_CODE_INVALD_DATA = 1007;
     public static final int WEBSOCKET_STATUS_CODE_UNEXPECTED_CONDITION = 1011;
     public static final int WEBSOCKET_REQUEST_SIZE = 8192;
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketHandshaker.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketHandshaker.java
@@ -41,42 +41,37 @@ public interface WebSocketHandshaker extends WebSocketMessage {
      * method is used.
      *
      * @param subProtocols    Sub-Protocols which are allowed by the service.
-     * @param allowExtensions whether the extensions are allowed or not.
      * @return the Server session for the newly created WebSocket connection.
      */
-    ServerHandshakeFuture handshake(String[] subProtocols, boolean allowExtensions);
+    ServerHandshakeFuture handshake(String[] subProtocols);
 
     /**
      * Complete the handshake of a given request. The connection will be timed out if the connection is idle for
      * given time period.
      *
      * @param subProtocols    Sub-Protocols which are allowed by the service.
-     * @param allowExtensions whether the extensions are allowed or not.
      * @param idleTimeout     Idle timeout in milli-seconds for WebSocket connection.
      * @return the handshake future.
      */
-    ServerHandshakeFuture handshake(String[] subProtocols, boolean allowExtensions, int idleTimeout);
+    ServerHandshakeFuture handshake(String[] subProtocols, int idleTimeout);
 
     /**
      * Complete the handshake of a given request. The connection will be timed out if the connection is idle for given
      * time period.
      *
      * @param subProtocols    Sub-Protocols which are allowed by the service.
-     * @param allowExtensions whether the extensions are allowed or not.
      * @param idleTimeout     Idle timeout in milli-seconds for WebSocket connection.
      * @param responseHeaders Extra headers to add to the handshake response or {@code null} if no extra headers should
      *                        be added
      * @return the handshake future.
      */
-    ServerHandshakeFuture handshake(String[] subProtocols, boolean allowExtensions, int idleTimeout,
-                                    HttpHeaders responseHeaders);
+    ServerHandshakeFuture handshake(String[] subProtocols, int idleTimeout, HttpHeaders responseHeaders);
 
     /**
      * Complete the handshake of a given request. The connection will be timed out if the connection is idle for given
      * time period.
      *
      * @param subProtocols          Sub-Protocols which are allowed by the service.
-     * @param allowExtensions       whether the extensions are allowed or not.
      * @param idleTimeout           Idle timeout in milli-seconds for WebSocket connection.
      * @param responseHeaders       Extra headers to add to the handshake response or {@code null} if no extra
      *                              headers should
@@ -85,8 +80,8 @@ public interface WebSocketHandshaker extends WebSocketMessage {
      *                              requirement may reduce denial of service attacks using long data frames.
      * @return the handshake future.
      */
-    ServerHandshakeFuture handshake(String[] subProtocols, boolean allowExtensions, int idleTimeout,
-                                    HttpHeaders responseHeaders, int maxFramePayloadLength);
+    ServerHandshakeFuture handshake(String[] subProtocols, int idleTimeout, HttpHeaders responseHeaders,
+                                    int maxFramePayloadLength);
 
     /**
      * Get the HttpCarbonRequest received from the client to perform the handshake.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerCompressionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/WebSocketServerCompressionHandler.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.listener;
+
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
+
+import static io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE;
+
+/**
+ * Extends <tt>io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerExtensionHandler</tt> to
+ * handle the WebSocket Compression Extensions.
+ */
+public class WebSocketServerCompressionHandler extends WebSocketServerExtensionHandler {
+
+    public WebSocketServerCompressionHandler() {
+        super(new PerMessageDeflateServerExtensionHandshaker(),
+              new PerMessageDeflateServerExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, true, false),
+              new PerMessageDeflateServerExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, false, true),
+              new PerMessageDeflateServerExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, true, true),
+              new DeflateFrameServerExtensionHandshaker());
+    }
+
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
@@ -30,10 +30,10 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.websocketx.Utf8FrameValidator;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
-import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
@@ -149,6 +149,7 @@ public class WebSocketClient {
         // Assuming that WebSocket Handshake messages will not be large than 8KB
         pipeline.addLast(new HttpObjectAggregator(8192));
         pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
+        pipeline.addLast(Utf8FrameValidator.class.getName(), new Utf8FrameValidator());
         if (idleTimeout > 0) {
             pipeline.addLast(new IdleStateHandler(0, 0, idleTimeout, TimeUnit.MILLISECONDS));
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClientCompressionHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClientCompressionHandler.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.sender.websocket;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameClientExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateClientExtensionHandshaker;
+
+import static io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE;
+
+/**
+ * Extends <tt>io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientExtensionHandler</tt> to
+ * handle the WebSocket Compression Extensions.
+ */
+@ChannelHandler.Sharable
+public class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
+    public static final WebSocketClientCompressionHandler INSTANCE = new WebSocketClientCompressionHandler();
+
+    private WebSocketClientCompressionHandler() {
+        super(new PerMessageDeflateClientExtensionHandshaker(),
+              new PerMessageDeflateClientExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, true, false),
+              new PerMessageDeflateClientExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, false, true),
+              new PerMessageDeflateClientExtensionHandshaker(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(),
+                                                             MAX_WINDOW_SIZE, true, true),
+              new DeflateFrameClientExtensionHandshaker(false),
+              new DeflateFrameClientExtensionHandshaker(true));
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/WebSocketInboundFrameHandler.java
@@ -187,6 +187,15 @@ public class WebSocketInboundFrameHandler extends ChannelInboundHandlerAdapter {
             closeFrameFuture.addListener(future -> ctx.close().addListener(
                     closeFuture -> connectorFuture.notifyWebSocketListener(webSocketConnection, cause)));
             return;
+        } else {
+            //Todo: remove if https://github.com/netty/netty/pull/8705 gets merged
+            String msg = cause.getMessage();
+            if (msg != null && msg.contains("UTF-8")) {
+                ChannelFuture closeFrameFuture = ctx.channel().writeAndFlush(new CloseWebSocketFrame(
+                        Constants.WEBSOCKET_STATUS_CODE_INVALD_DATA, "Invalid UTF-8 frame received"));
+                closeFrameFuture.addListener(future -> ctx.close().addListener(
+                        closeFuture -> connectorFuture.notifyWebSocketListener(webSocketConnection, cause)));
+            }
         }
         connectorFuture.notifyWebSocketListener(webSocketConnection, cause);
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityListener.java
@@ -59,13 +59,13 @@ public class WebSocketServerHandshakeFunctionalityListener implements WebSocketC
     public void onHandshake(WebSocketHandshaker webSocketHandshaker) {
         ServerHandshakeFuture handshakeFuture = null;
         if (getBooleanValueOfHeader(webSocketHandshaker, "x-negotiate-sub-protocols")) {
-            handshakeFuture = webSocketHandshaker.handshake(supportingSubProtocols, true);
+            handshakeFuture = webSocketHandshaker.handshake(supportingSubProtocols);
         } else if (getBooleanValueOfHeader(webSocketHandshaker, "x-send-custom-header")) {
             DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
             httpHeaders.add("x-custom-header", "custom-header-value");
-            handshakeFuture = webSocketHandshaker.handshake(null, true, -1, httpHeaders);
+            handshakeFuture = webSocketHandshaker.handshake(null, -1, httpHeaders);
         } else if (getBooleanValueOfHeader(webSocketHandshaker, "x-set-connection-timeout")) {
-            handshakeFuture = webSocketHandshaker.handshake(null, true, 4000);
+            handshakeFuture = webSocketHandshaker.handshake(null, 4000);
         } else if (getBooleanValueOfHeader(webSocketHandshaker, "x-wait-for-frame-read")) {
             handshakeFuture = webSocketHandshaker.handshake();
         } else if (getBooleanValueOfHeader(webSocketHandshaker, "x-handshake")) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketTestServerConnectorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketTestServerConnectorListener.java
@@ -76,7 +76,7 @@ public class WebSocketTestServerConnectorListener implements WebSocketConnectorL
 
     @Override
     public void onHandshake(WebSocketHandshaker webSocketHandshaker) {
-        ServerHandshakeFuture future = webSocketHandshaker.handshake(null, true, 3000);
+        ServerHandshakeFuture future = webSocketHandshaker.handshake(null, 3000);
         future.setHandshakeListener(new ServerHandshakeListener() {
             @Override
             public void onSuccess(WebSocketConnection webSocketConnection) {


### PR DESCRIPTION
## Purpose
> Resolve spec violations in WebSocket:
> - [server report](http://riyafa.github.io/Riyafa-Abdul-Hameed--web-page/others/reports/servers/)

>This PR resolves as much as possible of the spec violations. Not all spec violations have been resolved because they have not been resolved in netty itself.

>Following are added in this PR:

- Adds compression support for WebSocket Server

- Fixes issue with Reserved Bits usage on the server side

    Resolve ballerina-platform/ballerina-lang#12694

- Adds UTF-8 validation check for WebSocket frames.

    Resolve ballerina-platform/ballerina-lang#12696
    Resolve ballerina-platform/ballerina-lang#12695

- Fixes compression related issues

    Related issue: ballerina-platform/ballerina-lang#12698
    Related issue: ballerina-platform/ballerina-lang#12702
    The compression related issues are not fully fixed as they are issues in netty itself.