### PR TITLE
Set proper init value for Carbon Message properties map

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -393,6 +393,8 @@ public final class Constants {
 
     public static final String ERROR_COULD_NOT_RESOLVE_HOST = "Could not resolve host";
 
+    public static final int HTTP_CARBON_MESSAGE_PROPERTIES_MAP_DEFAULT_SIZE = 64;
+
 
     private Constants() {
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -52,7 +52,7 @@ public class HttpCarbonMessage {
 
     protected HttpMessage httpMessage;
     private EntityCollector blockingEntityCollector;
-    private Map<String, Object> properties = new HashMap<>();
+    private Map<String, Object> properties = new HashMap<>(Constants.HTTP_CARBON_MESSAGE_PROPERTIES_MAP_DEFAULT_SIZE);
 
     private MessageFuture messageFuture;
     private final ServerConnectorFuture httpOutboundRespFuture = new HttpWsServerConnectorFuture();


### PR DESCRIPTION
Initializing Http Carbon Message properties map with default size to avoid resizing of the map to improve the performance

## Purpose
Minimize the possibility of the capacity resizing of the hash map used in HttpCarbonMessage to improve the performance.