### PR TITLE
Fix HTTP2 inbound response headers getting mixed up with trailer validation logic

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/Constants.java
@@ -104,6 +104,7 @@ public final class Constants {
     public static final int DEFAULT_HTTP_PORT = 80;
     public static final int DEFAULT_HTTPS_PORT = 443;
     public static final String DEFAULT_BASE_PATH = "/";
+    public static final String COMMA = ",";
 
     public static final String TO = "TO";
     public static final String PROTOCOL = "PROTOCOL";

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/http2/ReceivingHeaders.java
@@ -27,11 +27,13 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.exceptions.EndpointTimeOutException;
 import org.wso2.transport.http.netty.contractimpl.common.states.Http2MessageStateContext;
 import org.wso2.transport.http.netty.contractimpl.common.states.StateUtil;
@@ -45,6 +47,8 @@ import org.wso2.transport.http.netty.message.Http2PushPromise;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.HttpCarbonResponse;
 import org.wso2.transport.http.netty.message.PooledDataStreamerFactory;
+
+import java.util.Locale;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.TRAILER;
 import static org.wso2.transport.http.netty.contract.Constants.DIRECTION;
@@ -164,7 +168,7 @@ public class ReceivingHeaders implements SenderState {
             } else if (http2Headers.contains(HTTP2_STATUS)) {
                 // if the header frame is an initial header frame and also it has endOfStream
                 responseMessage = setupResponseCarbonMessage(ctx, streamId, http2Headers, outboundMsgHolder);
-                onTrailersRead(streamId, http2Headers, outboundMsgHolder, responseMessage);
+                checkForTrailerHeaders(streamId, http2Headers, outboundMsgHolder, responseMessage);
                 outboundMsgHolder.addPushResponse(streamId, responseMessage);
             }
             http2ClientChannel.removePromisedMessage(streamId);
@@ -189,7 +193,7 @@ public class ReceivingHeaders implements SenderState {
             } else if (http2Headers.contains(HTTP2_STATUS)) {
                 // if the header frame is an initial header frame and also it has endOfStream
                 responseMessage = setupResponseCarbonMessage(ctx, streamId, http2Headers, outboundMsgHolder);
-                onTrailersRead(streamId, http2Headers, outboundMsgHolder, responseMessage);
+                checkForTrailerHeaders(streamId, http2Headers, outboundMsgHolder, responseMessage);
                 outboundMsgHolder.setResponse(responseMessage);
             }
             http2ClientChannel.removeInFlightMessage(streamId);
@@ -200,6 +204,29 @@ public class ReceivingHeaders implements SenderState {
                     http2Headers, outboundMsgHolder);
             outboundMsgHolder.setResponse(responseMessage);
             http2MessageStateContext.setSenderState(new ReceivingEntityBody(http2TargetHandler, http2RequestWriter));
+        }
+    }
+
+    private void checkForTrailerHeaders(int streamId, Http2Headers http2Headers, OutboundMsgHolder outboundMsgHolder,
+                                        HttpCarbonResponse responseMessage) {
+        if (!http2Headers.contains(TRAILER)) {
+            completeResponseMessage(responseMessage, new DefaultLastHttpContent());
+            return;
+        }
+        String trailerHeader = http2Headers.get(TRAILER).toString();
+        Http2Headers newHttp2Headers = new DefaultHttp2Headers();
+        String[] trailerKeys = trailerHeader.split(Constants.COMMA);
+        for (String key : trailerKeys) {
+            String headerKey = key.toLowerCase(Locale.getDefault()).trim();
+            CharSequence headerValue = http2Headers.get(headerKey);
+            if (headerValue != null) {
+                newHttp2Headers.add(headerKey, headerValue);
+            }
+        }
+        if (newHttp2Headers.isEmpty()) {
+            completeResponseMessage(responseMessage, new DefaultLastHttpContent());
+        } else {
+            onTrailersRead(streamId, newHttp2Headers, outboundMsgHolder, responseMessage);
         }
     }
 
@@ -216,6 +243,10 @@ public class ReceivingHeaders implements SenderState {
             outboundMsgHolder.getResponseFuture().
                     notifyHttpListener(new Exception("Error while setting http headers", e));
         }
