### PR TITLE
Remove super close()

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -35,6 +35,7 @@ import org.wso2.transport.http.netty.contract.Constants;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
@@ -73,6 +74,7 @@ public class HttpMessageDataStreamer {
         private int limit;
         private ByteBuffer byteBuffer;
         private HttpContent httpContent;
+        private PrintStream printStream = System.out;
 
         @Override
         public int read() {
@@ -111,13 +113,17 @@ public class HttpMessageDataStreamer {
         @Override
         public void close() throws IOException {
             byteBuffer = null;
-//            releaseHttpContent();    //fix memory leak issue in error path
-            super.close();
+            releaseHttpContent();    //fix memory leak issue in error path
+            for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+                printStream.println(element);
+            }
+//            super.close();
         }
 
         private synchronized void releaseHttpContent() {
             if (httpContent != null && httpContent.refCnt() > 0) {
                 httpContent.release();
+                printStream.println("---Release HttpContent is called---");
             }
         }
     }


### PR DESCRIPTION
## Purpose
> This PR will add stacktrace logs to identify a possible test failure path. This change will be reverted in the next immediate release. 

Please note that do not use 6.0.286 HTTP transport version