### PR TITLE
Remove the warning logs if verifyClient is not set

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -63,7 +63,7 @@ public class SslConfiguration {
             sslConfig.setNeedClientAuth(true);
         } else if (OPTIONAL.equalsIgnoreCase(verifyClient)) {
             sslConfig.setWantClientAuth(true);
-        } else {
+        } else if (!verifyClient.isEmpty()) {
             LOG.warn("Received an unidentified configuration for sslVerify client. "
                     + "Hence client verification will be disabled which is the default configuration.");
         }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
@@ -139,9 +139,6 @@ public class SSLHandlerFactory {
             engine.setNeedClientAuth(true);
         } else if (wantClientAuth) {
             engine.setWantClientAuth(true);
-        } else {
-            LOG.warn("Received an unidentified configuration for sslVerifyClient. "
-                    + "Hence client verification will be disabled which is the default configuration.");
         }
         return addCommonConfigs(engine);
     }


### PR DESCRIPTION
## Purpose
When you don't specify the verifyClient option, you get a warning message saying 'Received an unidentified configuration for sslVerify client. Hence client verification will be disabled which is the default configuration.'. This is an unnecessary warning message and removed it. 