+        completeResponseMessage(responseMessage, lastHttpContent);
+    }
+
+    private void completeResponseMessage(HttpCarbonMessage responseMessage, LastHttpContent lastHttpContent) {
         responseMessage.addHttpContent(lastHttpContent);
         responseMessage.setLastHttpContentArrived();
     }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerTrailersInInitialHeaderFrameTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/H2ListenerTrailersInInitialHeaderFrameTestCase.java
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.transport.http.netty.http2.trailer;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.contract.Constants;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
+import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.message.HttpCarbonMessage;
+import org.wso2.transport.http.netty.message.HttpConnectorUtil;
+import org.wso2.transport.http.netty.trailer.TrailerHeaderTestTemplate;
+import org.wso2.transport.http.netty.util.TestUtil;
+import org.wso2.transport.http.netty.util.client.http2.MessageGenerator;
+import org.wso2.transport.http.netty.util.client.http2.MessageSender;
+import org.wso2.transport.http.netty.util.server.HttpServer;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test case for H2 inbound response which contains only the header frame without any data frame.
+ *
+ * @since 6.3.20
+ */
+public class H2ListenerTrailersInInitialHeaderFrameTestCase extends TrailerHeaderTestTemplate {
+    private static final Logger LOG = LoggerFactory.getLogger(H2ListenerTrailersInInitialHeaderFrameTestCase.class);
+
+    private HttpServer http2Server;
+    private HttpClientConnector httpClientConnector;
+    private HttpWsConnectorFactory connectorFactory;
+    private SendHeadersWithoutDataFrameInitializer initializer;
+
+    @BeforeClass
+    public void setup() {
+        initializer = new SendHeadersWithoutDataFrameInitializer();
+        http2Server = TestUtil.startHTTPServer(TestUtil.HTTP_SERVER_PORT, initializer);
+
+        connectorFactory = new DefaultHttpWsConnectorFactory();
+        TransportsConfiguration transportsConfiguration = new TransportsConfiguration();
+        SenderConfiguration senderConfiguration = HttpConnectorUtil.getSenderConfiguration(
+                transportsConfiguration, Constants.HTTP_SCHEME);
+        senderConfiguration.setHttpVersion(Constants.HTTP_2_0);
+        httpClientConnector = connectorFactory.createHttpClientConnector(
+                HttpConnectorUtil.getTransportProperties(transportsConfiguration), senderConfiguration);
+    }
+
+    @Test()
+    public void testNoDataFrameResponse() {
+        Http2Headers inputHeaders = new DefaultHttp2Headers().status(OK.codeAsText());
+        inputHeaders.add("x-abc", "abc");
+        inputHeaders.add("content-length", "0");
+        inputHeaders.add("content-type", "text/plain");
+        initializer.setHeaders(inputHeaders);
+
+        HttpCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.GET, "Test");
+        HttpCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
+        assertNotNull(response, "Expected response not received");
+        assertEquals(response.getHeaders().get("x-abc"), "abc");
+        assertEquals(response.getHeaders().get("content-length"), "0");
+        assertEquals(response.getHeaders().get("content-type"), "text/plain");
+    }
+
+
+    @Test(dependsOnMethods = "testNoDataFrameResponse")
+    public void testNoDataFrameButWithTrailersInsideHeaderFrame() {
+        Http2Headers inputHeaders = new DefaultHttp2Headers().status(OK.codeAsText());
+        inputHeaders.add("x-abc", "abc");
+        inputHeaders.add("trailer", "abc , hello");
+        inputHeaders.add("content-length", "0");
+        inputHeaders.add("content-type", "text/plain");
+        inputHeaders.add("abc", "abc");
+        initializer.setHeaders(inputHeaders);
+
+        HttpCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.GET, "Test");
+        HttpCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
+        assertNotNull(response, "Expected response not received");
+        assertEquals(response.getHeaders().get("x-abc"), "abc");
+        assertEquals(response.getHeaders().get("content-length"), "0");
+        assertEquals(response.getHeaders().get("content-type"), "text/plain");
+        assertEquals(response.getHeaders().get("trailer"), "abc , hello");
+        assertEquals(response.getHeaders().get("abc"), "abc");
+        assertEquals(response.getTrailerHeaders().get("abc"), "abc");
+    }
+
+    @Test(dependsOnMethods = "testNoDataFrameButWithTrailersInsideHeaderFrame")
+    public void testNoDataFrameButWithTrailerHeaderAndNoRespectiveTrailers() {
+        Http2Headers inputHeaders = new DefaultHttp2Headers().status(OK.codeAsText());
+        inputHeaders.add("x-abc", "abc");
+        inputHeaders.add("trailer", "abc,cool");
+        inputHeaders.add("content-length", "0");
+        inputHeaders.add("content-type", "text/plain");
+        initializer.setHeaders(inputHeaders);
+
+        HttpCarbonMessage httpCarbonMessage = MessageGenerator.generateRequest(HttpMethod.GET, "Test");
+        HttpCarbonMessage response = new MessageSender(httpClientConnector).sendMessage(httpCarbonMessage);
+        assertNotNull(response, "Expected response not received");
+        assertEquals(response.getHeaders().get("x-abc"), "abc");
+        assertEquals(response.getHeaders().get("content-length"), "0");
+        assertEquals(response.getHeaders().get("content-type"), "text/plain");
+        assertEquals(response.getHeaders().get("trailer"), "abc,cool");
+        assertTrue(response.getTrailerHeaders().isEmpty());
+    }
+
+    @AfterClass
+    public void cleanUp() throws ServerConnectorException {
+        try {
+            http2Server.shutdown();
+            connectorFactory.shutdown();
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted while waiting for HttpWsFactory to shutdown", e);
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/SendHeadersWithoutDataFrameInitializer.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/trailer/SendHeadersWithoutDataFrameInitializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.transport.http.netty.http2.trailer;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.DefaultHttp2WindowUpdateFrame;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2FrameStream;
+import io.netty.handler.codec.http2.Http2Headers;
+import org.wso2.transport.http.netty.util.server.initializers.http2.Http2ServerInitializer;
+
+/**
+ * An initializer class for HTTP Server. The responsibility of this class is to simulate an abnormal backend response
+ * scenario which send trailers along with leading headers and no data frame.
+ */
+public class SendHeadersWithoutDataFrameInitializer extends Http2ServerInitializer {
+
+    private Http2Headers headers;
+
+    protected void addBusinessLogicHandler(Channel channel) {
+        channel.pipeline().addLast("handler", new SendHeadersWithoutDataFrameHandler());
+    }
+
+    public void setHeaders(Http2Headers headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    protected ChannelHandler getBusinessLogicHandler() {
+        return new SendHeadersWithoutDataFrameHandler();
+    }
+
+    @Override
+    protected Http2ConnectionHandler getBusinessLogicHandlerViaBuiler() {
+        return null;
+    }
+
+    private class SendHeadersWithoutDataFrameHandler extends ChannelDuplexHandler {
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+
+            if (msg instanceof Http2DataFrame) {
+                Http2DataFrame data = (Http2DataFrame) msg;
+                Http2FrameStream stream = data.stream();
+                if (data.isEndStream()) {
+                    ctx.write(new DefaultHttp2HeadersFrame(headers, true).stream(stream));
+                } else {
+                    data.release();
+                }
+                ctx.write(new DefaultHttp2WindowUpdateFrame(data.initialFlowControlledBytes()).stream(stream));
+            }
+        }
+    }
+}

--- a/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
+++ b/components/org.wso2.transport.http.netty/src/test/resources/testng.xml
@@ -143,6 +143,7 @@
             <class name="org.wso2.transport.http.netty.http2.expect100continue.ClientContinueResponseTimeout"/>
             <class name="org.wso2.transport.http.netty.http2.trailer.H2ListenerIntendedResponseTrailerHeaderTestCase"/>
             <class name="org.wso2.transport.http.netty.http2.trailer.H2ListenerPushResponseTrailerHeaderTestCase"/>
+            <class name="org.wso2.transport.http.netty.http2.trailer.H2ListenerTrailersInInitialHeaderFrameTestCase"/>
         </classes>
     </test>
     <test name="Transport Security Tests" parallel="false">


### PR DESCRIPTION
## Purpose
> $subject

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/27636

