### PR TITLE
Set default forwarded configurations to disabled

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
@@ -48,7 +48,7 @@ public class SenderConfiguration extends SslConfiguration {
     private ProxyServerConfiguration proxyServerConfiguration;
     private PoolConfiguration poolConfiguration;
 
-    private ForwardedExtensionConfig forwardedExtensionConfig;
+    private ForwardedExtensionConfig forwardedExtensionConfig = ForwardedExtensionConfig.DISABLE;
 
     public SenderConfiguration() {
         this.poolConfiguration = new PoolConfiguration();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/forwardedextension/ForwardedDefaultTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/forwardedextension/ForwardedDefaultTestCase.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.contract.Constants;
-import org.wso2.transport.http.netty.contract.config.ForwardedExtensionConfig;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
 
@@ -30,12 +29,11 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
 /**
- * A test class for disable Forwarded behaviour.
+ * A test class for default(disable) Forwarded behaviour.
  */
-public class ForwardedDisableTestCase extends ForwardedClientTemplate {
+public class ForwardedDefaultTestCase extends ForwardedClientTemplate {
     @BeforeClass
     public void setUp() {
-        senderConfiguration.setForwardedExtensionConfig(ForwardedExtensionConfig.DISABLE);
         super.setUp();
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -72,7 +72,7 @@
 
             <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedEnableTestCase" />
             <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedTransitionTestCase" />
-            <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedDisableTestCase" />
+            <class name="org.wso2.transport.http.netty.forwardedextension.ForwardedDefaultTestCase" />
 
             <class name="org.wso2.transport.http.netty.method.head.HeadRequestTestCase"/>
         </classes>


### PR DESCRIPTION
Transport shouldn't modify Forwarded/X-Forwarded header by default if the user doesn't specifically configure to do so.

## Automation tests
 - Unit tests 
   > Yes

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes