### PR TITLE
Fix the issue with HTTP2 content-encoding

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
@@ -184,9 +184,9 @@ public class Http2OutboundRespListener implements HttpConnectorListener {
     }
 
     /***
-     * This function is to determine one encoding scheme from the request's `accept-encoding` header. This function is
-     * similar to Netty's `determineWrapper()` function in the `HttpContentCompressor` class which is used to do the
-     * same when doing the HTTP1.1 compression.
+     * This function is to determine one encoding scheme from the request's `accept-encoding` header. The logic to
+     * determine the scheme is similar to the logic used in Netty's `determineWrapper()` function in the
+     * `HttpContentCompressor` class which is used to do the same, when doing the HTTP1.1 compression.
      *
      * @param acceptEncoding `accept-encoding` header value
      * @return the chosen encoding scheme

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
@@ -51,6 +51,8 @@ import org.wso2.transport.http.netty.message.ServerRemoteFlowControlListener;
 import java.util.Calendar;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.wso2.transport.http.netty.contract.Constants.ENCODING_DEFLATE;
+import static org.wso2.transport.http.netty.contract.Constants.ENCODING_GZIP;
 import static org.wso2.transport.http.netty.contract.Constants.PROMISED_STREAM_REJECTED_ERROR;
 import static org.wso2.transport.http.netty.contractimpl.common.states.Http2StateUtil.isValidStreamId;
 
@@ -171,9 +173,63 @@ public class Http2OutboundRespListener implements HttpConnectorListener {
         if (contentEncoding == null) {
             String acceptEncoding = inboundRequestMsg.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString());
             if (acceptEncoding != null) {
-                outboundResponseMsg.setHeader(HttpHeaderNames.CONTENT_ENCODING.toString(), acceptEncoding);
+                // To set the `content-encoding` header, first we need to select a scheme based on the `q` value and
+                // server supporting encoding schemes when we have multiple values in the `accept-encoding` header.
+                String targetContentEncoding = determineScheme(acceptEncoding);
+                if (targetContentEncoding != null) {
+                    outboundResponseMsg.setHeader(HttpHeaderNames.CONTENT_ENCODING.toString(), targetContentEncoding);
+                }
             }
         }
+    }
+
+    /***
+     * This function is to determine one encoding scheme from the request's `accept-encoding` header. This function is
+     * similar to Netty's `determineWrapper()` function in the `HttpContentCompressor` class which is used to do the
+     * same when doing the HTTP1.1 compression.
+     *
+     * @param acceptEncoding `accept-encoding` header value
+     * @return the chosen encoding scheme
+     */
+    private String determineScheme(String acceptEncoding) {
+        float starQ = -1.0f;
+        float gzipQ = -1.0f;
+        float deflateQ = -1.0f;
+        for (String encoding : acceptEncoding.split(",")) {
+            float qValue = 1.0f;
+            int equalsPos = encoding.indexOf('=');
+            if (equalsPos != -1) {
+                try {
+                    qValue = Float.parseFloat(encoding.substring(equalsPos + 1));
+                } catch (NumberFormatException e) {
+                    // Ignore encoding
+                    qValue = 0.0f;
+                }
+            }
+            if (encoding.contains("*")) {
+                starQ = qValue;
+            } else if (encoding.contains(ENCODING_GZIP) && qValue > gzipQ) {
+                gzipQ = qValue;
+            } else if (encoding.contains(ENCODING_DEFLATE) && qValue > deflateQ) {
+                deflateQ = qValue;
+            }
+        }
+        if (gzipQ > 0.0f || deflateQ > 0.0f) {
+            if (gzipQ >= deflateQ) {
+                return ENCODING_GZIP;
+            } else {
+                return ENCODING_DEFLATE;
+            }
+        }
+        if (starQ > 0.0f) {
+            if (gzipQ == -1.0f) {
+                return ENCODING_GZIP;
+            }
+            if (deflateQ == -1.0f) {
+                return ENCODING_DEFLATE;
+            }
+        }
+        return null;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/Http2OutboundRespListener.java
@@ -173,8 +173,6 @@ public class Http2OutboundRespListener implements HttpConnectorListener {
         if (contentEncoding == null) {
             String acceptEncoding = inboundRequestMsg.getHeader(HttpHeaderNames.ACCEPT_ENCODING.toString());
             if (acceptEncoding != null) {
-                // To set the `content-encoding` header, first we need to select a scheme based on the `q` value and
-                // server supporting encoding schemes when we have multiple values in the `accept-encoding` header.
                 String targetContentEncoding = determineScheme(acceptEncoding);
                 if (targetContentEncoding != null) {
                     outboundResponseMsg.setHeader(HttpHeaderNames.CONTENT_ENCODING.toString(), targetContentEncoding);
@@ -212,6 +210,8 @@ public class Http2OutboundRespListener implements HttpConnectorListener {
                 gzipQ = qValue;
             } else if (encoding.contains(ENCODING_DEFLATE) && qValue > deflateQ) {
                 deflateQ = qValue;
+            } else {
+                LOG.debug("Server does not support the requested encoding scheme/s");
             }
         }
         if (gzipQ > 0.0f || deflateQ > 0.0f) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/compression/ResponseBodyCompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/compression/ResponseBodyCompressionTestCase.java
@@ -86,7 +86,7 @@ public class ResponseBodyCompressionTestCase {
 
         streamId = streamId + 2;
         responseHandler = h2ClientWithoutDecompressor.sendPostRequest(PAYLOAD, streamId, "deflate;q=1.0, gzip;q=0.8");
-        assertCompressedResults("deflate;q=1.0, gzip;q=0.8", responseHandler.getFullResponse(streamId),
+        assertCompressedResults("deflate", responseHandler.getFullResponse(streamId),
                                 responseHandler.getResponsePayload(streamId));
 
         streamId = streamId + 2;

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/compression/ResponseBodyCompressionTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/compression/ResponseBodyCompressionTestCase.java
@@ -94,6 +94,21 @@ public class ResponseBodyCompressionTestCase {
         assertPlainResults(responseHandler.getFullResponse(streamId),
                            responseHandler.getResponsePayload(streamId));
 
+        streamId = streamId + 2;
+        responseHandler = h2ClientWithoutDecompressor
+                .sendPostRequest(PAYLOAD, streamId, HttpHeaderValues.IDENTITY.toString());
+        assertPlainResults(responseHandler.getFullResponse(streamId),
+                responseHandler.getResponsePayload(streamId));
+
+        streamId = streamId + 2;
+        responseHandler = h2ClientWithoutDecompressor.sendPostRequest(PAYLOAD, streamId, "sdch, br");
+        assertPlainResults(responseHandler.getFullResponse(streamId),
+                responseHandler.getResponsePayload(streamId));
+
+        streamId = streamId + 2;
+        responseHandler = h2ClientWithoutDecompressor.sendPostRequest(PAYLOAD, streamId, "sdch, br, deflate");
+        assertCompressedResults("deflate", responseHandler.getFullResponse(streamId),
+                responseHandler.getResponsePayload(streamId));
     }
 
     private void assertCompressedResults(String expectedEncoding, FullHttpResponse response, String responsePayload) {


### PR DESCRIPTION
## Purpose
Fix the https://github.com/ballerina-platform/ballerina-lang/issues/24977

## Goals
Fix the issue of HTTP2 server not encoding when the request is sent with multiple values in `accept-encoding` header.

## Approach
In HTTP1.1, this is done in [HttpContentCompressor](https://github.com/netty/netty/blob/0992718f87bf0f0c23660489b1f7e697a24f2a4b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java) by checking the `accept-encoding` header in this [determineWrapper](https://github.com/netty/netty/blob/0992718f87bf0f0c23660489b1f7e697a24f2a4b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java#L175) function. Same logic is applied in this PR, before setting the `content-encoding` header in the response. 

## Automation tests
 - Integration tests
   > An integration test was already there and fixed the test.
