### PR TITLE
Skip the certificate expiration date validation when the user has disabled ssl validation

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -211,6 +211,10 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         return http2ConnectionManager;
     }
 
+    public SSLConfig getSslConfig() {
+        return sslConfig;
+    }
+
     /**
      * Creates the pipeline for handing http2 upgrade.
      *


### PR DESCRIPTION
## Purpose
Fix the issue: https://github.com/ballerina-platform/ballerina-lang/issues/19687