### PR TITLE
Prevent waiting when shutting down the connector factory

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -172,10 +172,8 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
 
     /**
      * This method is for shutting down the connectors without a delay.
-     *
-     * @throws InterruptedException when interrupted by some other event
-     */
-    public void shutdownNow() throws InterruptedException {
+     **/
+    public void shutdownNow() {
         allChannels.close();
         workerGroup.shutdownGracefully();
         bossGroup.shutdownGracefully();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -169,4 +169,19 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
             pipeliningGroup.shutdownGracefully().sync();
         }
     }
+
+    /**
+     * This method is for shutting down the connectors without a delay.
+     *
+     * @throws InterruptedException when interrupted by some other event
+     */
+    public void shutdownNow() throws InterruptedException {
+        allChannels.close();
+        workerGroup.shutdownGracefully();
+        bossGroup.shutdownGracefully();
+        clientGroup.shutdownGracefully();
+        if (pipeliningGroup != null) {
+            pipeliningGroup.shutdownGracefully();
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
> Prevent waiting when shutting down the connector factory

## Goals
> Stop waiting when shutting down a DefaultHttpWsConnectorFactory by avoiding waiting for the future until it is done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes