### PR TITLE
Refactor HTTP2 Trailer header logic and add test cases

### DIFF
--- a/components/org.wso2.transport.http.netty.statistics/pom.xml
+++ b/components/org.wso2.transport.http.netty.statistics/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.transport.http</groupId>
         <artifactId>http-parent</artifactId>
-        <version>6.2.35-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.transport.http</groupId>
         <artifactId>http-parent</artifactId>
-        <version>6.2.35-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -93,6 +93,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
 import static org.wso2.transport.http.netty.contract.Constants.COLON;
 import static org.wso2.transport.http.netty.contract.Constants.HEADER_VAL_100_CONTINUE;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_HOST;
@@ -281,6 +282,10 @@ public class Util {
         // Convert Http2Headers to HttpHeaders
         HttpConversionUtil.addHttp2ToHttpHeaders(
                 streamId, http2Headers, httpRequest.headers(), version, false, true);
+        CharSequence trailerHeaderValue = http2Headers.get(TRAILER.toString());
+        if (trailerHeaderValue != null) {
+            httpRequest.headers().add(TRAILER.toString(), trailerHeaderValue.toString());
+        }
         return httpRequest;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingHeaders.java
@@ -156,7 +156,7 @@ public class ReceivingHeaders implements ListenerState {
                                        REMOTE_CLIENT_CLOSED_WHILE_READING_INBOUND_REQUEST_HEADERS);
     }
 
-    private void readTrailerHeaders (int streamId, Http2Headers headers, HttpCarbonMessage requestMessage)
+    private void readTrailerHeaders(int streamId, Http2Headers headers, HttpCarbonMessage requestMessage)
             throws Http2Exception {
         HttpVersion version = new HttpVersion(HTTP_VERSION_2_0, true);
         LastHttpContent lastHttpContent = new DefaultLastHttpContent();

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/ReceivingHeaders.java
@@ -156,13 +156,15 @@ public class ReceivingHeaders implements ListenerState {
                                        REMOTE_CLIENT_CLOSED_WHILE_READING_INBOUND_REQUEST_HEADERS);
     }
 
