### PR TITLE
Get the java default ssl context

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -173,6 +173,10 @@ public class SslConfiguration {
         sslConfig.disableSsl();
     }
 
+    public void useJavaDefaults() {
+        sslConfig.setUseJavaDefaults();
+    }
+
     public SSLConfig getClientSSLConfig() {
         if (scheme == null || !scheme.equalsIgnoreCase(HTTPS_SCHEME)) {
             return null;
@@ -240,7 +244,7 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForSender() {
-        if (sslConfig.isDisableSsl()) {
+        if (sslConfig.isDisableSsl() || sslConfig.useJavaDefaults()) {
             return sslConfig;
         }
         if ((sslConfig.getTrustStore() == null || sslConfig.getTrustStorePass() == null) && (

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
@@ -63,6 +63,7 @@ public class SSLConfig {
     private int sessionTimeOut;
     private long handshakeTimeOut;
     private boolean disableSsl = false;
+    private boolean useJavaDefaults = false;
 
     public SSLConfig() {}
 
@@ -334,5 +335,13 @@ public class SSLConfig {
 
     public void disableSsl() {
         this.disableSsl = true;
+    }
+
+    public boolean useJavaDefaults() {
+        return useJavaDefaults;
+    }
+
+    public void setUseJavaDefaults() {
+        this.useJavaDefaults = true;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLHandlerFactory.java
@@ -81,6 +81,9 @@ public class SSLHandlerFactory {
     public SSLContext createSSLContextFromKeystores(boolean isServer) {
         String protocol = sslConfig.getSSLProtocol();
         try {
+            if (sslConfig.useJavaDefaults() && !isServer) {
+                return SSLContext.getDefault();
+            }
             KeyManager[] keyManagers = null;
             if (sslConfig.getKeyStore() != null) {
                 KeyStore ks = getKeyStore(sslConfig.getKeyStore(), sslConfig.getKeyStorePass());


### PR DESCRIPTION
## Purpose
Get the java default context when the user hasn't provided any truststore information.
