### PR TITLE
Add referenceCount to track content release

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpMessageDataStreamer.java
@@ -73,6 +73,7 @@ public class HttpMessageDataStreamer {
         private int limit;
         private ByteBuffer byteBuffer;
         private HttpContent httpContent;
+        private int referenceCount = 0;
 
         @Override
         public int read() {
@@ -80,6 +81,7 @@ public class HttpMessageDataStreamer {
                 return -1;
             } else if (chunkFinished) {
                 httpContent = httpCarbonMessage.getHttpContent();
+                referenceCount++;
                 validateHttpContent();
                 byteBuffer = httpContent.content().nioBuffer();
                 count = 0;
@@ -115,9 +117,10 @@ public class HttpMessageDataStreamer {
             super.close();
         }
 
-        private synchronized void releaseHttpContent() {
-            if (httpContent != null && httpContent.refCnt() > 0) {
+        private void releaseHttpContent() {
+            if (httpContent != null && referenceCount > 0) {
                 httpContent.release();
+                referenceCount--;
             }
         }
     }


### PR DESCRIPTION
## Purpose
> $Subject.
> This is not related to HttpContent.refCnt. We maintain a count privately to release the consumed content

## Goals
> Avoid memory leaks and do proper content release

## Related PRs
> https://github.com/ballerina-platform/ballerina-lang/pull/18305