-    private void readTrailerHeaders(int streamId, Http2Headers headers, HttpCarbonMessage responseMessage)
+    private void readTrailerHeaders (int streamId, Http2Headers headers, HttpCarbonMessage requestMessage)
             throws Http2Exception {
         HttpVersion version = new HttpVersion(HTTP_VERSION_2_0, true);
         LastHttpContent lastHttpContent = new DefaultLastHttpContent();
         HttpHeaders trailers = lastHttpContent.trailingHeaders();
-        HttpConversionUtil.addHttp2ToHttpHeaders(streamId, headers, trailers, version, true, false);
-        responseMessage.addHttpContent(lastHttpContent);
+        HttpConversionUtil.addHttp2ToHttpHeaders(streamId, headers, trailers, version, true, true);
+        requestMessage.getTrailerHeaders().add(trailers);
+        requestMessage.addHttpContent(lastHttpContent);
+        requestMessage.setLastHttpContentArrived();
     }
 
     private HttpCarbonMessage setupHttp2CarbonMsg(Http2Headers http2Headers, int streamId) throws Http2Exception {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/http2/SendingEntityBody.java
@@ -166,11 +166,13 @@ public class SendingEntityBody implements ListenerState {
                               HttpCarbonMessage outboundResponseMsg, HttpContent httpContent, int streamId)
             throws Http2Exception {
         if (httpContent instanceof LastHttpContent) {
-            final LastHttpContent lastContent = (LastHttpContent) httpContent;
-            HttpHeaders trailers = lastContent.trailingHeaders();
             if (serverChannelInitializer.isHttpAccessLogEnabled()) {
                 logAccessInfo(outboundResponseMsg, streamId);
             }
+
+            final LastHttpContent lastContent = (LastHttpContent) httpContent;
+            HttpHeaders trailers = lastContent.trailingHeaders();
+            trailers.add(outboundResponseMsg.getTrailerHeaders());
             boolean endStream = trailers.isEmpty();
             writeData(lastContent, streamId, endStream);
             if (!trailers.isEmpty()) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -22,11 +22,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -47,11 +45,7 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
 
-import java.util.Map;
-
 import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
-import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static org.wso2.transport.http.netty.contract.Constants.DIRECTION;
 import static org.wso2.transport.http.netty.contract.Constants.DIRECTION_RESPONSE;
 import static org.wso2.transport.http.netty.contract.Constants.EXECUTOR_WORKER_POOL;

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -209,6 +209,7 @@ public class ReceivingHeaders implements SenderState {
 
         try {
             HttpConversionUtil.addHttp2ToHttpHeaders(streamId, headers, trailers, version, true, false);
+            responseMessage.getTrailerHeaders().add(trailers);
         } catch (Http2Exception e) {
             outboundMsgHolder.getResponseFuture().
                     notifyHttpListener(new Exception("Error while setting http headers", e));

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/SendingEntityBody.java
@@ -148,6 +148,7 @@ public class SendingEntityBody implements SenderState {
                 // Convert any trailing headers.
                 final LastHttpContent lastContent = (LastHttpContent) msg;
                 trailers = lastContent.trailingHeaders();
+                trailers.add(outboundMsgHolder.getRequest().getTrailerHeaders());
                 http2Trailers = HttpConversionUtil.toHttp2Headers(trailers, true);
             }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -59,6 +59,7 @@ public class HttpCarbonMessage {
     private final ServerConnectorFuture httpOutboundRespFuture = new HttpWsServerConnectorFuture();
     private final DefaultHttpResponseFuture httpOutboundRespStatusFuture = new DefaultHttpResponseFuture();
     private final Observable contentObservable = new DefaultObservable();
+    private HttpHeaders httpTrailerHeaders = new DefaultLastHttpContent().trailingHeaders();
     private IOException ioException;
     public ListenerReqRespStateManager listenerReqRespStateManager;
     private Http2MessageStateContext http2MessageStateContext;
@@ -256,6 +257,15 @@ public class HttpCarbonMessage {
      */
     public void removeHeader(String key) {
         httpMessage.headers().remove(key);
+    }
+
+    /**
+     * Returns the trailer header map of the message.
+     *
+     * @return all trailer headers.
+     */
+    public HttpHeaders getTrailerHeaders() {
+        return httpTrailerHeaders;
     }
 
     public Object getProperty(String key) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/http2forwardedextension/Http2ForwardedTestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/http2forwardedextension/Http2ForwardedTestUtil.java
@@ -19,8 +19,6 @@
 package org.wso2.transport.http.netty.http2.http2forwardedextension;
 
 import io.netty.handler.codec.http.HttpHeaders;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.wso2.transport.http.netty.contentaware.listeners.EchoMessageListener;
 import org.wso2.transport.http.netty.contract.Constants;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/http2forwardedextension/Http2ForwardedTestUtil.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/http2forwardedextension/Http2ForwardedTestUtil.java
@@ -46,8 +46,6 @@ public class Http2ForwardedTestUtil {
     protected HttpClientConnector clientConnector;
     protected ServerConnector serverConnector;
     protected SenderConfiguration senderConfiguration;
-    private static final Logger LOG = LoggerFactory.getLogger(Http2ForwardedTestUtil.class);
-
 
     public void setUp(SenderConfiguration senderConfiguration) throws InterruptedException {
         this.senderConfiguration = senderConfiguration;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2EchoServerWithTrailerHeader.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2EchoServerWithTrailerHeader.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.listeners;
+
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.contentaware.listeners.EchoMessageListener;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpCarbonResponse;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * {@code Http2ServerConnectorListener} is a HttpConnectorListener which receives messages and respond back with
+ * different types of HTTP/2 messages depending on the request.
+ */
+public class Http2EchoServerWithTrailerHeader extends EchoMessageListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Http2EchoServerWithTrailerHeader.class);
+
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private HttpHeaders expectedTrailer;
+    private boolean request;
+
+    public void setMessageType(boolean request) {
+        this.request = request;
+    }
+
+    public Http2EchoServerWithTrailerHeader setTrailer(HttpHeaders trailers) {
+        this.expectedTrailer = trailers;
+        return this;
+    }
+
+    @Override
+    public void onMessage(HttpCarbonMessage httpRequest) {
+        executor.execute(() -> {
+            try {
+                if (request) {
+                    String trailerHeaderValue = httpRequest.getHeader(HttpHeaderNames.TRAILER.toString());
+                    HttpHeaders trailingHeaders;
+                    do {
+                        HttpContent httpContent = httpRequest.getHttpContent();
+                        if (httpContent instanceof LastHttpContent) {
+                            trailingHeaders = ((LastHttpContent) httpContent).trailingHeaders();
+                            break;
+                        }
+                    }
+                    while (true);
+
+                    HttpCarbonMessage httpResponse = getHttpCarbonMessage();
+                    httpResponse.setHeader("Request-trailer", trailerHeaderValue);
+                    httpResponse.getHeaders().add(trailingHeaders);
+                    httpRequest.respond(httpResponse);
+                } else {
+                    HttpCarbonMessage httpResponse = getHttpCarbonMessage();
+                    String trailerHeaderValue = String.join(",", expectedTrailer.names());
+                    httpResponse.setHeader(HttpHeaderNames.TRAILER.toString(), trailerHeaderValue);
+                    do {
+                        HttpContent httpContent = httpRequest.getHttpContent();
+                        httpResponse.addHttpContent(httpContent);
+                        if (httpContent instanceof LastHttpContent) {
+                            ((LastHttpContent) httpContent).trailingHeaders().add(expectedTrailer);
+                            break;
+                        }
+                    }
+                    while (true);
+                    httpRequest.respond(httpResponse);
+                }
+            } catch (ServerConnectorException e) {
+                LOG.error("Error occurred during message notification: " + e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+    }
+
+    private HttpCarbonMessage getHttpCarbonMessage() {
+        HttpCarbonMessage httpResponse = new HttpCarbonResponse(
+                new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+
+        httpResponse.setHeader(HttpHeaderNames.CONNECTION.toString(),
+                               HttpHeaderValues.KEEP_ALIVE.toString());
+        httpResponse.setHeader(HttpHeaderNames.CONTENT_TYPE.toString(), Constants.TEXT_PLAIN);
+        httpResponse.setHttpStatusCode(HttpResponseStatus.OK.code());
+        return httpResponse;
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2EchoServerWithTrailerHeader.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/listeners/Http2EchoServerWithTrailerHeader.java
@@ -46,8 +46,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
- * {@code Http2ServerConnectorListener} is a HttpConnectorListener which receives messages and respond back with
- * different types of HTTP/2 messages along with trailing headers.
+ * {@code Http2EchoServerWithTrailerHeader} is a HttpConnectorListener which receives messages and respond back with
+ * trailing headers.
  *
  * @since 6.3.0
  */
@@ -86,8 +86,7 @@ public class Http2EchoServerWithTrailerHeader extends EchoMessageListener {
                             expectedTrailer = ((LastHttpContent) httpContent).trailingHeaders();
                             break;
                         }
-                    }
-                    while (true);
+                    } while (true);
                     httpResponse.setHeader("Request-trailer", trailerHeaderValue);
                     httpResponse.getHeaders().add(expectedTrailer);
                     try {
@@ -106,8 +105,7 @@ public class Http2EchoServerWithTrailerHeader extends EchoMessageListener {
                             ((LastHttpContent) httpContent).trailingHeaders().add(expectedTrailer);
                             break;
                         }
-                    }
-                    while (true);
+                    } while (true);
                     try {
                         httpRequest.respond(httpResponse);
                     } catch (ServerConnectorException e) {
@@ -120,7 +118,6 @@ public class Http2EchoServerWithTrailerHeader extends EchoMessageListener {
                     try {
                         responseFuture = httpRequest.pushPromise(promise);
                         responseFuture.sync();
-
                     } catch (ServerConnectorException | InterruptedException e) {
                         LOG.error("Error occurred while processing message: " + e.getMessage());
                     }
@@ -177,13 +174,11 @@ public class Http2EchoServerWithTrailerHeader extends EchoMessageListener {
         httpResponse.setHttpStatusCode(status.code());
         populateTrailerHeader(httpResponse);
 
-        DefaultLastHttpContent lastHttpContent;
+        DefaultLastHttpContent lastHttpContent = new DefaultLastHttpContent();
         if (response != null) {
             byte[] responseByteValues = response.getBytes(StandardCharsets.UTF_8);
             ByteBuffer responseValueByteBuffer = ByteBuffer.wrap(responseByteValues);
             lastHttpContent = new DefaultLastHttpContent(Unpooled.wrappedBuffer(responseValueByteBuffer));
-        } else {
-            lastHttpContent = new DefaultLastHttpContent();
         }
         lastHttpContent.trailingHeaders().add(expectedTrailer);
         httpResponse.addHttpContent(lastHttpContent);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ClientRequestTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ClientRequestTrailerHeaderTestCase.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -46,6 +46,7 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonRequest;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.Http2Util;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
 
@@ -70,10 +71,7 @@ public class H2ClientRequestTrailerHeaderTestCase {
 
     @BeforeClass
     public void setup() {
-        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
-        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
-        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
-        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        ListenerConfiguration listenerConfiguration = Http2Util.getH2CListenerConfiguration();
         httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
         serverConnector = httpWsConnectorFactory
                 .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
@@ -90,18 +88,11 @@ public class H2ClientRequestTrailerHeaderTestCase {
         }
 
         TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
-        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
-        senderConfiguration1.setForceHttp2(true);
+        SenderConfiguration senderConfiguration = Http2Util.getH2CSenderConfiguration();
         h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
-                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
     }
 
-    private SenderConfiguration getSenderConfiguration() {
-        SenderConfiguration senderConfiguration = new SenderConfiguration();
-        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
-        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
-        return senderConfiguration;
-    }
 
     @Test
     public void testSmallPayload() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
@@ -36,11 +35,11 @@ import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
 import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
-import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
 import org.wso2.transport.http.netty.http2.listeners.Http2EchoServerWithTrailerHeader;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.Http2Util;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
@@ -62,11 +61,7 @@ public class H2ListenerIntendedResponseTrailerHeaderTestCase {
 
     @BeforeClass
     public void setup() {
-        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
-        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
-        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
-        listenerConfiguration.setVersion(Constants.HTTP_2_0);
-        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+        ListenerConfiguration listenerConfiguration = Http2Util.getH2CListenerConfiguration();
         serverConnector = httpWsConnectorFactory
                 .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture serverConnectorFuture = serverConnector.start();
@@ -86,17 +81,9 @@ public class H2ListenerIntendedResponseTrailerHeaderTestCase {
         }
 
         TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
-        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
-        senderConfiguration1.setForceHttp2(true);
+        SenderConfiguration senderConfiguration = Http2Util.getH2CSenderConfiguration();
         h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
-                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
-    }
-
-    private SenderConfiguration getSenderConfiguration() {
-        SenderConfiguration senderConfiguration = new SenderConfiguration();
-        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
-        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
-        return senderConfiguration;
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
 import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
 import org.wso2.transport.http.netty.http2.listeners.Http2EchoServerWithTrailerHeader;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
@@ -62,6 +63,7 @@ public class H2ListenerIntendedResponseTrailerHeaderTestCase {
     @BeforeClass
     public void setup() {
         ListenerConfiguration listenerConfiguration = Http2Util.getH2CListenerConfiguration();
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
         serverConnector = httpWsConnectorFactory
                 .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
         ServerConnectorFuture serverConnectorFuture = serverConnector.start();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerIntendedResponseTrailerHeaderTestCase.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.trailer;
+
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.http2.listeners.Http2EchoServerWithTrailerHeader;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpConnectorUtil;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test case for H2 trailer headers come along with inbound intended response.
+ *
+ * @since 6.3.0
+ */
+public class H2ListenerIntendedResponseTrailerHeaderTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(H2ListenerIntendedResponseTrailerHeaderTestCase.class);
+
+    private HttpWsConnectorFactory httpWsConnectorFactory;
+    private HttpClientConnector h2ClientWithPriorKnowledge;
+    private ServerConnector serverConnector;
+
+    @BeforeClass
+    public void setup() {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+        serverConnector = httpWsConnectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+
+        Http2EchoServerWithTrailerHeader http2ConnectorListener = new Http2EchoServerWithTrailerHeader();
+        HttpHeaders trailers = new DefaultLastHttpContent().trailingHeaders();
+        trailers.add("foo", "bar");
+        trailers.add("baz", "ballerina");
+        http2ConnectorListener.setTrailer(trailers);
+        http2ConnectorListener.setMessageType(Http2EchoServerWithTrailerHeader.MessageType.RESPONSE);
+        serverConnectorFuture.setHttpConnectorListener(http2ConnectorListener);
+
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for server connector to start");
+        }
+
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
+        senderConfiguration1.setForceHttp2(true);
+        h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
+    }
+
+    private SenderConfiguration getSenderConfiguration() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        return senderConfiguration;
+    }
+
+    @Test
+    public void testNoPayload() {
+        String testValue = "";
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.GET, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    @Test
+    public void testSmallPayload() {
+        String testValue = "Test Http2 Message";
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    @Test
+    public void testLargePayload() {
+        String testValue = TestUtil.largeEntity;
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    private void verifyResult(HttpCarbonMessage httpCarbonMessage, HttpClientConnector http2ClientConnector,
+                              String expectedValue) {
+        HttpCarbonMessage response = new MessageSender(http2ClientConnector).sendMessage(httpCarbonMessage);
+        assertNotNull(response);
+        String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
+        assertEquals(result, expectedValue, "Expected response not received");
+        assertEquals(response.getHeaders().get("Trailer"), "foo,baz");
+        assertEquals(response.getTrailerHeaders().get("foo"), "bar");
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            serverConnector.stop();
+            httpWsConnectorFactory.shutdown();
+        } catch (Exception e) {
+            LOG.warn("Resource clean up is interrupted", e);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerPushResponseTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerPushResponseTrailerHeaderTestCase.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
@@ -43,6 +42,7 @@ import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpConnectorUtil;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.message.ResponseHandle;
+import org.wso2.transport.http.netty.util.Http2Util;
 import org.wso2.transport.http.netty.util.TestUtil;
 import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
 import org.wso2.transport.http.netty.util.client.http2.MessageSender;
@@ -65,10 +65,7 @@ public class H2ListenerPushResponseTrailerHeaderTestCase {
 
     @BeforeClass
     public void setup() {
-        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
-        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
-        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
-        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        ListenerConfiguration listenerConfiguration = Http2Util.getH2CListenerConfiguration();
         httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
         serverConnector = httpWsConnectorFactory
                 .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
@@ -89,17 +86,9 @@ public class H2ListenerPushResponseTrailerHeaderTestCase {
         }
 
         TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
-        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
-        senderConfiguration1.setForceHttp2(true);
+        SenderConfiguration senderConfiguration = Http2Util.getH2CSenderConfiguration();
         h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
-                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
-    }
-
-    private SenderConfiguration getSenderConfiguration() {
-        SenderConfiguration senderConfiguration = new SenderConfiguration();
-        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
-        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
-        return senderConfiguration;
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerPushResponseTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerPushResponseTrailerHeaderTestCase.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.trailer;
+
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.http2.listeners.Http2EchoServerWithTrailerHeader;
+import org.wso2.transport.http.netty.message.Http2PushPromise;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpConnectorUtil;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.message.ResponseHandle;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for H2 trailer headers come along with inbound push response.
+ *
+ * @since 6.3.0
+ */
+public class H2ListenerPushResponseTrailerHeaderTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(H2ListenerPushResponseTrailerHeaderTestCase.class);
+
+    private HttpWsConnectorFactory httpWsConnectorFactory;
+    private HttpClientConnector h2ClientWithPriorKnowledge;
+    private ServerConnector serverConnector;
+
+    @BeforeClass
+    public void setup() {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+        serverConnector = httpWsConnectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+
+        Http2EchoServerWithTrailerHeader http2ConnectorListener = new Http2EchoServerWithTrailerHeader();
+        HttpHeaders trailers = new DefaultLastHttpContent().trailingHeaders();
+        trailers.add("foo", "bar;q=0.8");
+        trailers.add("jkl", "ballerina");
+        http2ConnectorListener.setTrailer(trailers);
+        http2ConnectorListener.setMessageType(Http2EchoServerWithTrailerHeader.MessageType.PUSH_RESPONSE);
+        serverConnectorFuture.setHttpConnectorListener(http2ConnectorListener);
+
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for server connector to start");
+        }
+
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
+        senderConfiguration1.setForceHttp2(true);
+        h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
+    }
+
+    private SenderConfiguration getSenderConfiguration() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        return senderConfiguration;
+    }
+
+    @Test
+    public void testHttp2ServerPush() {
+        String expectedResource = "/main";
+        String promisedPath = "/resource1";
+
+        MessageSender msgSender = new MessageSender(h2ClientWithPriorKnowledge);
+        HttpCarbonMessage request = MessageGenerator.generateRequest(HttpMethod.POST, expectedResource);
+        // Submit a request and get the handle
+        ResponseHandle handle = msgSender.submitMessage(request);
+        assertNotNull(handle, "Response handle not found");
+
+        // Look for promise
+        assertTrue(msgSender.checkPromiseAvailability(handle), "Promise not available");
+        // Get the promise
+        Http2PushPromise promise = msgSender.getNextPromise(handle);
+        assertNotNull(promise, "Promise not available");
+        assertEquals(promise.getPath(), promisedPath, "Invalid Promise received");
+
+        // Get the promised response
+        HttpCarbonMessage promisedResponse = msgSender.getPushResponse(promise);
+        assertNotNull(promisedResponse);
+        String result = TestUtil.getStringFromInputStream(
+                new HttpMessageDataStreamer(promisedResponse).getInputStream());
+        assertTrue(result.contains(promisedPath), "Promised response not received");
+        assertEquals(promisedResponse.getHeaders().get("Trailer"), "foo,jkl");
+        assertEquals(promisedResponse.getTrailerHeaders().get("foo"), "bar;q=0.8");
+        assertEquals(promisedResponse.getTrailerHeaders().get("jkl"), "ballerina");
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            serverConnector.stop();
+            httpWsConnectorFactory.shutdown();
+        } catch (Exception e) {
+            LOG.warn("Resource clean up is interrupted", e);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailerheader/H2ListenerTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailerheader/H2ListenerTrailerHeaderTestCase.java
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.trailerheader;
+
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.http2.listeners.Http2EchoServerWithTrailerHeader;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpConnectorUtil;
+import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test case for H2 trailer headers.
+ *
+ * @since 6.2.35
+ */
+public class H2ListenerTrailerHeaderTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(H2ListenerTrailerHeaderTestCase.class);
+
+    private HttpWsConnectorFactory httpWsConnectorFactory;
+    private HttpClientConnector h2ClientWithPriorKnowledge;
+    private ServerConnector serverConnector;
+
+    @BeforeClass
+    public void setup() {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+        serverConnector = httpWsConnectorFactory
+                .createServerConnector(TestUtil.getDefaultServerBootstrapConfig(), listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+
+        Http2EchoServerWithTrailerHeader http2ConnectorListener = new Http2EchoServerWithTrailerHeader();
+        HttpHeaders trailers = new DefaultLastHttpContent().trailingHeaders();
+        trailers.add("foo","bar");
+        trailers.add("baz","ballerina");
+        http2ConnectorListener.setTrailer(trailers).setMessageType(false);
+        serverConnectorFuture.setHttpConnectorListener(http2ConnectorListener);
+
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for server connector to start");
+        }
+
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration1 = getSenderConfiguration();
+        senderConfiguration1.setForceHttp2(true);
+        h2ClientWithPriorKnowledge = httpWsConnectorFactory.createHttpClientConnector(
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration1);
+    }
+
+    private SenderConfiguration getSenderConfiguration() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        return senderConfiguration;
+    }
+
+    @Test
+    public void testNoPayload() {
+        String testValue = "";
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.GET, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    @Test
+    public void testSmallPayload() {
+        String testValue = "Test Http2 Message";
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    @Test
+    public void testLargePayload() {
+        String testValue = TestUtil.largeEntity;
+        HttpCarbonMessage httpMsg = MessageGenerator.generateRequest(HttpMethod.POST, testValue);
+        verifyResult(httpMsg, h2ClientWithPriorKnowledge, testValue);
+    }
+
+    private void verifyResult(HttpCarbonMessage httpCarbonMessage, HttpClientConnector http2ClientConnector,
+                              String expectedValue) {
+        HttpCarbonMessage response = new MessageSender(http2ClientConnector).sendMessage(httpCarbonMessage);
+        assertNotNull(response);
+        String result = TestUtil.getStringFromInputStream(new HttpMessageDataStreamer(response).getInputStream());
+        assertEquals(result, expectedValue, "Expected response not received");
+        assertEquals(response.getHeaders().get("Trailer"), "foo,baz");
+        assertEquals(response.getTrailerHeaders().get("foo"), "bar");
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            serverConnector.stop();
+            httpWsConnectorFactory.shutdown();
+        } catch (Exception e) {
+            LOG.warn("Resource clean up is interrupted", e);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailerheader/H2ListenerTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailerheader/H2ListenerTrailerHeaderTestCase.java
@@ -73,8 +73,8 @@ public class H2ListenerTrailerHeaderTestCase {
 
         Http2EchoServerWithTrailerHeader http2ConnectorListener = new Http2EchoServerWithTrailerHeader();
         HttpHeaders trailers = new DefaultLastHttpContent().trailingHeaders();
-        trailers.add("foo","bar");
-        trailers.add("baz","ballerina");
+        trailers.add("foo", "bar");
+        trailers.add("baz", "ballerina");
         http2ConnectorListener.setTrailer(trailers).setMessageType(false);
         serverConnectorFuture.setHttpConnectorListener(http2ConnectorListener);
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/Http2Util.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/util/Http2Util.java
@@ -152,4 +152,20 @@ public class Http2Util {
         }
         return http2Headers;
     }
+
+    public static ListenerConfiguration getH2CListenerConfiguration() {
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.HTTP_SERVER_PORT);
+        listenerConfiguration.setScheme(Constants.HTTP_SCHEME);
+        listenerConfiguration.setVersion(Constants.HTTP_2_0);
+        return listenerConfiguration;
+    }
+
+    public static SenderConfiguration getH2CSenderConfiguration() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.setScheme(Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        senderConfiguration.setForceHttp2(true);
+        return senderConfiguration;
+    }
 }

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -137,6 +137,7 @@
             <class name="org.wso2.transport.http.netty.http2.expect100continue.Expect100ContinueClientTestCase"/>
             <class name="org.wso2.transport.http.netty.http2.expect100continue.ClientContinue100TimeoutTestcase"/>
             <class name="org.wso2.transport.http.netty.http2.expect100continue.ClientContinueResponseTimeout"/>
+            <class name="org.wso2.transport.http.netty.http2.trailerheader.H2ListenerTrailerHeaderTestCase"/>
         </classes>
     </test>
     <test name="Transport Security Tests" parallel="false">

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -137,7 +137,9 @@
             <class name="org.wso2.transport.http.netty.http2.expect100continue.Expect100ContinueClientTestCase"/>
             <class name="org.wso2.transport.http.netty.http2.expect100continue.ClientContinue100TimeoutTestcase"/>
             <class name="org.wso2.transport.http.netty.http2.expect100continue.ClientContinueResponseTimeout"/>
-            <class name="org.wso2.transport.http.netty.http2.trailerheader.H2ListenerTrailerHeaderTestCase"/>
+            <class name="org.wso2.transport.http.netty.http2.trailer.H2ClientRequestTrailerHeaderTestCase"/>
+            <class name="org.wso2.transport.http.netty.http2.trailer.H2ListenerIntendedResponseTrailerHeaderTestCase"/>
+            <class name="org.wso2.transport.http.netty.http2.trailer.H2ListenerPushResponseTrailerHeaderTestCase"/>
         </classes>
     </test>
     <test name="Transport Security Tests" parallel="false">

--- a/features/org.wso2.transport.http.netty.feature/pom.xml
+++ b/features/org.wso2.transport.http.netty.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.transport.http</groupId>
         <artifactId>http-parent</artifactId>
-        <version>6.2.35-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.transport.http.netty.statistics.feature/pom.xml
+++ b/features/org.wso2.transport.http.netty.statistics.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.transport.http</groupId>
         <artifactId>http-parent</artifactId>
-        <version>6.2.35-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
     <groupId>org.wso2.transport.http</groupId>
     <artifactId>http-parent</artifactId>
-    <version>6.2.35-SNAPSHOT</version>
+    <version>6.3.0-SNAPSHOT</version>
     <name>WSO2 Carbon Transport Parent</name>
 
     <modules>


### PR DESCRIPTION
## Purpose
> Add API to hold trailing headers in the carbon message.
> Implement user provided trailing header handling process.
> Fix payload hanging issue due to trailing header set
> Add Trailer header internally after http2-to-http header conversion

## Goals
> Provide API to process trailing headers(https://tools.ietf.org/html/rfc7540)

## Automation tests
 - Unit tests 
   > Added
 - Integration tests
   > N/A

## Samples
```
HEADERS
- END_STREAM
+ END_HEADERS
     :status = 200
content-length = 123
content-type = image/jpeg
**trailer = Foo**

DATA
- END_STREAM
{binary data}

HEADERS
+ END_STREAM
+ END_HEADERS
**foo = bar**
```

## Related PRs
> List any other related PRs