### PR TITLE
Support setting ssl handshake/session time out

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -161,6 +161,14 @@ public class SslConfiguration {
         sslConfig.setServerKeyPassword(serverKeyPassword);
     }
 
+    public void setSslSessionTimeOut(int sessionTimeOut) {
+        sslConfig.setSessionTimeOut(sessionTimeOut);
+    }
+
+    public void setSslHandshakeTimeOut(long handshakeTimeOut) {
+        sslConfig.setHandshakeTimeOut(handshakeTimeOut);
+    }
+
     public SSLConfig getClientSSLConfig() {
         if (scheme == null || !scheme.equalsIgnoreCase(HTTPS_SCHEME)) {
             return null;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -45,7 +45,6 @@ import org.wso2.transport.http.netty.contractimpl.websocket.DefaultWebSocketClie
 
 import java.util.Map;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 
 import static org.wso2.transport.http.netty.contract.Constants.PIPELINING_THREAD_COUNT;
@@ -119,12 +118,12 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
             serverConnectorBootstrap.addOcspStapling(sslConfig.isOcspStaplingEnabled());
             serverConnectorBootstrap.addSslHandlerFactory(sslHandlerFactory);
             if (sslConfig.getKeyStore() != null) {
-                SSLContext sslContext = sslHandlerFactory.createSSLContextFromKeystores();
                 if (Constants.HTTP_2_0 == Float.valueOf(listenerConfig.getVersion())) {
                     serverConnectorBootstrap
                             .addHttp2SslContext(sslHandlerFactory.createHttp2TLSContextForServer(sslConfig));
                 } else {
-                    serverConnectorBootstrap.addKeystoreSslContext(sslContext);
+                    serverConnectorBootstrap
+                            .addKeystoreSslContext(sslHandlerFactory.createSSLContextFromKeystores(true));
                 }
             } else {
                 if (Constants.HTTP_2_0 == Float.valueOf(listenerConfig.getVersion())) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -879,8 +879,9 @@ public class Util {
     }
 
     public static void setSslHandshakeTimeOut(SSLConfig sslConfig, SslHandler sslHandler) {
-        if (sslConfig.getHandshakeTimeOut() > 0) {
-            sslHandler.setHandshakeTimeout(sslConfig.getHandshakeTimeOut(), TimeUnit.SECONDS);
+        long handshakeTimeout = sslConfig.getHandshakeTimeOut();
+        if (handshakeTimeout > 0) {
+            sslHandler.setHandshakeTimeout(handshakeTimeout, TimeUnit.SECONDS);
         }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
@@ -60,6 +60,8 @@ public class SSLConfig {
     private File clientTrustCertificates;
     private String serverKeyPassword;
     private String clientKeyPassword;
+    private int sessionTimeOut;
+    private long handshakeTimeOut;
 
     public SSLConfig() {}
 
@@ -307,5 +309,21 @@ public class SSLConfig {
 
     public void setClientKeyPassword(String clientKeyPassword) {
         this.clientKeyPassword = clientKeyPassword;
+    }
+
+    public int getSessionTimeOut() {
+        return sessionTimeOut;
+    }
+
+    public void setSessionTimeOut(int sessionTimeOut) {
+        this.sessionTimeOut = sessionTimeOut;
+    }
+
+    public long getHandshakeTimeOut() {
+        return handshakeTimeOut;
+    }
+
+    public void setHandshakeTimeOut(long handshakeTimeOut) {
+        this.handshakeTimeOut = handshakeTimeOut;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
@@ -102,13 +102,14 @@ public class SSLHandlerFactory {
             }
             sslContext = SSLContext.getInstance(protocol);
             sslContext.init(keyManagers, trustManagers, null);
+            int sessionTimeout = sslConfig.getSessionTimeOut();
             if (isServer) {
-                if (sslConfig.getSessionTimeOut() > 0) {
-                    sslContext.getServerSessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+                if (sessionTimeout > 0) {
+                    sslContext.getServerSessionContext().setSessionTimeout(sessionTimeout);
                 }
             } else {
-                if (sslConfig.getSessionTimeOut() > 0) {
-                    sslContext.getClientSessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+                if (sessionTimeout > 0) {
+                    sslContext.getClientSessionContext().setSessionTimeout(sessionTimeout);
                 }
             }
             return sslContext;
@@ -172,8 +173,9 @@ public class SSLHandlerFactory {
         setSslProtocol(sslContextBuilder);
         ReferenceCountedOpenSslContext referenceCountedOpenSslCtx = (ReferenceCountedOpenSslContext) sslContextBuilder
                 .build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            referenceCountedOpenSslCtx.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            referenceCountedOpenSslCtx.sessionContext().setSessionTimeout(sessionTimeout);
         }
         return referenceCountedOpenSslCtx;
     }
@@ -198,8 +200,9 @@ public class SSLHandlerFactory {
         setSslProtocol(sslContextBuilder);
         ReferenceCountedOpenSslContext referenceCountedOpenSslCtx = (ReferenceCountedOpenSslContext) sslContextBuilder
                 .build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            referenceCountedOpenSslCtx.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            referenceCountedOpenSslCtx.sessionContext().setSessionTimeout(sessionTimeout);
         }
         return referenceCountedOpenSslCtx;
     }
@@ -262,8 +265,9 @@ public class SSLHandlerFactory {
         setOcspStapling(sslContextBuilder, sslConfig.isOcspStaplingEnabled());
 
         SslContext sslCtx = sslContextBuilder.build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            sslCtx.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            sslCtx.sessionContext().setSessionTimeout(sessionTimeout);
         }
 
         return sslCtx;
@@ -278,8 +282,9 @@ public class SSLHandlerFactory {
     public SslContext createHttpTLSContextForServer() throws SSLException {
         SslProvider provider = SslProvider.JDK;
         SslContext certsSslContext = serverContextBuilderWithCerts(provider).build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            certsSslContext.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            certsSslContext.sessionContext().setSessionTimeout(sessionTimeout);
         }
         return certsSslContext;
     }
@@ -293,8 +298,9 @@ public class SSLHandlerFactory {
     public SslContext createHttpTLSContextForClient() throws SSLException {
         SslProvider provider = SslProvider.JDK;
         SslContext certsSslContext = clientContextBuilderWithCerts(provider).build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            certsSslContext.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            certsSslContext.sessionContext().setSessionTimeout(sessionTimeout);
         }
         return certsSslContext;
     }
@@ -346,8 +352,9 @@ public class SSLHandlerFactory {
         setAlpnConfigs(sslContextBuilder);
         setOcspStapling(sslContextBuilder, enableOcsp);
         SslContext sslContext = sslContextBuilder.build();
-        if (sslConfig.getSessionTimeOut() > 0) {
-            sslContext.sessionContext().setSessionTimeout(sslConfig.getSessionTimeOut());
+        int sessionTimeout = sslConfig.getSessionTimeOut();
+        if (sessionTimeout > 0) {
+            sslContext.sessionContext().setSessionTimeout(sessionTimeout);
         }
         return sslContextBuilder.build();
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ALPNwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ALPNwithCertsTest.java
@@ -73,6 +73,8 @@ public class Http2ALPNwithCertsTest {
         listenerConfiguration.setPort(TestUtil.SERVER_PORT1);
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVersion(String.valueOf(HTTP_2_0));
+        listenerConfiguration.setSslSessionTimeOut(30);
+        listenerConfiguration.setSslHandshakeTimeOut(20);
         listenerConfiguration.setServerKeyFile(TestUtil.getAbsolutePath(TestUtil.KEY_FILE));
         listenerConfiguration.setServerCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         return listenerConfiguration;
@@ -83,6 +85,8 @@ public class Http2ALPNwithCertsTest {
         senderConfiguration.setClientTrustCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         senderConfiguration.setHttpVersion(String.valueOf(HTTP_2_0));
         senderConfiguration.setScheme(HTTPS_SCHEME);
+        senderConfiguration.setSslSessionTimeOut(30);
+        senderConfiguration.setSslHandshakeTimeOut(20);
         return senderConfiguration;
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ALPNwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/Http2ALPNwithCertsTest.java
@@ -73,8 +73,8 @@ public class Http2ALPNwithCertsTest {
         listenerConfiguration.setPort(TestUtil.SERVER_PORT1);
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVersion(String.valueOf(HTTP_2_0));
-        listenerConfiguration.setSslSessionTimeOut(30);
-        listenerConfiguration.setSslHandshakeTimeOut(20);
+        listenerConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        listenerConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         listenerConfiguration.setServerKeyFile(TestUtil.getAbsolutePath(TestUtil.KEY_FILE));
         listenerConfiguration.setServerCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         return listenerConfiguration;
@@ -85,8 +85,8 @@ public class Http2ALPNwithCertsTest {
         senderConfiguration.setClientTrustCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         senderConfiguration.setHttpVersion(String.valueOf(HTTP_2_0));
         senderConfiguration.setScheme(HTTPS_SCHEME);
-        senderConfiguration.setSslSessionTimeOut(30);
-        senderConfiguration.setSslHandshakeTimeOut(20);
+        senderConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        senderConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         return senderConfiguration;
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
@@ -98,6 +98,8 @@ public class TestHttp2WithALPN {
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVersion(String.valueOf(HTTP_2_0));
         listenerConfiguration.setVerifyClient(OPTIONAL);
+        listenerConfiguration.setSslSessionTimeOut(30);
+        listenerConfiguration.setSslHandshakeTimeOut(20);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         return listenerConfiguration;
@@ -112,6 +114,8 @@ public class TestHttp2WithALPN {
         senderConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         senderConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         senderConfiguration.setHttpVersion(httpVersion);
+        senderConfiguration.setSslSessionTimeOut(30);
+        senderConfiguration.setSslHandshakeTimeOut(20);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         return senderConfiguration;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/TestHttp2WithALPN.java
@@ -98,8 +98,8 @@ public class TestHttp2WithALPN {
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVersion(String.valueOf(HTTP_2_0));
         listenerConfiguration.setVerifyClient(OPTIONAL);
-        listenerConfiguration.setSslSessionTimeOut(30);
-        listenerConfiguration.setSslHandshakeTimeOut(20);
+        listenerConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        listenerConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         return listenerConfiguration;
@@ -114,8 +114,8 @@ public class TestHttp2WithALPN {
         senderConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         senderConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         senderConfiguration.setHttpVersion(httpVersion);
-        senderConfiguration.setSslSessionTimeOut(30);
-        senderConfiguration.setSslHandshakeTimeOut(20);
+        senderConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        senderConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         return senderConfiguration;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -71,7 +71,9 @@ public class MutualSSLTestCase {
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);
+        listenerConfiguration.setSslSessionTimeOut(11);
         listenerConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
+        listenerConfiguration.setSslHandshakeTimeOut(20);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
@@ -84,6 +86,8 @@ public class MutualSSLTestCase {
         senderConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         senderConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
         senderConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
+        senderConfiguration.setSslSessionTimeOut(10);
+        senderConfiguration.setSslHandshakeTimeOut(20);
         senderConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         return senderConfiguration;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -71,9 +71,9 @@ public class MutualSSLTestCase {
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);
-        listenerConfiguration.setSslSessionTimeOut(11);
+        listenerConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
         listenerConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
-        listenerConfiguration.setSslHandshakeTimeOut(20);
+        listenerConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
@@ -86,8 +86,8 @@ public class MutualSSLTestCase {
         senderConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         senderConfiguration.setTrustStoreFile(TestUtil.getAbsolutePath(TestUtil.TRUST_STORE_FILE_PATH));
         senderConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
-        senderConfiguration.setSslSessionTimeOut(10);
-        senderConfiguration.setSslHandshakeTimeOut(20);
+        senderConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        senderConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         senderConfiguration.setTrustStorePass(TestUtil.KEY_STORE_PASSWORD);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         return senderConfiguration;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
@@ -69,6 +69,8 @@ public class MutualSSLwithCertsTest {
         listenerConfiguration.setServerKeyFile(TestUtil.getAbsolutePath(TestUtil.KEY_FILE));
         listenerConfiguration.setServerCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         listenerConfiguration.setServerTrustCertificates(TestUtil.getAbsolutePath(TestUtil.TRUST_CERT_CHAIN));
+        listenerConfiguration.setSslSessionTimeOut(30);
+        listenerConfiguration.setSslHandshakeTimeOut(20);
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVerifyClient("require");
         return listenerConfiguration;
@@ -80,6 +82,8 @@ public class MutualSSLwithCertsTest {
         senderConfiguration.setClientCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         senderConfiguration.setClientTrustCertificates(TestUtil.getAbsolutePath(TestUtil.TRUST_CERT_CHAIN));
         senderConfiguration.setScheme(HTTPS_SCHEME);
+        senderConfiguration.setSslSessionTimeOut(30);
+        senderConfiguration.setSslHandshakeTimeOut(20);
         senderConfiguration.setHostNameVerificationEnabled(false);
         return senderConfiguration;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
@@ -69,8 +69,8 @@ public class MutualSSLwithCertsTest {
         listenerConfiguration.setServerKeyFile(TestUtil.getAbsolutePath(TestUtil.KEY_FILE));
         listenerConfiguration.setServerCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         listenerConfiguration.setServerTrustCertificates(TestUtil.getAbsolutePath(TestUtil.TRUST_CERT_CHAIN));
-        listenerConfiguration.setSslSessionTimeOut(30);
-        listenerConfiguration.setSslHandshakeTimeOut(20);
+        listenerConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        listenerConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setVerifyClient("require");
         return listenerConfiguration;
@@ -82,8 +82,8 @@ public class MutualSSLwithCertsTest {
         senderConfiguration.setClientCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));
         senderConfiguration.setClientTrustCertificates(TestUtil.getAbsolutePath(TestUtil.TRUST_CERT_CHAIN));
         senderConfiguration.setScheme(HTTPS_SCHEME);
-        senderConfiguration.setSslSessionTimeOut(30);
-        senderConfiguration.setSslHandshakeTimeOut(20);
+        senderConfiguration.setSslSessionTimeOut(TestUtil.SSL_SESSION_TIMEOUT);
+        senderConfiguration.setSslHandshakeTimeOut(TestUtil.SSL_HANDSHAKE_TIMEOUT);
         senderConfiguration.setHostNameVerificationEnabled(false);
         return senderConfiguration;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/TestUtil.java
@@ -88,6 +88,8 @@ public class TestUtil {
     public static final int WEBSOCKET_REMOTE_SERVER_PORT = 9010;
     public static final int WEBSOCKET_TEST_IDLE_TIMEOUT = 30;
     public static final long HTTP2_RESPONSE_TIME_OUT = 30;
+    public static final long SSL_HANDSHAKE_TIMEOUT = 20;
+    public static final int SSL_SESSION_TIMEOUT = 30;
     public static final String TEST_HOST = "localhost";
     public static final String BOGUS_HOST = "bogus_hostname";
     public static final String TEST_SERVER = "test-server";


### PR DESCRIPTION
## Purpose
Currently, there is no way of changing the default values of SSL session time out and SSL handshake time out. This PR is to introduce the capability to set SSL handshake and session time outs as a user prefers.

Fixed issues: https://github.com/ballerina-platform/ballerina-lang/issues/13847
https://github.com/ballerina-platform/ballerina-lang/issues/13846