### PR TITLE
Handle abnormal 100 continue response

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
@@ -495,6 +496,15 @@ public class HttpCarbonMessage {
 
     public boolean isPipeliningEnabled() {
         return pipeliningEnabled;
+    }
+
+    /**
+     * Can be used to detect if a request is expecting 100 continue
+     *
+     * @return true if the request is expecting 100 continue
+     */
+    public boolean is100ContinueExpected() {
+        return HttpUtil.is100ContinueExpected(httpMessage);
     }
 
     public void setPipeliningEnabled(boolean pipeliningEnabled) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -499,7 +499,7 @@ public class HttpCarbonMessage {
     }
 
     /**
-     * Can be used to detect if a request is expecting 100 continue
+     * Can be used to detect if a request is expecting 100 continue.
      *
      * @return true if the request is expecting 100 continue
      */

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.expect100continue;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.util.DefaultHttpConnectorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+import org.wso2.transport.http.netty.util.server.initializers.Abnormal100ContinueServerInitializer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.transport.http.netty.contract.Constants.TEXT_PLAIN;
+import static org.wso2.transport.http.netty.util.TestUtil.sendRequestAsync;
+
+/**
+ * Tests for connection pool implementation.
+ */
+public class Abnormal100ContinueTestCase {
+
+    private HttpServer httpServer;
+    private HttpClientConnector httpClientConnector;
+    private HttpWsConnectorFactory connectorFactory;
+    private String responseContent = "Test Message";
+
+    @BeforeClass
+    public void setup() {
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT,
+                                   new Abnormal100ContinueServerInitializer(responseContent, TEXT_PLAIN, 200));
+
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
+    }
+
+    @Test
+    public void testConnectionReuseForMain() {
+        try {
+            CountDownLatch waitForResponseLatch = new CountDownLatch(1);
+            DefaultHttpConnectorListener responseListener = sendRequestAsync(waitForResponseLatch, httpClientConnector);
+            String responseOne = TestUtil.waitAndGetStringEntity(waitForResponseLatch, responseListener);
+
+            assertEquals(responseOne, responseContent);
+        } catch (Exception e) {
+            TestUtil.handleException("IOException occurred while running testConnectionReuseForMain", e);
+        }
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        TestUtil.cleanUp(new ArrayList<>(), httpServer, connectorFactory);
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Abnormal100ContinueTestCase.java
@@ -60,7 +60,7 @@ public class Abnormal100ContinueTestCase {
     }
 
     @Test
-    public void testConnectionReuseForMain() {
+    public void testAbnormal100continueResponse() {
         try {
             CountDownLatch waitForResponseLatch = new CountDownLatch(1);
             DefaultHttpConnectorListener responseListener = sendRequestAsync(waitForResponseLatch, httpClientConnector);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Continue100TestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/expect100continue/Continue100TestCase.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.transport.http.netty.headers;
+package org.wso2.transport.http.netty.expect100continue;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpRequest;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/Abnormal100ContinueServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/Abnormal100ContinueServerInitializer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.util.server.initializers;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+/**
+ * An initializer class for HTTP Server
+ */
+public class Abnormal100ContinueServerInitializer extends HttpServerInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Abnormal100ContinueServerInitializer.class);
+
+    private String stringContent;
+    private String contentType;
+    private int responseStatusCode;
+    private HttpRequest req;
+
+    public Abnormal100ContinueServerInitializer(String stringContent, String contentType, int responseStatusCode) {
+        this.stringContent = stringContent;
+        this.contentType = contentType;
+        this.responseStatusCode = responseStatusCode;
+    }
+
+    protected void addBusinessLogicHandler(Channel channel) {
+        channel.pipeline().addLast("handler", new Abnormal100ContinueServerHandler());
+    }
+
+    private class Abnormal100ContinueServerHandler extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+
+            if (stringContent != null) {
+                ByteBuf content = Unpooled.wrappedBuffer(stringContent.getBytes("UTF-8"));
+                if (msg instanceof HttpRequest) {
+                    req = (HttpRequest) msg;
+                } else if (msg instanceof LastHttpContent) {
+                    ctx.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE));
+                    writeResponse(ctx, content);
+                }
+            }
+        }
+
+        private void writeResponse(ChannelHandlerContext ctx, ByteBuf content) {
+            FullHttpResponse response = makeOutboundResponse(content);
+            boolean keepAlive = HttpUtil.isKeepAlive(req);
+            if (!keepAlive) {
+                ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+                LOG.debug("Writing response with data to client-connector");
+                LOG.debug("Closing the client-connector connection");
+            } else {
+                response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+                ctx.writeAndFlush(response);
+                LOG.debug("Writing response with data to client-connector");
+            }
+        }
+
+        private FullHttpResponse makeOutboundResponse(ByteBuf content) {
+            HttpResponseStatus httpResponseStatus = new HttpResponseStatus(responseStatusCode,
+                                                      HttpResponseStatus.valueOf(responseStatusCode).reasonPhrase());
+            FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, httpResponseStatus, content);
+            response.headers().set(CONTENT_TYPE, contentType);
+            response.headers().set(CONTENT_LENGTH, content.readableBytes());
+            return response;
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/Abnormal100ContinueServerInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/server/initializers/Abnormal100ContinueServerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -66,7 +66,6 @@ public class Abnormal100ContinueServerInitializer extends HttpServerInitializer 
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-
             if (stringContent != null) {
                 ByteBuf content = Unpooled.wrappedBuffer(stringContent.getBytes("UTF-8"));
                 if (msg instanceof HttpRequest) {

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -50,7 +50,8 @@
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkEnableClientTestCase" />
             <class name="org.wso2.transport.http.netty.chunkdisable.ChunkDisableClientTestCase" />
 
-            <class name="org.wso2.transport.http.netty.headers.Continue100TestCase" />
+            <class name="org.wso2.transport.http.netty.expect100continue.Continue100TestCase" />
+            <class name="org.wso2.transport.http.netty.expect100continue.Abnormal100ContinueTestCase"/>
 
             <class name="org.wso2.transport.http.netty.unitfunction.CommonUtilTestCase" />
             <class name="org.wso2.transport.http.netty.unitfunction.HttpCarbonMessageTestCase" />


### PR DESCRIPTION
## Purpose
Some HTTP servers could respond with 100 continue before sending the payload even though the request does not have Expect: continue header. This PR is to handle such scenario. 

P.S. - Same fix was done few days ago by Bhashinee. I just improved that fix and added a test-case.