### PR TITLE
Move HTTP/2 request's content writing logic out of I/O thread

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -50,6 +50,7 @@ import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.Connection
 import org.wso2.transport.http.netty.contractimpl.sender.http2.Http2ClientChannel;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.Http2ConnectionManager;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.OutboundMsgHolder;
+import org.wso2.transport.http.netty.contractimpl.sender.http2.RequestWriteStarter;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.TimeoutHandler;
 import org.wso2.transport.http.netty.message.Http2PushPromise;
 import org.wso2.transport.http.netty.message.Http2Reset;
@@ -185,8 +186,9 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
 
                 if (activeHttp2ClientChannel != null) {
                     outboundMsgHolder.setHttp2ClientChannel(activeHttp2ClientChannel);
-                    activeHttp2ClientChannel.getChannel().eventLoop().execute(
-                        () -> activeHttp2ClientChannel.getChannel().write(outboundMsgHolder));
+                   /* activeHttp2ClientChannel.getChannel().eventLoop().execute(
+                        () -> activeHttp2ClientChannel.getChannel().write(outboundMsgHolder));*/
+                    new RequestWriteStarter(outboundMsgHolder, activeHttp2ClientChannel).startWritingContent();
                     httpResponseFuture = outboundMsgHolder.getResponseFuture();
                     httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
                     return httpResponseFuture;
@@ -255,8 +257,9 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                                                                  new TimeoutHandler(socketIdleTimeout,
                                                                                     freshHttp2ClientChannel));
 
