### PR TITLE
Remove backPressureObservable listener after failure

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpResponseFuture.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpResponseFuture.java
@@ -23,6 +23,7 @@ import org.wso2.transport.http.netty.contract.HttpClientConnectorListener;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contractimpl.sender.http2.OutboundMsgHolder;
+import org.wso2.transport.http.netty.message.BackPressureObservable;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.message.ResponseHandle;
 
@@ -118,6 +119,12 @@ public class DefaultHttpResponseFuture implements HttpResponseFuture {
     public void notifyHttpListener(Throwable throwable) {
         responseLock.lock();
         try {
+            if (outboundMsgHolder != null) {
+                BackPressureObservable backPressureObservable = outboundMsgHolder.getBackPressureObservable();
+                if (backPressureObservable != null) {
+                    backPressureObservable.removeListener();
+                }
+            }
             this.throwable = throwable;
             returnError = throwable;
             if (executionWaitSem != null) {


### PR DESCRIPTION
## Purpose

When the channel is not writable but active, it acquires a semaphore and waits until it get notified by `onWritable()`. So when there is a failure the BackPressureObservable listener should be removed in order to release the semaphore through `onWritable()`. 
