### PR TITLE
Add IllegalStateException for countMessageLengthTill method

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
@@ -70,8 +70,9 @@ public interface EntityCollector {
      * available message size. This method is blocking function. Hence, use with care.
      * @param maxLength is the maximum length to count
      * @return counted length
+     * @throws InterruptedException if interrupted while waiting
      */
-    long countMessageLengthTill(long maxLength);
+    long countMessageLengthTill(long maxLength) throws InterruptedException;
 
     /**
      * Complete the message.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/EntityCollector.java
@@ -68,11 +68,12 @@ public interface EntityCollector {
      * Count the message length till the given message length and returns.
      * If the message length is shorter than the given length it returns with the
      * available message size. This method is blocking function. Hence, use with care.
+     *
      * @param maxLength is the maximum length to count
      * @return counted length
-     * @throws InterruptedException if interrupted while waiting
+     * @throws IllegalStateException if illegal state occurs in the absence of content
      */
-    long countMessageLengthTill(long maxLength) throws InterruptedException;
+    long countMessageLengthTill(long maxLength) throws IllegalStateException;
 
     /**
      * Complete the message.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -172,8 +172,9 @@ public class HttpCarbonMessage {
      * available message size. This method is blocking function. Hence, use with care.
      * @param maxLength is the maximum length to count
      * @return counted length
+     * @throws InterruptedException if interrupted while waiting
      */
-    public long countMessageLengthTill(long maxLength) {
+    public long countMessageLengthTill(long maxLength) throws InterruptedException {
         return this.blockingEntityCollector.countMessageLengthTill(maxLength);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -170,11 +170,12 @@ public class HttpCarbonMessage {
      * Count the message length till the given message length and returns.
      * If the message length is shorter than the given length it returns with the
      * available message size. This method is blocking function. Hence, use with care.
+     *
      * @param maxLength is the maximum length to count
      * @return counted length
-     * @throws InterruptedException if interrupted while waiting
+     * @throws IllegalStateException if illegal state occurs in the absence of content
      */
-    public long countMessageLengthTill(long maxLength) throws InterruptedException {
+    public long countMessageLengthTill(long maxLength) throws IllegalStateException {
         return this.blockingEntityCollector.countMessageLengthTill(maxLength);
     }
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/BlockingEntityCollectorTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/unitfunction/BlockingEntityCollectorTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.unitfunction;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.util.TestUtil;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ * A unit test class for BlockingEntityCollector class functions.
+ */
+public class BlockingEntityCollectorTestCase {
+
+    @Test(description = "Test count message length till a give limit")
+    public void testCountMessageLengthTill() {
+        HttpCarbonMessage msg = new HttpCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, ""));
+        ByteBuffer byteBuffer = ByteBuffer.wrap(TestUtil.largeEntity.getBytes(Charset.forName("UTF-8")));
+        msg.addHttpContent(new DefaultLastHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+
+        long count = 0;
+        String exceptionMessage = "";
+        try {
+            count = msg.getBlockingEntityCollector().countMessageLengthTill(15);
+        } catch (IllegalStateException e) {
+            exceptionMessage = e.getMessage();
+        }
+        // TODO: Verify logic as countMessageLengthTill returns complete length regardless of the given max length
+        Assert.assertEquals(count, 9342);
+        Assert.assertEquals(exceptionMessage, "");
+    }
+
+    @Test(description = "Test countMessageLengthTill for poll timeout")
+    public void testCountMessageLengthTillPollTimeout() {
+        HttpCarbonMessage msg = new HttpCarbonMessage(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, ""), 10000, null);
+        ByteBuffer byteBuffer = ByteBuffer.wrap("".getBytes(Charset.forName("UTF-8")));
+        msg.addHttpContent(new DefaultHttpContent(Unpooled.wrappedBuffer(byteBuffer)));
+
+        long count = 0;
+        String exceptionMessage = "";
+        try {
+            count = msg.getBlockingEntityCollector().countMessageLengthTill(3);
+        } catch (IllegalStateException e) {
+            exceptionMessage = e.getMessage();
+        }
+        Assert.assertEquals(count, 0);
+        Assert.assertEquals(exceptionMessage, "poll timeout expired");
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -56,6 +56,7 @@
             <class name="org.wso2.transport.http.netty.unitfunction.CommonUtilTestCase" />
             <class name="org.wso2.transport.http.netty.unitfunction.HttpCarbonMessageTestCase" />
             <class name="org.wso2.transport.http.netty.unitfunction.ForwardedTestCase" />
+            <class name="org.wso2.transport.http.netty.unitfunction.BlockingEntityCollectorTestCase" />
 
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
             <class name="org.wso2.transport.http.netty.urilengthvalidation.Status414And413ResponseTest"/>


### PR DESCRIPTION
## Purpose
> Use same Endpoint timeout interval for the poll action.
> Update countMessageLengthTill function to throw IllegalStateException upon polling timeout expired

## Goals
> Provide proper error when polling is expired
> Prevent execution hanging issue while polling as it did not had a timeout

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.