### PR TITLE
Release remnant content in inbound HTTPCarbonMsg

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/ResponseCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/ResponseCompleted.java
@@ -85,6 +85,7 @@ public class ResponseCompleted implements ListenerState {
     }
 
     private void cleanupSourceHandler(HttpCarbonMessage inboundRequestMsg) {
+        inboundRequestMsg.waitAndReleaseAllEntities();
         sourceHandler.removeRequestEntry(inboundRequestMsg);
     }
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/12815

## Approach
> Release remnant content of inbound carbon message in the response completed state.