-                    freshHttp2ClientChannel.getChannel().eventLoop().execute(
-                        () -> freshHttp2ClientChannel.getChannel().write(outboundMsgHolder));
+                   /* freshHttp2ClientChannel.getChannel().eventLoop().execute(
+                        () -> freshHttp2ClientChannel.getChannel().write(outboundMsgHolder));*/
+                    new RequestWriteStarter(outboundMsgHolder, freshHttp2ClientChannel).startWritingContent();
                     httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
                 }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -186,8 +186,6 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
 
                 if (activeHttp2ClientChannel != null) {
                     outboundMsgHolder.setHttp2ClientChannel(activeHttp2ClientChannel);
-                   /* activeHttp2ClientChannel.getChannel().eventLoop().execute(
-                        () -> activeHttp2ClientChannel.getChannel().write(outboundMsgHolder));*/
                     new RequestWriteStarter(outboundMsgHolder, activeHttp2ClientChannel).startWritingContent();
                     httpResponseFuture = outboundMsgHolder.getResponseFuture();
                     httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
@@ -256,9 +254,6 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
                     freshHttp2ClientChannel.addDataEventListener(Constants.IDLE_STATE_HANDLER,
                                                                  new TimeoutHandler(socketIdleTimeout,
                                                                                     freshHttp2ClientChannel));
-
-                   /* freshHttp2ClientChannel.getChannel().eventLoop().execute(
-                        () -> freshHttp2ClientChannel.getChannel().write(outboundMsgHolder));*/
                     new RequestWriteStarter(outboundMsgHolder, freshHttp2ClientChannel).startWritingContent();
                     httpResponseFuture.notifyResponseHandle(new ResponseHandle(outboundMsgHolder));
                 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
@@ -222,6 +222,9 @@ public class TargetChannel {
                 .setSenderState(new SendingHeaders(messageStateContext, this, httpVersion, chunkConfig,
                                                    httpInboundResponseFuture));
         httpOutboundRequest.getHttpContentAsync().setMessageListener((httpContent -> {
+            //TODO:Until the listener is set, content writing will happen in I/O thread. If writability changed
+            //while in I/O thread and DefaultBackPressureListener is engaged, there's a chance of I/O thread
+            //getting blocked. Cannot recreate, only a possibility.
             Util.checkUnWritabilityAndNotify(targetHandler.getContext(), backpressureHandler);
             this.channel.eventLoop().execute(() -> {
                 try {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/channel/TargetChannel.java
@@ -222,7 +222,7 @@ public class TargetChannel {
                 .setSenderState(new SendingHeaders(messageStateContext, this, httpVersion, chunkConfig,
                                                    httpInboundResponseFuture));
         httpOutboundRequest.getHttpContentAsync().setMessageListener((httpContent -> {
-            //TODO:Until the listener is set, content writing will happen in I/O thread. If writability changed
+            //TODO:Until the listener is set, content writing happens in I/O thread. If writability changed
             //while in I/O thread and DefaultBackPressureListener is engaged, there's a chance of I/O thread
             //getting blocked. Cannot recreate, only a possibility.
             Util.checkUnWritabilityAndNotify(targetHandler.getContext(), backpressureHandler);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2Content.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2Content.java
@@ -1,0 +1,24 @@
+package org.wso2.transport.http.netty.contractimpl.sender.http2;
+
+import io.netty.handler.codec.http.HttpContent;
+
+/**
+ * Represents HTTP2 request content.
+ */
+public class Http2Content {
+    private final HttpContent httpContent;
+    private final OutboundMsgHolder outboundMsgHolder;
+
+    Http2Content(HttpContent httpContent, OutboundMsgHolder outboundMsgHolder) {
+        this.httpContent = httpContent;
+        this.outboundMsgHolder = outboundMsgHolder;
+    }
+
+    public HttpContent getHttpContent() {
+        return httpContent;
+    }
+
+    public OutboundMsgHolder getOutboundMsgHolder() {
+        return outboundMsgHolder;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2Content.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2Content.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
 package org.wso2.transport.http.netty.contractimpl.sender.http2;
 
 import io.netty.handler.codec.http.HttpContent;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -59,11 +59,6 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        /*if (msg instanceof OutboundMsgHolder) {
-            OutboundMsgHolder outboundMsgHolder = (OutboundMsgHolder) msg;
-            new Http2TargetHandler.Http2RequestWriter(outboundMsgHolder).writeContent(ctx);
-        } else */
-
         if (msg instanceof Http2Content) {
             Http2Content http2Content = (Http2Content) msg;
             try {
@@ -137,21 +132,6 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         return encoder;
     }
 
-    /*private void writeContent(ChannelHandlerContext ctx, HttpContent httpContent,
-                              Http2MessageStateContext http2MessageStateContext, OutboundMsgHolder outboundMsgHolder)
-                              throws Http2Exception {
-        try {
-            http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, httpContent,
-            http2MessageStateContext);
-        } catch (RuntimeException ex) {
-            http2MessageStateContext
-                .setSenderState(new SendingEntityBody(Http2TargetHandler.this, this));
-            http2MessageStateContext
-                .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent(),
-                                                           http2MessageStateContext);
-        }
-    }*/
-
     /**
      * {@code Http2RequestWriter} is used to write Http2 content to the connection.
      */
@@ -171,26 +151,6 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                 httpOutboundRequest.setHttp2MessageStateContext(http2MessageStateContext);
             }
         }
-
-        /*void writeContent(ChannelHandlerContext ctx) {
-            httpOutboundRequest.getHttp2MessageStateContext()
-                    .setSenderState(new SendingHeaders(Http2TargetHandler.this, this));
-            // Write Content
-            httpOutboundRequest.getHttpContentAsync().setMessageListener(httpContent ->
-                    http2ClientChannel.getChannel().eventLoop().execute(() -> {
-                        try {
-                            writeOutboundRequest(ctx, httpContent);
-                        } catch (Http2NoMoreStreamIdsException ex) {
-                            //Remove connection from the pool
-                            http2ClientChannel.removeFromConnectionPool();
-                            LOG.warn("Channel is removed from the connection pool : {}", ex.getMessage(), ex);
-                            outboundMsgHolder.getResponseFuture().notifyHttpListener(ex);
-                        } catch (Http2Exception ex) {
-                            LOG.error("Failed to send the request : " + ex.getMessage(), ex);
-                            outboundMsgHolder.getResponseFuture().notifyHttpListener(ex);
-                        }
-                    }));
-        }*/
 
         void writeContent(ChannelHandlerContext ctx, HttpContent msg) throws Http2Exception {
             try {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -74,7 +74,6 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                 LOG.error("Failed to send the request : " + ex.getMessage(), ex);
                 http2Content.getOutboundMsgHolder().getResponseFuture().notifyHttpListener(ex);
             }
-
         } else if (msg instanceof Http2Reset) {
             Http2Reset resetMsg = (Http2Reset) msg;
             resetStream(ctx, resetMsg.getStreamId(), resetMsg.getError());

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -59,9 +59,27 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        if (msg instanceof OutboundMsgHolder) {
+        /*if (msg instanceof OutboundMsgHolder) {
             OutboundMsgHolder outboundMsgHolder = (OutboundMsgHolder) msg;
             new Http2TargetHandler.Http2RequestWriter(outboundMsgHolder).writeContent(ctx);
+        } else */
+
+        if (msg instanceof Http2Content) {
+            Http2Content http2Content = (Http2Content) msg;
+            try {
+                new Http2TargetHandler.Http2RequestWriter(http2Content.getOutboundMsgHolder()).writeContent(ctx,
+                                                                                            http2Content
+                                                                                                .getHttpContent());
+            } catch (Http2NoMoreStreamIdsException ex) {
+                //Remove connection from the pool
+                http2ClientChannel.removeFromConnectionPool();
+                LOG.warn("Channel is removed from the connection pool : {}", ex.getMessage(), ex);
+                http2Content.getOutboundMsgHolder().getResponseFuture().notifyHttpListener(ex);
+            } catch (Http2Exception ex) {
+                LOG.error("Failed to send the request : " + ex.getMessage(), ex);
+                http2Content.getOutboundMsgHolder().getResponseFuture().notifyHttpListener(ex);
+            }
+
         } else if (msg instanceof Http2Reset) {
             Http2Reset resetMsg = (Http2Reset) msg;
             resetStream(ctx, resetMsg.getStreamId(), resetMsg.getError());
@@ -119,6 +137,21 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         return encoder;
     }
 
+    /*private void writeContent(ChannelHandlerContext ctx, HttpContent httpContent,
+                              Http2MessageStateContext http2MessageStateContext, OutboundMsgHolder outboundMsgHolder)
+                              throws Http2Exception {
+        try {
+            http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, httpContent,
+            http2MessageStateContext);
+        } catch (RuntimeException ex) {
+            http2MessageStateContext
+                .setSenderState(new SendingEntityBody(Http2TargetHandler.this, this));
+            http2MessageStateContext
+                .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent(),
+                                                           http2MessageStateContext);
+        }
+    }*/
+
     /**
      * {@code Http2RequestWriter} is used to write Http2 content to the connection.
      */
@@ -139,7 +172,7 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
             }
         }
 
-        void writeContent(ChannelHandlerContext ctx) {
+        /*void writeContent(ChannelHandlerContext ctx) {
             httpOutboundRequest.getHttp2MessageStateContext()
                     .setSenderState(new SendingHeaders(Http2TargetHandler.this, this));
             // Write Content
@@ -157,17 +190,22 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
                             outboundMsgHolder.getResponseFuture().notifyHttpListener(ex);
                         }
                     }));
-        }
+        }*/
 
-        private void writeOutboundRequest(ChannelHandlerContext ctx, HttpContent msg) throws Http2Exception {
+        void writeContent(ChannelHandlerContext ctx, HttpContent msg) throws Http2Exception {
             try {
+                if (!outboundMsgHolder.isFirstContentWritten()) {
+                    httpOutboundRequest.getHttp2MessageStateContext()
+                        .setSenderState(new SendingHeaders(Http2TargetHandler.this, this));
+                    outboundMsgHolder.setFirstContentWritten(true);
+                }
                 http2MessageStateContext.getSenderState().writeOutboundRequestBody(ctx, msg, http2MessageStateContext);
             } catch (RuntimeException ex) {
                 httpOutboundRequest.getHttp2MessageStateContext()
-                        .setSenderState(new SendingEntityBody(Http2TargetHandler.this, this));
+                    .setSenderState(new SendingEntityBody(Http2TargetHandler.this, this));
                 httpOutboundRequest.getHttp2MessageStateContext()
-                        .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent(),
-                        http2MessageStateContext);
+                    .getSenderState().writeOutboundRequestBody(ctx, new DefaultLastHttpContent(),
+                                                               http2MessageStateContext);
             }
         }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/Http2TargetHandler.java
@@ -62,16 +62,15 @@ public class Http2TargetHandler extends ChannelDuplexHandler {
         if (msg instanceof Http2Content) {
             Http2Content http2Content = (Http2Content) msg;
             try {
-                new Http2TargetHandler.Http2RequestWriter(http2Content.getOutboundMsgHolder()).writeContent(ctx,
-                                                                                            http2Content
-                                                                                                .getHttpContent());
+                new Http2TargetHandler.Http2RequestWriter(http2Content.getOutboundMsgHolder()).
+                    writeContent(ctx, http2Content.getHttpContent());
             } catch (Http2NoMoreStreamIdsException ex) {
                 //Remove connection from the pool
                 http2ClientChannel.removeFromConnectionPool();
                 LOG.warn("Channel is removed from the connection pool : {}", ex.getMessage(), ex);
                 http2Content.getOutboundMsgHolder().getResponseFuture().notifyHttpListener(ex);
             } catch (Http2Exception ex) {
-                LOG.error("Failed to send the request : " + ex.getMessage(), ex);
+                LOG.error("Failed to send the request : {}", ex.getMessage(), ex);
                 http2Content.getOutboundMsgHolder().getResponseFuture().notifyHttpListener(ex);
             }
         } else if (msg instanceof Http2Reset) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/OutboundMsgHolder.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/OutboundMsgHolder.java
@@ -46,6 +46,7 @@ public class OutboundMsgHolder {
     private boolean allPromisesReceived = false;
     private long lastReadWriteTime;
     private boolean requestWritten;
+    private boolean firstContentWritten;
 
     public OutboundMsgHolder(HttpCarbonMessage httpOutboundRequest) {
         this.requestCarbonMessage = httpOutboundRequest;
@@ -208,5 +209,12 @@ public class OutboundMsgHolder {
     public void setRequestWritten(boolean requestWritten) {
         this.requestWritten = requestWritten;
     }
-}
 
+    boolean isFirstContentWritten() {
+        return firstContentWritten;
+    }
+
+    void setFirstContentWritten(boolean firstContentWritten) {
+        this.firstContentWritten = firstContentWritten;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/RequestWriteStarter.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/RequestWriteStarter.java
@@ -1,0 +1,26 @@
+package org.wso2.transport.http.netty.contractimpl.sender.http2;
+
+/**
+ * Starts the request content writing.
+ */
+public class RequestWriteStarter {
+
+    private final OutboundMsgHolder outboundMsgHolder;
+    private final Http2ClientChannel http2ClientChannel;
+
+    public RequestWriteStarter(OutboundMsgHolder outboundMsgHolder, Http2ClientChannel http2ClientChannel) {
+        this.outboundMsgHolder = outboundMsgHolder;
+        this.http2ClientChannel = http2ClientChannel;
+    }
+
+    public void startWritingContent() {
+        // Write Content
+        outboundMsgHolder.setFirstContentWritten(false);
+        outboundMsgHolder.getRequest().getHttpContentAsync().setMessageListener((httpContent) -> {
+            http2ClientChannel.getChannel().eventLoop().execute(() -> {
+                Http2Content http2Content = new Http2Content(httpContent, outboundMsgHolder);
+                http2ClientChannel.getChannel().write(http2Content);
+            });
+        });
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/RequestWriteStarter.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/http2/RequestWriteStarter.java
@@ -1,7 +1,26 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
 package org.wso2.transport.http.netty.contractimpl.sender.http2;
 
 /**
- * Starts the request content writing.
+ * Starts HTTP/2 request content writing.
  */
 public class RequestWriteStarter {
 
@@ -14,7 +33,6 @@ public class RequestWriteStarter {
     }
 
     public void startWritingContent() {
-        // Write Content
         outboundMsgHolder.setFirstContentWritten(false);
         outboundMsgHolder.getRequest().getHttpContentAsync().setMessageListener((httpContent) -> {
             http2ClientChannel.getChannel().eventLoop().execute(() -> {


### PR DESCRIPTION
$subject is a prerequisite for Http/2 flow controlling for client