### PR TITLE
Add streaming property to carbon message

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/SendingEntityBody.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/listener/states/SendingEntityBody.java
@@ -149,8 +149,9 @@ public class SendingEntityBody implements ListenerState {
         IOException connectionClose = new IOException(REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE_BODY);
         outboundResponseMsg.setIoException(connectionClose);
         outboundRespStatusFuture.notifyHttpListener(connectionClose);
-
-        LOG.error(REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE_BODY);
+        if (!outboundResponseMsg.isStreaming()) {
+            LOG.error(REMOTE_CLIENT_CLOSED_WHILE_WRITING_OUTBOUND_RESPONSE_BODY);
+        }
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/RequestCompleted.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/states/RequestCompleted.java
@@ -80,8 +80,11 @@ public class RequestCompleted implements SenderState {
         if (targetHandler.getCause() != null) {
             message = targetHandler.getCause().getMessage();
         }
+
         httpResponseFuture.notifyHttpListener(new ServerConnectorException(message));
-        LOG.error(message);
+        if (!targetHandler.getInboundResponseMsg().isStreaming()) {
+            LOG.error(message);
+        }
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/message/HttpCarbonMessage.java
@@ -74,6 +74,7 @@ public class HttpCarbonMessage {
     private boolean pipeliningEnabled;
     private boolean passthrough = false;
     private boolean lastHttpContentArrived = false;
+    private boolean streaming = false;
     private String httpVersion;
     private String httpMethod;
     private String requestUrl;
@@ -510,6 +511,14 @@ public class HttpCarbonMessage {
 
     public boolean isPipeliningEnabled() {
         return pipeliningEnabled;
+    }
+
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+    public void setStreaming(boolean streaming) {
+        this.streaming = streaming;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> While streaming events with siddhi-sse, remote client closed connection logs should not be displayed.  

## Goals
> Remove the unnecessary logs while streaming responses. 