### PR TITLE
Enable configuring the WebSocket Compression

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
@@ -53,6 +53,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private List<Parameter> parameters = getDefaultParameters();
     private RequestSizeValidationConfig requestSizeValidationConfig = new RequestSizeValidationConfig();
     private boolean pipeliningEnabled;
+    private boolean webSocketCompressionEnabled;
     private long pipeliningLimit;
 
     public ListenerConfiguration() {
@@ -191,5 +192,13 @@ public class ListenerConfiguration extends SslConfiguration {
 
     public void setPipeliningLimit(long pipeliningLimit) {
         this.pipeliningLimit = pipeliningLimit;
+    }
+
+    public boolean isWebSocketCompressionEnabled() {
+        return webSocketCompressionEnabled;
+    }
+
+    public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
+        this.webSocketCompressionEnabled = webSocketCompressionEnabled;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketClientConnectorConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketClientConnectorConfig.java
@@ -40,6 +40,7 @@ public class WebSocketClientConnectorConfig extends SslConfiguration {
     private boolean autoRead;
     private final HttpHeaders headers;
     private int maxFrameSize = 65536;
+    private boolean webSocketCompressionEnabled;
 
     public WebSocketClientConnectorConfig(String remoteAddress) {
         this.remoteAddress = remoteAddress;
@@ -158,5 +159,13 @@ public class WebSocketClientConnectorConfig extends SslConfiguration {
 
     public void setMaxFrameSize(int maxFrameSize) {
         this.maxFrameSize = maxFrameSize;
+    }
+
+    public boolean isWebSocketCompressionEnabled() {
+        return webSocketCompressionEnabled;
+    }
+
+    public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
+        this.webSocketCompressionEnabled = webSocketCompressionEnabled;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -96,6 +96,7 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
         serverConnectorBootstrap.addServerHeader(listenerConfig.getServerHeader());
 
         serverConnectorBootstrap.setPipeliningEnabled(listenerConfig.isPipeliningEnabled());
+        serverConnectorBootstrap.setWebSocketCompressionEnabled(listenerConfig.isWebSocketCompressionEnabled());
         serverConnectorBootstrap.setPipeliningLimit(listenerConfig.getPipeliningLimit());
 
         if (listenerConfig.isPipeliningEnabled()) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -99,6 +99,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
     private boolean pipeliningEnabled;
     private long pipeliningLimit;
     private EventExecutorGroup pipeliningGroup;
+    private boolean webSocketCompressionEnabled;
 
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
@@ -216,7 +217,8 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         }
 
         serverPipeline.addLast(Constants.WEBSOCKET_SERVER_HANDSHAKE_HANDLER,
-                         new WebSocketServerHandshakeHandler(this.serverConnectorFuture, this.interfaceId));
+                               new WebSocketServerHandshakeHandler(this.serverConnectorFuture, this.interfaceId,
+                                                                   webSocketCompressionEnabled));
         serverPipeline.addLast(Constants.BACK_PRESSURE_HANDLER, new BackPressureHandler());
         serverPipeline.addLast(Constants.HTTP_SOURCE_HANDLER,
                                new SourceHandler(this.serverConnectorFuture, this.interfaceId, this.chunkConfig,
@@ -372,6 +374,10 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
 
     public void setPipeliningThreadGroup(EventExecutorGroup pipeliningGroup) {
         this.pipeliningGroup = pipeliningGroup;
+    }
+
+    public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
+        this.webSocketCompressionEnabled = webSocketCompressionEnabled;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ServerConnectorBootstrap.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ServerConnectorBootstrap.java
@@ -184,6 +184,10 @@ public class ServerConnectorBootstrap {
         httpServerChannelInitializer.setPipeliningThreadGroup(pipeliningGroup);
     }
 
+    public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
+        httpServerChannelInitializer.setWebSocketCompressionEnabled(webSocketCompressionEnabled);
+    }
+
     class HttpServerConnector implements ServerConnector {
 
        private final Logger log = LoggerFactory.getLogger(HttpServerConnector.class);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
@@ -155,7 +155,9 @@ public class WebSocketClient {
         pipeline.addLast(new HttpClientCodec());
         // Assuming that WebSocket Handshake messages will not be large than 8KB
         pipeline.addLast(new HttpObjectAggregator(8192));
-        pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
+        if (connectorConfig.isWebSocketCompressionEnabled()) {
+            pipeline.addLast(WebSocketClientCompressionHandler.INSTANCE);
+        }
         pipeline.addLast(Utf8FrameValidator.class.getName(), new Utf8FrameValidator());
         if (idleTimeout > 0) {
             pipeline.addLast(new IdleStateHandler(0, 0, idleTimeout, TimeUnit.MILLISECONDS));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
@@ -80,7 +80,7 @@ public class WebSocketClientFunctionalityTestCase {
         sendTextMessageAndReceiveResponse(textSent, connectorListener, webSocketConnection);
         WebSocketTextMessage textMessage = connectorListener.getReceivedTextMessageToClient();
 
-        assetMessageProperties(textMessage);
+        assertMessageProperties(textMessage);
         Assert.assertEquals(textMessage.getText(), textSent);
         Assert.assertTrue(textMessage.isFinalFragment());
     }
@@ -125,7 +125,7 @@ public class WebSocketClientFunctionalityTestCase {
         sendAndReceiveBinaryMessage(bufferSent, connectorListener, webSocketConnection);
         WebSocketBinaryMessage receivedBinaryMessage = connectorListener.getReceivedBinaryMessageToClient();
 
-        assetMessageProperties(receivedBinaryMessage);
+        assertMessageProperties(receivedBinaryMessage);
         Assert.assertEquals(receivedBinaryMessage.getByteBuffer(), bufferSent);
         Assert.assertEquals(receivedBinaryMessage.getByteArray(), bytes);
     }
@@ -237,7 +237,7 @@ public class WebSocketClientFunctionalityTestCase {
         webSocketConnection.terminateConnection(1000, "");
     }
 
-    private void assetMessageProperties(WebSocketMessage webSocketMessage) {
+    private void assertMessageProperties(WebSocketMessage webSocketMessage) {
         Assert.assertEquals(webSocketMessage.getTarget(), "ws://localhost:9010/websocket");
         Assert.assertFalse(webSocketMessage.isServerMessage());
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/server/WebSocketServerHandshakeFunctionalityTestCase.java
@@ -64,6 +64,7 @@ public class WebSocketServerHandshakeFunctionalityTestCase {
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         listenerConfiguration.setHost(Constants.LOCALHOST);
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        listenerConfiguration.setWebSocketCompressionEnabled(true);
         httpConnectorFactory = new DefaultHttpWsConnectorFactory();
         serverConnector = httpConnectorFactory.createServerConnector(TestUtil.getDefaultServerBootstrapConfig(),
                                                                      listenerConfiguration);
@@ -145,7 +146,7 @@ public class WebSocketServerHandshakeFunctionalityTestCase {
         testClient.setCountDownLatch(countDownLatch);
         webSocketConnection.readNextFrame();
         countDownLatch.await(countdownLatchTimeout, TimeUnit.SECONDS);
-        CloseWebSocketFrame closeFrame =  testClient.getReceivedCloseFrame();
+        CloseWebSocketFrame closeFrame = testClient.getReceivedCloseFrame();
 
         Assert.assertNotNull(closeFrame);
         Assert.assertEquals(closeFrame.statusCode(), 1002);
@@ -258,7 +259,7 @@ public class WebSocketServerHandshakeFunctionalityTestCase {
     }
 
     @Test(priority = 1)
-    public void testListerNotSetInMessageReading() throws URISyntaxException, InterruptedException {
+    public void testListnerNotSetInMessageReading() throws URISyntaxException, InterruptedException {
         CountDownLatch serverHandshakeCountDownLatch = new CountDownLatch(1);
         listener.setHandshakeCompleteCountDownLatch(serverHandshakeCountDownLatch);
         WebSocketTestClient testClient = createClientAndHandshake("x-handshake", null);


### PR DESCRIPTION
## Purpose
> Add a parameters to support enabling or disabling the support of compression in WebSocket

## Goals
> Support  configuring the WebSocket Compression

## Approach
> Add a new config param to Listener and client configs.

## User stories
>N/A

## Release note
> API change to http Listener and WebSocket client config.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> N/A

## Related PRs
> 
## Migrations (if applicable)
> N/A

## Test environment
> JDK 8
 
## Learning
> N/A