### PR TITLE
Add support for sending HSTS headers for HTTPS

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -129,6 +129,7 @@ public final class Constants {
     public static final String X_FORWARDED_BY = "x-forwarded-by";
     public static final String X_FORWARDED_HOST = "x-forwarded-host";
     public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
+    public static final String HTTP_STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
 
     public static final String HEADER_VAL_100_CONTINUE = "100-continue";
     public static final String NO_ENTITY_BODY = "NO_ENTITY_BODY";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
@@ -27,6 +27,9 @@ import java.util.List;
 public class ListenerConfiguration extends SslConfiguration {
 
     public static final String DEFAULT_KEY = "default";
+    public static final String DEFAULT_SCHEME = "https";
+    public static final String DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE = "max-age=15768000;" +
+            " includeSubDomains";
 
     /**
      * @deprecated
@@ -35,7 +38,8 @@ public class ListenerConfiguration extends SslConfiguration {
     @Deprecated
     public static ListenerConfiguration getDefault() {
         ListenerConfiguration defaultConfig;
-        defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080);
+        defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080, DEFAULT_SCHEME,
+                DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         return defaultConfig;
     }
     private String id = DEFAULT_KEY;
@@ -55,6 +59,10 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean pipeliningEnabled;
     private boolean webSocketCompressionEnabled;
     private long pipeliningLimit;
+    private String strictTransportSecurityHeader;
+    private String keyStoreFile;
+    private String keyStorePass;
+    private String certPass;
 
     public ListenerConfiguration() {
     }
@@ -63,6 +71,14 @@ public class ListenerConfiguration extends SslConfiguration {
         this.id = id;
         this.host = host;
         this.port = port;
+    }
+
+    public ListenerConfiguration(String id, String host, int port, String scheme, String hstsHeader) {
+        this.id = id;
+        this.host = host;
+        this.port = port;
+        super.setScheme(scheme);
+        this.strictTransportSecurityHeader = hstsHeader;
     }
 
     public String getHost() {
@@ -200,5 +216,31 @@ public class ListenerConfiguration extends SslConfiguration {
 
     public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
         this.webSocketCompressionEnabled = webSocketCompressionEnabled;
+    }
+
+    public String getStrictTransportSecurityHeader() {
+        return strictTransportSecurityHeader;
+    }
+
+    public void setStrictTransportSecurityHeader(String strictTransportSecurityHeader) {
+        this.strictTransportSecurityHeader = strictTransportSecurityHeader;
+    }
+
+    public void setKeyStoreFile(String keyStoreFile) {
+        this.keyStoreFile = keyStoreFile;
+        super.setKeyStoreFile(this.keyStoreFile);
+    }
+
+    public void setKeyStorePass(String keyStorePass) {
+        this.keyStorePass = keyStorePass;
+        super.setKeyStorePass(this.keyStorePass);
+    }
+
+    public void setCertPass(String certPass) {
+        this.certPass = certPass;
+    }
+
+    public String getCertPass() {
+        return certPass;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
@@ -31,17 +31,6 @@ public class ListenerConfiguration extends SslConfiguration {
     public static final String DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE = "max-age=15768000;" +
             " includeSubDomains";
 
-    /**
-     * @deprecated
-     * @return the default listener configuration.
-     */
-    @Deprecated
-    public static ListenerConfiguration getDefault() {
-        ListenerConfiguration defaultConfig;
-        defaultConfig = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080, DEFAULT_SCHEME,
-                DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
-        return defaultConfig;
-    }
     private String id = DEFAULT_KEY;
     private String host = "0.0.0.0";
     private int port = 9090;
@@ -59,10 +48,6 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean pipeliningEnabled;
     private boolean webSocketCompressionEnabled;
     private long pipeliningLimit;
-    private String strictTransportSecurityHeader;
-    private String keyStoreFile;
-    private String keyStorePass;
-    private String certPass;
 
     public ListenerConfiguration() {
     }
@@ -78,7 +63,7 @@ public class ListenerConfiguration extends SslConfiguration {
         this.host = host;
         this.port = port;
         super.setScheme(scheme);
-        this.strictTransportSecurityHeader = hstsHeader;
+        super.setStrictTransportSecurityHeader(hstsHeader);
     }
 
     public String getHost() {
@@ -216,31 +201,5 @@ public class ListenerConfiguration extends SslConfiguration {
 
     public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
         this.webSocketCompressionEnabled = webSocketCompressionEnabled;
-    }
-
-    public String getStrictTransportSecurityHeader() {
-        return strictTransportSecurityHeader;
-    }
-
-    public void setStrictTransportSecurityHeader(String strictTransportSecurityHeader) {
-        this.strictTransportSecurityHeader = strictTransportSecurityHeader;
-    }
-
-    public void setKeyStoreFile(String keyStoreFile) {
-        this.keyStoreFile = keyStoreFile;
-        super.setKeyStoreFile(this.keyStoreFile);
-    }
-
-    public void setKeyStorePass(String keyStorePass) {
-        this.keyStorePass = keyStorePass;
-        super.setKeyStorePass(this.keyStorePass);
-    }
-
-    public void setCertPass(String certPass) {
-        this.certPass = certPass;
-    }
-
-    public String getCertPass() {
-        return certPass;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
@@ -47,6 +47,8 @@ public class SenderConfiguration extends SslConfiguration {
     private String httpVersion = "1.1";
     private ProxyServerConfiguration proxyServerConfiguration;
     private PoolConfiguration poolConfiguration;
+    private String trustStoreFile;
+    private String trustStorePass;
 
     private ForwardedExtensionConfig forwardedExtensionConfig = ForwardedExtensionConfig.DISABLE;
 
@@ -142,5 +144,25 @@ public class SenderConfiguration extends SslConfiguration {
 
     public void setForwardedExtensionConfig(ForwardedExtensionConfig forwardedExtensionEnabled) {
         this.forwardedExtensionConfig = forwardedExtensionEnabled;
+    }
+
+    public String getTrustStoreFile() {
+        return trustStoreFile;
+    }
+
+    @Override
+    public void setTrustStoreFile(String trustStoreFile) {
+        this.trustStoreFile = trustStoreFile;
+        super.setTrustStoreFile(trustStoreFile);
+    }
+
+    public String getTrustStorePass() {
+        return trustStorePass;
+    }
+
+    @Override
+    public void setTrustStorePass(String trustStorePass) {
+        this.trustStorePass = trustStorePass;
+        super.setTrustStorePass(this.trustStorePass);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
@@ -47,8 +47,6 @@ public class SenderConfiguration extends SslConfiguration {
     private String httpVersion = "1.1";
     private ProxyServerConfiguration proxyServerConfiguration;
     private PoolConfiguration poolConfiguration;
-    private String trustStoreFile;
-    private String trustStorePass;
 
     private ForwardedExtensionConfig forwardedExtensionConfig = ForwardedExtensionConfig.DISABLE;
 
@@ -144,25 +142,5 @@ public class SenderConfiguration extends SslConfiguration {
 
     public void setForwardedExtensionConfig(ForwardedExtensionConfig forwardedExtensionEnabled) {
         this.forwardedExtensionConfig = forwardedExtensionEnabled;
-    }
-
-    public String getTrustStoreFile() {
-        return trustStoreFile;
-    }
-
-    @Override
-    public void setTrustStoreFile(String trustStoreFile) {
-        this.trustStoreFile = trustStoreFile;
-        super.setTrustStoreFile(trustStoreFile);
-    }
-
-    public String getTrustStorePass() {
-        return trustStorePass;
-    }
-
-    @Override
-    public void setTrustStorePass(String trustStorePass) {
-        this.trustStorePass = trustStorePass;
-        super.setTrustStorePass(this.trustStorePass);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -49,6 +49,12 @@ public class SslConfiguration {
     private List<Parameter> parameters = new ArrayList<>();
     private SSLConfig sslConfig = new SSLConfig();
     private static final Logger LOG = LoggerFactory.getLogger(SslConfiguration.class);
+    private String keyStoreFile;
+    private String keyStorePass;
+    private String certPass;
+    private String strictTransportSecurityHeader;
+    private String trustStoreFile;
+    private String trustStorePass;
 
     public void setKeyStoreFile(String keyStoreFile) {
         sslConfig.setKeyStore(new File(Util.substituteVariables(keyStoreFile)));
@@ -284,5 +290,29 @@ public class SslConfiguration {
             }
         }
         return sslConfig;
+    }
+
+    public String getStrictTransportSecurityHeader() {
+        return strictTransportSecurityHeader;
+    }
+
+    public void setStrictTransportSecurityHeader(String strictTransportSecurityHeader) {
+        this.strictTransportSecurityHeader = strictTransportSecurityHeader;
+    }
+
+    public void setCertPass(String certPass) {
+        this.certPass = certPass;
+    }
+
+    public String getCertPass() {
+        return certPass;
+    }
+
+    public String getTrustStoreFile() {
+        return trustStoreFile;
+    }
+
+    public String getTrustStorePass() {
+        return trustStorePass;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/TransportsConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/TransportsConfiguration.java
@@ -28,6 +28,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
+
 /**
  * JAXB representation of the Netty transport configuration.
  */
@@ -42,7 +46,8 @@ public class TransportsConfiguration {
     @Deprecated
     public static TransportsConfiguration getDefault() {
         TransportsConfiguration defaultConfig = new TransportsConfiguration();
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         HashSet<ListenerConfiguration> listenerConfigurations = new HashSet<>();
         listenerConfigurations.add(listenerConfiguration);
         defaultConfig.setListenerConfigurations(listenerConfigurations);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -135,6 +135,8 @@ public class Util {
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+    private static final Set<ListenerConfiguration>
+            listenerConfigurations = ConfigurationBuilder.getInstance().getConfiguration().getListenerConfigurations();
 
     private static String getStringValue(HttpCarbonMessage msg, String key, String defaultValue) {
         String value = (String) msg.getProperty(key);
@@ -200,9 +202,6 @@ public class Util {
             outboundResponseMsg.setHeader(HttpHeaderNames.DATE.toString(),
                                           ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME));
         }
-
-        Set<ListenerConfiguration> listenerConfigurations =
-                ConfigurationBuilder.getInstance().getConfiguration().getListenerConfigurations();
 
         HttpHeaders headers = outboundResponseMsg.getHeaders();
 

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/certificatevalidation/Utils.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/certificatevalidation/Utils.java
@@ -96,6 +96,9 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 import static org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.Constants.BOUNCY_CASTLE_PROVIDER;
 
 /**
@@ -335,7 +338,8 @@ class Utils {
         List<Parameter> serverParams = new ArrayList<>(1);
         Parameter paramServerCiphers = new Parameter("ciphers", "TLS_RSA_WITH_AES_128_CBC_SHA");
         serverParams.add(paramServerCiphers);
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setParameters(serverParams);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(keyStore));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/hostnameverfication/HostnameVerificationTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/hostnameverfication/HostnameVerificationTest.java
@@ -48,6 +48,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * A test for hostname verification. Contains two test scenarios to test certificates with CN included and not included.
@@ -142,7 +145,8 @@ public class HostnameVerificationTest {
     }
 
     private ListenerConfiguration setListenerConfiguration(int port, String keyStore, String keyStorePassword) {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(port);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(keyStore));
         listenerConfiguration.setKeyStorePass(keyStorePassword);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -51,6 +51,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Tests for different cipher suites provided by client and server.
@@ -144,7 +147,8 @@ public class CipherSuitesTest {
     }
 
     private ListenerConfiguration getListenerConfiguration(int serverPort, List<Parameter> serverParams) {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(serverPort);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuiteswithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuiteswithCertsTest.java
@@ -51,6 +51,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Tests for different cipher suites provided by client and server with certs and keys.
@@ -141,7 +144,8 @@ public class CipherSuiteswithCertsTest {
     }
 
     private ListenerConfiguration getListenerConfiguration(int serverPort, List<Parameter> serverParams) {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(serverPort);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -37,6 +37,9 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.util.HashMap;
 
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Tests for mutual ssl
@@ -67,7 +70,8 @@ public class MutualSSLTestCase {
     }
 
     private ListenerConfiguration getListenerConfiguration() {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
@@ -37,6 +37,9 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.util.HashMap;
 
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * This test contains 2 way ssl handshake with certs and Keys.
@@ -64,7 +67,8 @@ public class MutualSSLwithCertsTest {
     }
 
     private ListenerConfiguration getListenerConfiguration() {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         listenerConfiguration.setServerKeyFile(TestUtil.getAbsolutePath(TestUtil.KEY_FILE));
         listenerConfiguration.setServerCertificates(TestUtil.getAbsolutePath(TestUtil.CERT_FILE));

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -51,6 +51,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Tests for SSL protocols.
@@ -109,7 +112,8 @@ public class SSLProtocolsTest {
     }
 
     private ListenerConfiguration getListenerConfiguration(int serverPort, List<Parameter> severParams) {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(serverPort);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsWithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsWithCertsTest.java
@@ -51,6 +51,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Tests for SSL protocols with certs and Keys.
@@ -106,7 +109,8 @@ public class SSLProtocolsWithCertsTest {
     }
 
     private ListenerConfiguration getListenerConfiguration(int serverPort, List<Parameter> severParams) {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(serverPort);
         String verifyClient = "require";
         listenerConfiguration.setVerifyClient(verifyClient);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpsTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassThroughHttpsTestCase.java
@@ -42,6 +42,9 @@ import java.net.URI;
 import java.util.Properties;
 
 import static org.testng.AssertJUnit.assertEquals;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * A test case for https pass-through transport.
@@ -59,7 +62,8 @@ public class PassThroughHttpsTestCase {
     public void setUp() {
         httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
 
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));
         listenerConfiguration.setKeyStorePass(TestUtil.KEY_STORE_PASSWORD);
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -34,6 +34,9 @@ import org.wso2.transport.http.netty.util.TestUtil;
 import java.util.HashMap;
 
 import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * Test case for testing PKCS12 keystore and truststore.
@@ -63,7 +66,8 @@ public class PKCSTest {
     }
 
     private ListenerConfiguration getListenerConfiguration() {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080,
+                DEFAULT_SCHEME, DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT3);
         //set PKCS12 keystore to ballerina server.
         String keyStoreFile = "/simple-test-config/wso2carbon.p12";

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/HttpProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/HttpProxyServerTestCase.java
@@ -44,6 +44,7 @@ import static org.wso2.transport.http.netty.contract.Constants.HTTP_POST_METHOD;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_SCHEME;
 import static org.wso2.transport.http.netty.contract.Constants.IS_PROXY_ENABLED;
 import static org.wso2.transport.http.netty.contract.Constants.PROTOCOL;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
 
 /**
  * A test for connecting to a proxy server over HTTP.
@@ -70,7 +71,7 @@ public class HttpProxyServerTestCase {
     }
 
     private ListenerConfiguration getListenerConfiguration() {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT1);
         return listenerConfiguration;
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/HttpsProxyServerTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/proxyserver/HttpsProxyServerTestCase.java
@@ -40,6 +40,9 @@ import static org.wso2.transport.http.netty.contract.Constants.HTTPS_SCHEME;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_HOST;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_PORT;
 import static org.wso2.transport.http.netty.contract.Constants.PROTOCOL;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_KEY;
+import static org.wso2.transport.http.netty.contract.config.ListenerConfiguration.DEFAULT_SCHEME;
 
 /**
  * A test for connecting to a proxy server over HTTPS.
@@ -56,7 +59,9 @@ public class HttpsProxyServerTestCase {
     }
 
     private ListenerConfiguration getListenerConfiguration() {
-        ListenerConfiguration listenerConfiguration = ListenerConfiguration.getDefault();
+        ListenerConfiguration listenerConfiguration =
+                new ListenerConfiguration(DEFAULT_KEY, "0.0.0.0", 8080, DEFAULT_SCHEME,
+                        DEFAULT_HTTP_STRICT_TRANSPORT_SECURITY_HEADER_VALUE);
         listenerConfiguration.setPort(TestUtil.SERVER_PORT1);
         listenerConfiguration.setScheme(HTTPS_SCHEME);
         listenerConfiguration.setKeyStoreFile(TestUtil.getAbsolutePath(TestUtil.KEY_STORE_FILE_PATH));


### PR DESCRIPTION
## Purpose
> Implementing HTTP Strict Transport Security in transport-http

## Goals
> Making HTTP Strict Transport Security configurable headers in carbon transports.

## Approach
> Adding the header values configured in netty-transports.yml into the HTTP response.
Users have to configure HSTS header values in netty-transports.yaml under listener configurations as follows.

id: "msf4j-https"
....
scheme: https
....
strictTransportSecurityHeader:

The headers are added into the response only If the configuration values are not null and the listener
scheme is https. Configuration values in the netty-transport.yaml can be left blank if the headers are not
needed.


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes