### PR TITLE
Add missing ssl configs and headers in listener

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/ListenerConfiguration.java
@@ -55,6 +55,7 @@ public class ListenerConfiguration extends SslConfiguration {
     private boolean pipeliningEnabled;
     private boolean webSocketCompressionEnabled;
     private long pipeliningLimit;
+    private String responseHeaderList;
 
     public ListenerConfiguration() {
     }
@@ -200,5 +201,13 @@ public class ListenerConfiguration extends SslConfiguration {
 
     public void setWebSocketCompressionEnabled(boolean webSocketCompressionEnabled) {
         this.webSocketCompressionEnabled = webSocketCompressionEnabled;
+    }
+
+    public String getResponseHeaderList() {
+        return responseHeaderList;
+    }
+
+    public void setResponseHeaderList(String responseHeaderList) {
+        this.responseHeaderList = responseHeaderList;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -131,7 +131,7 @@ public class SslConfiguration {
         return String.valueOf(sslConfig.getKeyStore());
     }
 
-    public String getKeyStorePassword() {
+    public String getKeyStorePass() {
         return sslConfig.getKeyStorePass();
     }
 

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -49,6 +49,12 @@ public class SslConfiguration {
     private List<Parameter> parameters = new ArrayList<>();
     private SSLConfig sslConfig = new SSLConfig();
     private static final Logger LOG = LoggerFactory.getLogger(SslConfiguration.class);
+    private String keyStoreFile;
+    private String keyStorePassword;
+    private String certPass;
+    private String trustStoreFile;
+    private String trustStorePass;
+    private String headerList;
 
     public void setKeyStoreFile(String keyStoreFile) {
         sslConfig.setKeyStore(new File(Util.substituteVariables(keyStoreFile)));
@@ -125,7 +131,7 @@ public class SslConfiguration {
         return String.valueOf(sslConfig.getKeyStore());
     }
 
-    public String getKeyStorePass() {
+    public String getKeyStorePassword() {
         return sslConfig.getKeyStorePass();
     }
 
@@ -284,5 +290,29 @@ public class SslConfiguration {
             }
         }
         return sslConfig;
+    }
+
+    public void setCertPass(String certPass) {
+        this.certPass = certPass;
+    }
+
+    public String getCertPass() {
+        return certPass;
+    }
+
+    public String getTrustStoreFile() {
+        return trustStoreFile;
+    }
+
+    public String getTrustStorePass() {
+        return trustStorePass;
+    }
+
+    public String getHeaderList() {
+        return headerList;
+    }
+
+    public void setHeaderList(String headerList) {
+        this.headerList = headerList;
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -52,9 +52,7 @@ public class SslConfiguration {
     private String keyStoreFile;
     private String keyStorePassword;
     private String certPass;
-    private String trustStoreFile;
-    private String trustStorePass;
-    private String headerList;
+    private String strictTransportSecurityHeader;
 
     public void setKeyStoreFile(String keyStoreFile) {
         sslConfig.setKeyStore(new File(Util.substituteVariables(keyStoreFile)));
@@ -300,19 +298,11 @@ public class SslConfiguration {
         return certPass;
     }
 
-    public String getTrustStoreFile() {
-        return trustStoreFile;
+    public String getStrictTransportSecurityHeader() {
+        return strictTransportSecurityHeader;
     }
 
-    public String getTrustStorePass() {
-        return trustStorePass;
-    }
-
-    public String getHeaderList() {
-        return headerList;
-    }
-
-    public void setHeaderList(String headerList) {
-        this.headerList = headerList;
+    public void setStrictTransportSecurityHeader(String strictTransportSecurityHeader) {
+        this.strictTransportSecurityHeader = strictTransportSecurityHeader;
     }
 }


### PR DESCRIPTION
## Purpose
> Add HTTP response headers including strictTransportSecurityHeader

## Goals
> Configure headers such as HTTP Strict Transport Security, Referrer-Policy, Feature-Policy, Content-Security-Policy, etc in carbon transports.

## Approach
> Adding the header values configured in netty-transports.yml into the HTTP response.
Users have to configure HSTS header values in netty-transports.yaml under listener configurations as follows.

id: "msf4j-https"
....
scheme: https
....
strictTransportSecurityHeader: max-age=342352535; includeSubDomains
responseHeaderList: "Feature-Policy: microphone 'none'; geolocation 'none', Referrer-Policy: no-referrer"

Multiple headers can be added to responseHeaderList which can be separated by commas (",") . `responseHeaderList` and `strictTransportSecurityHeader` configuration values in the netty-transport.yaml can be left blank if the headers are not needed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes