### PR TITLE
Upgrade orbit/snakeyaml version to 1.26.0.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,8 +329,8 @@
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
 
         <carbon.p2.plugin.version>2.0.1</carbon.p2.plugin.version>
-        <org.snakeyaml.version>1.16.0.wso2v1</org.snakeyaml.version>
-        <org.snakeyaml.package.import.version.range>[1.16.0, 2.0.0)</org.snakeyaml.package.import.version.range>
+        <org.snakeyaml.version>1.26.0.wso2v1</org.snakeyaml.version>
+        <org.snakeyaml.package.import.version.range>[1.26.0, 2.0.0)</org.snakeyaml.package.import.version.range>
 
         <!-- Package exports -->
         <netty.transport.package.export.version>${project.version}</netty.transport.package.export.version>


### PR DESCRIPTION
## Purpose
> $subject

```
During the OB/MGW analysis, it was found that,

snakeyaml 1.16 is used in ballerina and bundled into the platform.zip in mgw pack.

Both the dependency versions impose the following threat.

CVE-2017-18640:
org.yaml_snakeyaml- 1.16/1.23
CVE-2017-18640
High
The Alias feature in SnakeYAML 1.18 allows entity expansion during a load operation, a related issue to CVE-2003-1564.

Vulnerable Package: org.yaml_snakeyaml
Current Version: 1.16/1.23
Fixed in 1.26
High
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS v3 base score: 7.5)
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-18640
```