### PR TITLE
Upgrade Netty version to 4.1.45

### DIFF
--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/client/WebSocketClientFunctionalityTestCase.java
@@ -357,10 +357,9 @@ public class WebSocketClientFunctionalityTestCase {
         sendTextMessageAndReceiveResponse("close-without-frame", connectorListener, webSocketConnection);
         WebSocketCloseMessage closeMessage = connectorListener.getCloseMessage();
 
-        Assert.assertEquals(closeMessage.getCloseCode(), 1006);
-        Assert.assertNull(closeMessage.getCloseReason());
         Assert.assertTrue(connectorListener.isClosed());
-        Assert.assertFalse(closeMessage.getWebSocketConnection().isOpen());
+        Assert.assertEquals(closeMessage.getCloseCode(), 1000);
+        Assert.assertEquals(closeMessage.getCloseReason(), "Bye");
     }
 
     @Test(description = "Test connection termination using WebSocketConnection without sending a close frame.")

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.39.Final</netty.version>
+        <netty.version>4.1.45.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>


### PR DESCRIPTION
## Purpose
> $Subject
> Fix websocket test failure (Recently Netty has refactored websocket error handling via netty/netty#9116)

