### PR TITLE
Make the inbound response size validation configurable

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -253,6 +253,9 @@ public final class Constants {
     public static final String HTTP_ACCESS_LOG_HANDLER = "http-access-logger";
     public static final String HTTP_EXCEPTION_HANDLER = "HttpExceptionHandler";
     public static final String HTTP2_EXCEPTION_HANDLER = "Http2ExceptionHandler";
+    public static final String URI_HEADER_LENGTH_VALIDATION_HANDLER = "uriAndHeaderLengthValidator";
+    public static final String STATUS_LINE_HEADER_LENGTH_VALIDATION_HANDLER = "statusLineAndHeaderLengthValidator";
+    public static final String MAX_ENTITY_BODY_VALIDATION_HANDLER = "maxEntityBodyValidator";
 
     public static final AttributeKey<Integer> REDIRECT_COUNT = AttributeKey.valueOf("REDIRECT_COUNT");
     public static final AttributeKey<String> RESOLVED_REQUESTED_URI_ATTR = AttributeKey

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/InboundMsgSizeValidationConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/InboundMsgSizeValidationConfig.java
@@ -19,23 +19,31 @@
 package org.wso2.transport.http.netty.contract.config;
 
 /**
- * Configuration for the request size validation.
+ * Configuration for the inbound request and response size validation.
  */
-public class RequestSizeValidationConfig {
+public class InboundMsgSizeValidationConfig {
 
-    private int maxUriLength = 4096;
+    private int maxInitialLineLength = 4096;
     private int maxHeaderSize = 8192;
     private int maxChunkSize = 8192;
     private long maxEntityBodySize = -1;
 
-    public int getMaxUriLength() {
-        return maxUriLength;
+    /**
+     * The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"} or {@code "HTTP/1.0 200 OK"}) If the length
+     * of the initial line exceeds this value, a TooLongFrameException will be raised from netty code.
+     */
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
     }
 
-    public void setMaxUriLength(int maxUriLength) {
-        this.maxUriLength = maxUriLength;
+    public void setMaxInitialLineLength(int maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
     }
 
+    /**
+     * The maximum length of all headers.  If the sum of the length of each header exceeds this value, a
+     * TooLongFrameException will be raised from netty code.
+     */
     public int getMaxHeaderSize() {
         return maxHeaderSize;
     }
@@ -44,6 +52,11 @@ public class RequestSizeValidationConfig {
         this.maxHeaderSize = maxHeaderSize;
     }
 
+    /**
+     * The maximum length of the content or each chunk.  If the content length (or the length of each chunk) exceeds
+     * this value, the content or chunk will be split into multiple HttpContents whose length is {@code maxChunkSize} at
+     * maximum.
+     */
     public int getMaxChunkSize() {
         return maxChunkSize;
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
@@ -51,7 +51,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean httpAccessLogEnabled;
     private String serverHeader = "wso2-http-transport";
     private List<Parameter> parameters = getDefaultParameters();
-    private RequestSizeValidationConfig requestSizeValidationConfig = new RequestSizeValidationConfig();
+    private InboundMsgSizeValidationConfig requestSizeValidationConfig = new InboundMsgSizeValidationConfig();
     private boolean pipeliningEnabled;
     private boolean webSocketCompressionEnabled;
     private long pipeliningLimit;
@@ -146,11 +146,11 @@ public class ListenerConfiguration extends SslConfiguration {
         this.httpAccessLogEnabled = httpAccessLogEnabled;
     }
 
-    public RequestSizeValidationConfig getRequestSizeValidationConfig() {
+    public InboundMsgSizeValidationConfig getMsgSizeValidationConfig() {
         return requestSizeValidationConfig;
     }
 
-    public void setRequestSizeValidationConfig(RequestSizeValidationConfig requestSizeValidationConfig) {
+    public void setMsgSizeValidationConfig(InboundMsgSizeValidationConfig requestSizeValidationConfig) {
         this.requestSizeValidationConfig = requestSizeValidationConfig;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SenderConfiguration.java
@@ -47,7 +47,7 @@ public class SenderConfiguration extends SslConfiguration {
     private String httpVersion = "1.1";
     private ProxyServerConfiguration proxyServerConfiguration;
     private PoolConfiguration poolConfiguration;
-
+    private InboundMsgSizeValidationConfig responseSizeValidationConfig = new InboundMsgSizeValidationConfig();
     private ForwardedExtensionConfig forwardedExtensionConfig = ForwardedExtensionConfig.DISABLE;
 
     public SenderConfiguration() {
@@ -142,5 +142,13 @@ public class SenderConfiguration extends SslConfiguration {
 
     public void setForwardedExtensionConfig(ForwardedExtensionConfig forwardedExtensionEnabled) {
         this.forwardedExtensionConfig = forwardedExtensionEnabled;
+    }
+
+    public InboundMsgSizeValidationConfig getMsgSizeValidationConfig() {
+        return responseSizeValidationConfig;
+    }
+
+    public void setMsgSizeValidationConfig(InboundMsgSizeValidationConfig responseSizeValidationConfig) {
+        this.responseSizeValidationConfig = responseSizeValidationConfig;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -90,7 +90,7 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
         serverConnectorBootstrap.addHttpTraceLogHandler(listenerConfig.isHttpTraceLogEnabled());
         serverConnectorBootstrap.addHttpAccessLogHandler(listenerConfig.isHttpAccessLogEnabled());
         serverConnectorBootstrap.addThreadPools(bossGroup, workerGroup);
-        serverConnectorBootstrap.addHeaderAndEntitySizeValidation(listenerConfig.getRequestSizeValidationConfig());
+        serverConnectorBootstrap.addHeaderAndEntitySizeValidation(listenerConfig.getMsgSizeValidationConfig());
         serverConnectorBootstrap.addChunkingBehaviour(listenerConfig.getChunkConfig());
         serverConnectorBootstrap.addKeepAliveBehaviour(listenerConfig.getKeepAliveConfig());
         serverConnectorBootstrap.addServerHeader(listenerConfig.getServerHeader());

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -69,9 +69,11 @@ import javax.net.ssl.SSLEngine;
 import static org.wso2.transport.http.netty.contract.Constants.ACCESS_LOG;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_ACCESS_LOG_HANDLER;
 import static org.wso2.transport.http.netty.contract.Constants.HTTP_TRACE_LOG_HANDLER;
+import static org.wso2.transport.http.netty.contract.Constants.MAX_ENTITY_BODY_VALIDATION_HANDLER;
 import static org.wso2.transport.http.netty.contract.Constants.SECURITY;
 import static org.wso2.transport.http.netty.contract.Constants.SSL;
 import static org.wso2.transport.http.netty.contract.Constants.TRACE_LOG_DOWNSTREAM;
+import static org.wso2.transport.http.netty.contract.Constants.URI_HEADER_LENGTH_VALIDATION_HANDLER;
 import static org.wso2.transport.http.netty.contractimpl.common.Util.setSslHandshakeTimeOut;
 
 /**
@@ -218,9 +220,9 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
                 serverPipeline.addLast(HTTP_ACCESS_LOG_HANDLER, new HttpAccessLoggingHandler(ACCESS_LOG));
             }
         }
-        serverPipeline.addLast("uriLengthValidator", new UriAndHeaderLengthValidator(this.serverName));
+        serverPipeline.addLast(URI_HEADER_LENGTH_VALIDATION_HANDLER, new UriAndHeaderLengthValidator(this.serverName));
         if (reqSizeValidationConfig.getMaxEntityBodySize() > -1) {
-            serverPipeline.addLast("maxEntityBodyValidator", new MaxEntityBodyValidator(this.serverName,
+            serverPipeline.addLast(MAX_ENTITY_BODY_VALIDATION_HANDLER, new MaxEntityBodyValidator(this.serverName,
                     reqSizeValidationConfig.getMaxEntityBodySize()));
         }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/HttpServerChannelInitializer.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
+import org.wso2.transport.http.netty.contract.config.InboundMsgSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
-import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
 import org.wso2.transport.http.netty.contractimpl.common.BackPressureHandler;
 import org.wso2.transport.http.netty.contractimpl.common.Util;
 import org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.CertificateVerificationException;
@@ -94,7 +94,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
     private SslContext keystoreHttp2SslContext;
     private SslContext certAndKeySslContext;
     private ServerConnectorFuture serverConnectorFuture;
-    private RequestSizeValidationConfig reqSizeValidationConfig;
+    private InboundMsgSizeValidationConfig reqSizeValidationConfig;
     private boolean http2Enabled = false;
     private boolean validateCertEnabled;
     private int cacheDelay;
@@ -204,7 +204,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         if (initialHttpScheme.equals(Constants.HTTP_SCHEME)) {
             serverPipeline.addLast(Constants.HTTP_ENCODER, new HttpResponseEncoder());
             serverPipeline.addLast(Constants.HTTP_DECODER,
-                                   new HttpRequestDecoder(reqSizeValidationConfig.getMaxUriLength(),
+                                   new HttpRequestDecoder(reqSizeValidationConfig.getMaxInitialLineLength(),
                                                           reqSizeValidationConfig.getMaxHeaderSize(),
                                                           reqSizeValidationConfig.getMaxChunkSize()));
 
@@ -249,7 +249,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         pipeline.addLast(new Http2WithPriorKnowledgeHandler(
                 interfaceId, serverName, serverConnectorFuture, this));
         // Add http2 upgrade decoder and upgrade handler
-        final HttpServerCodec sourceCodec = new HttpServerCodec(reqSizeValidationConfig.getMaxUriLength(),
+        final HttpServerCodec sourceCodec = new HttpServerCodec(reqSizeValidationConfig.getMaxInitialLineLength(),
                                                                 reqSizeValidationConfig.getMaxHeaderSize(),
                                                                 reqSizeValidationConfig.getMaxChunkSize());
 
@@ -332,7 +332,7 @@ public class HttpServerChannelInitializer extends ChannelInitializer<SocketChann
         this.certAndKeySslContext = sslContext;
     }
 
-    void setReqSizeValidationConfig(RequestSizeValidationConfig reqSizeValidationConfig) {
+    void setReqSizeValidationConfig(InboundMsgSizeValidationConfig reqSizeValidationConfig) {
         this.reqSizeValidationConfig = reqSizeValidationConfig;
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ServerConnectorBootstrap.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/ServerConnectorBootstrap.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
+import org.wso2.transport.http.netty.contract.config.InboundMsgSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
-import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
 import org.wso2.transport.http.netty.contractimpl.HttpWsServerConnectorFuture;
@@ -43,6 +43,7 @@ import org.wso2.transport.http.netty.internal.HandlerExecutor;
 import org.wso2.transport.http.netty.internal.HttpTransportContextHolder;
 
 import java.net.InetSocketAddress;
+
 import javax.net.ssl.SSLContext;
 
 /**
@@ -140,7 +141,7 @@ public class ServerConnectorBootstrap {
         httpServerChannelInitializer.setCertandKeySslContext(sslContext);
     }
 
-    public void addHeaderAndEntitySizeValidation(RequestSizeValidationConfig requestSizeValidationConfig) {
+    public void addHeaderAndEntitySizeValidation(InboundMsgSizeValidationConfig requestSizeValidationConfig) {
         httpServerChannelInitializer.setReqSizeValidationConfig(requestSizeValidationConfig);
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/UriAndHeaderLengthValidator.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/UriAndHeaderLengthValidator.java
@@ -50,7 +50,7 @@ public class UriAndHeaderLengthValidator extends ChannelInboundHandlerAdapter {
                 Throwable cause = inboundRequest.decoderResult().cause();
                 if (cause instanceof TooLongFrameException) {
                     if (cause.getMessage().contains(Constants.REQUEST_HEADER_TOO_LARGE)) {
-                        Util.sendAndCloseNoEntityBodyResp(ctx, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+                        Util.sendAndCloseNoEntityBodyResp(ctx, HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE,
                                 HttpVersion.HTTP_1_0, serverName);
                         LOG.warn("Inbound request Entity exceeds the max entity size allowed for a request");
                     } else if (cause.getMessage().contains(Constants.REQUEST_LINE_TOO_LONG)) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -39,6 +39,7 @@ import io.netty.handler.ssl.ReferenceCountedOpenSslEngine;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.config.InboundMsgSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
@@ -86,6 +87,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
     private SenderConfiguration senderConfiguration;
     private ConnectionAvailabilityFuture connectionAvailabilityFuture;
     private SSLHandlerFactory sslHandlerFactory;
+    private final InboundMsgSizeValidationConfig responseSizeValidationConfig;
 
     public HttpClientChannelInitializer(SenderConfiguration senderConfiguration, HttpRoute httpRoute,
             ConnectionManager connectionManager, ConnectionAvailabilityFuture connectionAvailabilityFuture) {
@@ -97,6 +99,7 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
         this.httpRoute = httpRoute;
         this.sslConfig = senderConfiguration.getClientSSLConfig();
         this.connectionAvailabilityFuture = connectionAvailabilityFuture;
+        this.responseSizeValidationConfig = senderConfiguration.getMsgSizeValidationConfig();
 
         String httpVersion = senderConfiguration.getHttpVersion();
         if (Constants.HTTP_2_0.equals(httpVersion)) {
@@ -257,7 +260,10 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
      * @param targetHandler the target handler
      */
     public void configureHttpPipeline(ChannelPipeline pipeline, TargetHandler targetHandler) {
-        pipeline.addLast(Constants.HTTP_CLIENT_CODEC, new HttpClientCodec());
+        HttpClientCodec clientCodec = new HttpClientCodec(responseSizeValidationConfig.getMaxInitialLineLength(),
+                                                          responseSizeValidationConfig.getMaxHeaderSize(),
+                                                          responseSizeValidationConfig.getMaxChunkSize());
+        pipeline.addLast(Constants.HTTP_CLIENT_CODEC, clientCodec);
         addCommonHandlers(pipeline);
         pipeline.addLast(Constants.BACK_PRESSURE_HANDLER, new BackPressureHandler());
         pipeline.addLast(Constants.TARGET_HANDLER, targetHandler);

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/HttpClientChannelInitializer.java
@@ -62,6 +62,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 import static io.netty.handler.logging.LogLevel.TRACE;
+import static org.wso2.transport.http.netty.contract.Constants.MAX_ENTITY_BODY_VALIDATION_HANDLER;
 import static org.wso2.transport.http.netty.contract.Constants.SECURITY;
 import static org.wso2.transport.http.netty.contract.Constants.SSL;
 import static org.wso2.transport.http.netty.contractimpl.common.Util.setHostNameVerfication;
@@ -265,6 +266,12 @@ public class HttpClientChannelInitializer extends ChannelInitializer<SocketChann
                                                           responseSizeValidationConfig.getMaxChunkSize());
         pipeline.addLast(Constants.HTTP_CLIENT_CODEC, clientCodec);
         addCommonHandlers(pipeline);
+        pipeline.addLast(Constants.STATUS_LINE_HEADER_LENGTH_VALIDATION_HANDLER,
+                         new StatusLineAndHeaderLengthValidator());
+        if (responseSizeValidationConfig.getMaxEntityBodySize() > -1) {
+            pipeline.addLast(MAX_ENTITY_BODY_VALIDATION_HANDLER,
+                             new ResponseEntityBodySizeValidator(responseSizeValidationConfig.getMaxEntityBodySize()));
+        }
         pipeline.addLast(Constants.BACK_PRESSURE_HANDLER, new BackPressureHandler());
         pipeline.addLast(Constants.TARGET_HANDLER, targetHandler);
     }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/ResponseEntityBodySizeValidator.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/ResponseEntityBodySizeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,38 +16,32 @@
  * under the License.
  */
 
-package org.wso2.transport.http.netty.contractimpl.listener;
+package org.wso2.transport.http.netty.contractimpl.sender;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCounted;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.wso2.transport.http.netty.contractimpl.common.Util;
 
 import java.util.LinkedList;
 
 /**
- * Responsible for validating request entity body size before sending it to the application.
+ * Responsible for validating response entity body size before sending it to the application. If the validation fails,
+ * throws an exception to be handled by the targetHandler for downstream notification through respective response
+ * state.
  */
-public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
+public class ResponseEntityBodySizeValidator extends ChannelInboundHandlerAdapter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MaxEntityBodyValidator.class);
-
-    private String serverName;
     private long maxEntityBodySize;
     private long currentSize;
-    private HttpRequest inboundRequest;
+    private HttpResponse inboundResponse;
     private LinkedList<HttpContent> fullContent;
 
-    MaxEntityBodyValidator(String serverName, long maxEntityBodySize) {
-        this.serverName = serverName;
+    public ResponseEntityBodySizeValidator(long maxEntityBodySize) {
         this.maxEntityBodySize = maxEntityBodySize;
         this.fullContent = new LinkedList<>();
     }
@@ -55,10 +49,11 @@ public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (ctx.channel().isActive()) {
-            if (msg instanceof HttpRequest) {
-                inboundRequest = (HttpRequest) msg;
-                if (isContentLengthInvalid(inboundRequest, maxEntityBodySize)) {
-                    sendEntityTooLargeResponse(ctx);
+            if (msg instanceof HttpResponse) {
+                inboundResponse = (HttpResponse) msg;
+                if (isContentLengthInvalid(inboundResponse, maxEntityBodySize)) {
+                    releaseContentAndNotifyError();
+                    return;
                 }
                 ctx.channel().read();
             } else {
@@ -66,10 +61,10 @@ public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
                 this.currentSize += inboundContent.content().readableBytes();
                 this.fullContent.add(inboundContent);
                 if (this.currentSize > maxEntityBodySize) {
-                    sendEntityTooLargeResponse(ctx);
+                    releaseContentAndNotifyError();
                 } else {
                     if (msg instanceof LastHttpContent) {
-                        super.channelRead(ctx, this.inboundRequest);
+                        super.channelRead(ctx, this.inboundResponse);
                         while (!this.fullContent.isEmpty()) {
                             super.channelRead(ctx, this.fullContent.pop());
                         }
@@ -81,14 +76,11 @@ public class MaxEntityBodyValidator extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private void sendEntityTooLargeResponse(ChannelHandlerContext ctx) {
-        Util.sendAndCloseNoEntityBodyResp(ctx, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
-                inboundRequest.protocolVersion(), this.serverName);
-
+    private void releaseContentAndNotifyError() {
         this.fullContent.forEach(ReferenceCounted::release);
         this.fullContent.forEach(httpContent -> this.fullContent.remove(httpContent));
-
-        LOG.warn("Inbound request payload size exceeds the max entity body allowed for a request");
+        throw new RuntimeException("Response max entity body size exceeds: Entity body is larger than "
+                                           + this.maxEntityBodySize + " bytes. ");
     }
 
     private boolean isContentLengthInvalid(HttpMessage start, long maxContentLength) {

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/StatusLineAndHeaderLengthValidator.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/StatusLineAndHeaderLengthValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.contractimpl.sender;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.HttpResponse;
+import org.wso2.transport.http.netty.contract.Constants;
+
+/**
+ * Responsible for validating the inbound response's status line and total header size before sending it to the
+ * application. If the validation fails, throws an exception to be handled by the targetHandler for downstream
+ * notification through respective response state.
+ */
+public class StatusLineAndHeaderLengthValidator extends ChannelInboundHandlerAdapter {
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof HttpResponse) {
+            if (!ctx.channel().isActive()) {
+                return;
+            }
+            Throwable cause = ((HttpResponse) msg).decoderResult().cause();
+            if (cause instanceof TooLongFrameException) {
+                String message = cause.getMessage();
+                if (message.contains(Constants.REQUEST_HEADER_TOO_LARGE)) {
+                    throw new RuntimeException("Response max header size exceeds: " + cause.getMessage());
+                } else if (message.contains(Constants.REQUEST_LINE_TOO_LONG)) {
+                    throw new RuntimeException("Response max status line length exceeds: " + cause.getMessage());
+                } else {
+                    super.channelRead(ctx, msg);
+                }
+            } else {
+                super.channelRead(ctx, msg);
+            }
+        } else {
+            super.channelRead(ctx, msg);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/TargetHandler.java
@@ -62,6 +62,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
     private KeepAliveConfig keepAliveConfig;
     private boolean idleTimeoutTriggered;
     private ChannelHandlerContext context;
+    private Throwable cause;
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
@@ -126,6 +127,7 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        this.cause = cause;
         closeChannel(ctx);
         LOG.warn("Exception occurred in TargetHandler : {}", cause.getMessage());
     }
@@ -265,5 +267,9 @@ public class TargetHandler extends ChannelInboundHandlerAdapter {
      */
     public ChannelHandlerContext getContext() {
         return context;
+    }
+
+    public Throwable getCause() {
+        return cause;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/RequestCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/RequestCompleted.java
@@ -76,9 +76,12 @@ public class RequestCompleted implements SenderState {
 
     @Override
     public void handleAbruptChannelClosure(TargetHandler targetHandler, HttpResponseFuture httpResponseFuture) {
-        httpResponseFuture.notifyHttpListener(
-                new ServerConnectorException(REMOTE_SERVER_CLOSED_BEFORE_INITIATING_INBOUND_RESPONSE));
-        LOG.error(REMOTE_SERVER_CLOSED_BEFORE_INITIATING_INBOUND_RESPONSE);
+        String message = REMOTE_SERVER_CLOSED_BEFORE_INITIATING_INBOUND_RESPONSE;
+        if (targetHandler.getCause() != null) {
+            message = targetHandler.getCause().getMessage();
+        }
+        httpResponseFuture.notifyHttpListener(new ServerConnectorException(message));
+        LOG.error(message);
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -325,6 +326,13 @@ public class HttpCarbonMessage {
 
     public void setHttpStatusCode(Integer httpStatusCode) {
         this.httpStatusCode = httpStatusCode;
+    }
+
+    public String getReasonPhrase() {
+        if (httpMessage instanceof DefaultHttpResponse) {
+            return ((DefaultHttpResponse) httpMessage).status().reasonPhrase();
+        }
+        return "Unknown Status";
     }
 
     private void setBlockingEntityCollector(BlockingEntityCollector blockingEntityCollector) {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/lengthvalidation/RequestLengthValidationTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/lengthvalidation/RequestLengthValidationTest.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.transport.http.netty.urilengthvalidation;
+package org.wso2.transport.http.netty.lengthvalidation;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
@@ -56,11 +56,11 @@ import java.util.HashMap;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
- * This class tests for 414 and 413 responses.
+ * This class tests for 413, 414 and 431 responses.
  */
-public class Status414And413ResponseTest {
+public class RequestLengthValidationTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Status414And413ResponseTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RequestLengthValidationTest.class);
 
     protected ServerConnector serverConnector;
     protected ListenerConfiguration listenerConfiguration;
@@ -68,7 +68,7 @@ public class Status414And413ResponseTest {
     private static final String testValue = "Test Message";
     private URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
 
-    Status414And413ResponseTest() {
+    RequestLengthValidationTest() {
         this.listenerConfiguration = new ListenerConfiguration();
     }
 
@@ -78,7 +78,7 @@ public class Status414And413ResponseTest {
         listenerConfiguration.setServerHeader(TestUtil.TEST_SERVER);
         listenerConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(1024);
         listenerConfiguration.getMsgSizeValidationConfig().setMaxHeaderSize(1024);
-        listenerConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(1024);
+        listenerConfiguration.getMsgSizeValidationConfig().setMaxInitialLineLength(1024);
 
         ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
         httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
@@ -119,7 +119,9 @@ public class Status414And413ResponseTest {
             httpRequest.headers().set("X-Test", getLargeHeader());
             FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
 
-            assertEntityTooLargeResponse(httpResponse);
+            assertEquals(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE.code(), httpResponse.status().code());
+            assertEquals(Constants.CONNECTION_CLOSE, httpResponse.headers().get(HttpHeaderNames.CONNECTION.toString()));
+            assertEquals(TestUtil.TEST_SERVER, httpResponse.headers().get(HttpHeaderNames.SERVER));
 
             httpClient = new HttpClient(TestUtil.TEST_HOST, TestUtil.SERVER_CONNECTOR_PORT);
             httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/lengthvalidation/ResponseLengthValidationTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/lengthvalidation/ResponseLengthValidationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.lengthvalidation;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.mashape.unirest.http.options.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.ServerConnector;
+import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
+import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.config.ServerBootstrapConfiguration;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.passthrough.PassthroughMessageProcessorListener;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+import org.wso2.transport.http.netty.util.server.initializers.EchoServerInitializer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * This class tests inbound response status line, headers and entity body validations.
+ * <p>
+ * Test setup uses the PassthroughMessageProcessorListener with a configurable client. The EchoServerInitializer is used
+ * as the backend echo server. Each test changes the client sender config based on testing objective.
+ */
+public class ResponseLengthValidationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResponseLengthValidationTest.class);
+
+    private HttpServer httpServer;
+    private ServerConnector serverConnector;
+    private HttpWsConnectorFactory httpWsConnectorFactory;
+    static final String TEST_VALUE = "Test Message";
+    URI baseURI = URI.create(String.format("http://%s:%d", "localhost", TestUtil.SERVER_CONNECTOR_PORT));
+
+
+    private void setUp(SenderConfiguration senderConfiguration) {
+        httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();
+
+        ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
+        listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
+        serverConnector = httpWsConnectorFactory
+                .createServerConnector(new ServerBootstrapConfiguration(new HashMap<>()), listenerConfiguration);
+        ServerConnectorFuture serverConnectorFuture = serverConnector.start();
+        serverConnectorFuture.setHttpConnectorListener(
+                new PassthroughMessageProcessorListener(senderConfiguration));
+        try {
+            serverConnectorFuture.sync();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for server connector to start");
+        }
+
+        httpServer = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, new EchoServerInitializer());
+    }
+
+    @Test(description = "Configure setMaxInitialLineLength to 100 and test smaller status line")
+    public void statusLineValidationSuccessTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxInitialLineLength(100);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).body(TEST_VALUE).asString();
+            assertEquals(TEST_VALUE, response.getBody());
+            assertEquals(200, response.getStatus());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running shortHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test(description = "Configure setMaxInitialLineLength to 5 and test larger status line")
+    public void statusLineValidationNegativeTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxInitialLineLength(5);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).asString();
+            assertEquals("Response max status line length exceeds: An HTTP line is larger than 5 bytes.",
+                         response.getBody());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running longHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test(description = "Configure setMaxHeaderSize to 100 and test smaller total header size")
+    public void headerValidationSuccessTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxHeaderSize(100);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).body(TEST_VALUE).asString();
+            assertEquals(TEST_VALUE, response.getBody());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running shortHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test(description = "Configure setMaxHeaderSize to 10 and test larger total header size")
+    public void headerValidationNegativeTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxHeaderSize(10);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).asString();
+            assertEquals("Response max header size exceeds: HTTP header is larger than 10 bytes.", response.getBody());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running longHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test(description = "Configure setMaxEntityBodySize to 100 and test smaller payload")
+    public void entityBodyValidationSuccessTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(100);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).body(TEST_VALUE).asString();
+            assertEquals(TEST_VALUE, response.getBody());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running shortHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    @Test(description = "Configure setMaxEntityBodySize to 7 and test larger payload")
+    public void entityBodyValidationNegativeTest() {
+        SenderConfiguration senderConfiguration = new SenderConfiguration();
+        senderConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(7);
+        setUp(senderConfiguration);
+
+        try {
+            HttpResponse<String> response = Unirest.post(baseURI.resolve("/").toString()).body(TEST_VALUE).asString();
+            assertEquals("Response max entity body size exceeds: Entity body is larger than 7 bytes. ",
+                         response.getBody());
+        } catch (UnirestException e) {
+            TestUtil.handleException("IOException occurred while running longHeaderTest", e);
+        } finally {
+            cleanUp();
+        }
+    }
+
+    private void cleanUp() {
+        try {
+            Unirest.shutdown();
+            Options.refresh();
+            serverConnector.stop();
+            httpServer.shutdown();
+            httpWsConnectorFactory.shutdown();
+        } catch (IOException e) {
+            LOG.warn("IOException occurred while waiting for Unirest connection to shutdown", e);
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting for HttpWsFactory to shutdown", e);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/urilengthvalidation/Status414And413ResponseTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/urilengthvalidation/Status414And413ResponseTest.java
@@ -76,9 +76,9 @@ public class Status414And413ResponseTest {
     public void setUp() {
         listenerConfiguration.setPort(TestUtil.SERVER_CONNECTOR_PORT);
         listenerConfiguration.setServerHeader(TestUtil.TEST_SERVER);
-        listenerConfiguration.getRequestSizeValidationConfig().setMaxEntityBodySize(1024);
-        listenerConfiguration.getRequestSizeValidationConfig().setMaxHeaderSize(1024);
-        listenerConfiguration.getRequestSizeValidationConfig().setMaxEntityBodySize(1024);
+        listenerConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(1024);
+        listenerConfiguration.getMsgSizeValidationConfig().setMaxHeaderSize(1024);
+        listenerConfiguration.getMsgSizeValidationConfig().setMaxEntityBodySize(1024);
 
         ServerBootstrapConfiguration serverBootstrapConfig = new ServerBootstrapConfiguration(new HashMap<>());
         httpWsConnectorFactory = new DefaultHttpWsConnectorFactory();

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -75,7 +75,8 @@
             <class name="org.wso2.transport.http.netty.unitfunction.BlockingEntityCollectorTestCase" />
 
             <class name="org.wso2.transport.http.netty.encoding.ContentEncodingTestCase"/>
-            <class name="org.wso2.transport.http.netty.urilengthvalidation.Status414And413ResponseTest"/>
+            <class name="org.wso2.transport.http.netty.lengthvalidation.RequestLengthValidationTest"/>
+            <class name="org.wso2.transport.http.netty.lengthvalidation.ResponseLengthValidationTest"/>
             <class name="org.wso2.transport.http.netty.http1point0test.HttpOnePointZeroServerConnectorTestCase"/>
             <class name="org.wso2.transport.http.netty.http1point0test.KeepAliveHttpOnePointZeroClientTestCase"/>
             <class name="org.wso2.transport.http.netty.http1point0test.ChunkAutoHttpOnePointZeroClientTestCase"/>


### PR DESCRIPTION
## Purpose
> Add following configs to the HTTP client
- maxInitialLineLength
- maxHeaderSize
- maxEntityBodySize
- maxChunkSize

> Plug header and entity body validator handlers to the client channel.
> Generalize request and response validation configs logic
> Change request validation error status code form 413 to 431

## Automation tests
 - Unit tests 
   > Added