### PR TITLE
Clear trailers from LastHttpContent after consuming

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/ReceivingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/ReceivingEntityBody.java
@@ -36,6 +36,7 @@ import static org.wso2.transport.http.netty.contractimpl.common.Util.isKeepAlive
 import static org.wso2.transport.http.netty.contractimpl.common.Util.safelyRemoveHandlers;
 import static org.wso2.transport.http.netty.contractimpl.common.states.StateUtil.ILLEGAL_STATE_ERROR;
 import static org.wso2.transport.http.netty.contractimpl.common.states.StateUtil.handleIncompleteInboundMessage;
+import static org.wso2.transport.http.netty.contractimpl.common.states.StateUtil.setInboundTrailersToNewMessage;
 
 /**
  * State between start and end of inbound response entity body read.
@@ -73,7 +74,7 @@ public class ReceivingEntityBody implements SenderState {
         inboundResponseMsg.addHttpContent(httpContent);
 
         if (httpContent instanceof LastHttpContent) {
-            inboundResponseMsg.getTrailerHeaders().add(((LastHttpContent) httpContent).trailingHeaders());
+            setInboundTrailersToNewMessage(((LastHttpContent) httpContent).trailingHeaders(), inboundResponseMsg);
             inboundResponseMsg.setLastHttpContentArrived();
             targetHandler.resetInboundMsg();
             safelyRemoveHandlers(targetHandler.getTargetChannel().getChannel().pipeline(), IDLE_STATE_HANDLER);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.exceptions.EndpointTimeOutException;
 import org.wso2.transport.http.netty.contractimpl.common.states.Http2MessageStateContext;
+import org.wso2.transport.http.netty.contractimpl.common.states.StateUtil;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.Http2ClientChannel;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.Http2TargetHandler;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.OutboundMsgHolder;
@@ -210,7 +211,7 @@ public class ReceivingHeaders implements SenderState {
 
         try {
             HttpConversionUtil.addHttp2ToHttpHeaders(streamId, headers, trailers, version, true, false);
-            responseMessage.getTrailerHeaders().add(trailers);
+            StateUtil.setInboundTrailersToNewMessage(trailers, responseMessage);
         } catch (Http2Exception e) {
             outboundMsgHolder.getResponseFuture().
                     notifyHttpListener(new Exception("Error while setting http headers", e));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/trailer/ClientReadTrailerHeaderTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/trailer/ClientReadTrailerHeaderTestCase.java
@@ -21,9 +21,11 @@ package org.wso2.transport.http.netty.trailer;
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -37,6 +39,7 @@ import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.common.states.StateUtil;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpMessageDataStreamer;
 import org.wso2.transport.http.netty.util.DefaultHttpConnectorListener;
@@ -110,6 +113,23 @@ public class ClientReadTrailerHeaderTestCase extends TrailerHeaderTestTemplate {
         assertEquals(response.getTrailerHeaders().get("foo"), "xyz");
         assertEquals(response.getTrailerHeaders().get("bar"), "ballerina");
         assertEquals(response.getTrailerHeaders().get("Max-forwards"), "five");
+    }
+
+    @Test(description = "Test populating inbound trailers to the message")
+    public void testPopulateTrailersToMessage() {
+        DefaultLastHttpContent lastHttpContent = new DefaultLastHttpContent();
+        HttpHeaders trailers = lastHttpContent.trailingHeaders();
+        trailers.add("foo", "xyz");
+        trailers.add("bar", "ballerina");
+        trailers.add("Max-forwards", "five");
+        HttpCarbonMessage outboundResponseMsg = new HttpCarbonMessage(
+                new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        StateUtil.setInboundTrailersToNewMessage(trailers, outboundResponseMsg);
+
+        assertEquals(lastHttpContent.trailingHeaders().size(), 0);
+        assertEquals(outboundResponseMsg.getTrailerHeaders().get("foo"), "xyz");
+        assertEquals(outboundResponseMsg.getTrailerHeaders().get("bar"), "ballerina");
+        assertEquals(outboundResponseMsg.getTrailerHeaders().get("Max-forwards"), "five");
     }
 
     @AfterClass


### PR DESCRIPTION
## Purpose
> Prevent having redundant trailers during passthrough case
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/22190

## Approach
> Clear trailers in the **LastHttpContent** once consuming it from the HttpCarbonMessage. Otherwise same headers will get populated when responding

## Automation tests
 - Unit tests 
   > Added
 - Integration tests
   > N/A