### PR TITLE
Remove unnecessary connection close

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/SourceHandler.java
@@ -155,8 +155,6 @@ public class SourceHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
-        closeChannel(ctx);
-
         if (!idleTimeout) {
             if (!requestSet.isEmpty()) {
                 requestSet.forEach((key, inboundMsg) -> inboundMsg.listenerReqRespStateManager


### PR DESCRIPTION
Once the peer closes the connection channel  automatically gets closed from both sides. That's the default behavior of netty.

If we want to use half close that has to be configured specifically using 'setAllowHalfClosure' method. 
 >> https://netty.io/4.0/api/io/netty/channel/socket/SocketChannelConfig.html#setAllowHalfClosure-boolean-.

But with HTTP protocol that is not necessary.  

Using close on an already closed connection causes RST packets. 