### PR TITLE
Override ByteBufferInputStream close() function

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -108,6 +108,15 @@ public class HttpMessageDataStreamer {
                 throw new DecoderException(httpContent.decoderResult().cause().getMessage());
             }
         }
+
+        @Override
+        public void close() throws IOException {
+            byteBuffer = null;
+            if (httpContent != null && httpContent.refCnt() > 0) {
+                httpContent.release();
+            }
+            super.close();
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Clears the Byte Buffer and release remnant HTTP Content

## Goal
> Avoid possible memory leak if input stream read() function fails to read up to the limit.

## Approach
> Check whether content release status by refCnt method. Release content only if the count is above 0.
> Clears the buffer