### PR TITLE
Fix for configuring listener SSL config

### DIFF
--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -196,7 +196,8 @@
     <properties>
         <bundle.activator>org.wso2.transport.http.netty.internal.HttpTransportActivator</bundle.activator>
         <private.package>
-            org.wso2.transport.http.netty.internal
+            org.wso2.transport.http.netty.internal,
+            org.yaml.snakeyaml.*;version="${org.snakeyaml.package.import.version.range}",
         </private.package>
         <export.package>
             !org.wso2.transport.http.netty.internal,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/config/SslConfiguration.java
@@ -196,6 +196,12 @@ public class SslConfiguration {
     }
 
     private SSLConfig getSSLConfigForListener() {
+        if (sslConfig.getKeyStore() == null && keyStoreFile != null) {
+            sslConfig.setKeyStore(new File(Util.substituteVariables(keyStoreFile)));
+        }
+        if (sslConfig.getKeyStorePass() == null && keyStorePassword != null) {
+            sslConfig.setKeyStorePass(keyStorePassword);
+        }
         if ((sslConfig.getKeyStore() == null || sslConfig.getKeyStorePass() == null) && (
                 sslConfig.getServerKeyFile() == null || sslConfig.getServerCertificates() == null)) {
             throw new IllegalArgumentException("keyStoreFile or keyStorePassword not defined for HTTPS scheme");


### PR DESCRIPTION
## Purpose
> Initialise ssl config with  keyStoreFile and keyStorePassword which was initialised with the yaml loader.
> Private package snakeyaml due to complexities arised when used with msf4j due to different snakeyaml versions used.
 
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes