### PR TITLE
Fix IDLE_TIMEOUT_TRIGGERED_BEFORE_INITIATING_INBOUND_REQUEST when ssl handshake fails

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -215,6 +215,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             LOG.debug("Server upgrade event received");
         } else if (evt instanceof SslCloseCompletionEvent) {
             LOG.debug("SSL close completion event received");
+            setConnectedState(false);
         } else if (evt instanceof ChannelInputShutdownReadComplete) {
             // When you try to read from a channel which has already been closed by the peer,
             // 'java.io.IOException: Connection reset by peer' is thrown and it is a harmless exception.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -215,7 +215,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             LOG.debug("Server upgrade event received");
         } else if (evt instanceof SslCloseCompletionEvent) {
             LOG.debug("SSL close completion event received");
-            setConnectedState(false);
+            closeChannel(ctx);
         } else if (evt instanceof ChannelInputShutdownReadComplete) {
             // When you try to read from a channel which has already been closed by the peer,
             // 'java.io.IOException: Connection reset by peer' is thrown and it is a harmless exception.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -215,6 +215,7 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
             LOG.debug("Server upgrade event received");
         } else if (evt instanceof SslCloseCompletionEvent) {
             LOG.debug("SSL close completion event received");
+            setConnectedState(false);
             closeChannel(ctx);
         } else if (evt instanceof ChannelInputShutdownReadComplete) {
             // When you try to read from a channel which has already been closed by the peer,


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/transport-http/issues/305

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
Close connection after SslCloseCompletionEvent

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - N/A
 - Integration tests -  N/A


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A
