### PR TITLE
Add Codecove to the transport-http repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ cache:
 
 jdk:
   - openjdk8
+
+script: "mvn cobertura:cobertura"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+  

--- a/pom.xml
+++ b/pom.xml
@@ -290,6 +290,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>xml</format>
+                    </formats>
+                    <check />
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>${maven.cobertura.plugin.version}</version>
                 <configuration>
                     <formats>
                         <format>html</format>
@@ -350,7 +350,9 @@
         <!-- Following two properties should be removed once the versions are added the wso2 parent pom CARBON-15729 -->
         <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
         <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
-
+        
+        <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
+     
         <carbon.metrics.version>2.0.0</carbon.metrics.version>
         <metrics.version>3.1.2</metrics.version>
 


### PR DESCRIPTION
## Purpose
> Add Codecove to the transport-http repo

## Goals
> Publishing the testerina generated code coverage xml to Codecov triggered via Travis CI

## Approach
> A new job is inserted to Pull request and Travis CI publishes the XML report to Codecov

## Test environment
> Ubuntu 20.04
 