### PR TITLE
Introduce a new HttpClientConnector creator method to HttpWsConnectorFactory interface

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpWsConnectorFactory.java
@@ -24,6 +24,7 @@ import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.config.ServerBootstrapConfiguration;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnector;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnectorConfig;
+import org.wso2.transport.http.netty.contractimpl.sender.channel.BootstrapConfiguration;
 import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.ConnectionManager;
 
 import java.util.Map;
@@ -62,6 +63,18 @@ public interface HttpWsConnectorFactory {
      */
     HttpClientConnector createHttpClientConnector(Map<String, Object> transportProperties,
         SenderConfiguration senderConfiguration, ConnectionManager connectionManager);
+
+    /**
+     * Creates a client connector with given client bootstrap configuration and connection manager.
+     *
+     * @param bootstrapConfiguration Represents the client bootstrap configurations.
+     * @param senderConfiguration    Represents the configurations related to client channel creation
+     * @param connectionManager      Manages the client pool
+     * @return the HttpClientConnector
+     */
+    HttpClientConnector createHttpClientConnector(BootstrapConfiguration bootstrapConfiguration,
+                                                  SenderConfiguration senderConfiguration,
+                                                  ConnectionManager connectionManager);
 
     /**
      * This method is used to get WebSocket client connector.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -155,6 +155,14 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
     }
 
     @Override
+    public HttpClientConnector createHttpClientConnector(BootstrapConfiguration bootstrapConfig,
+                                                         SenderConfiguration senderConfiguration,
+                                                         ConnectionManager connectionManager) {
+
+        return new DefaultHttpClientConnector(connectionManager, senderConfiguration, bootstrapConfig, clientGroup);
+    }
+
+    @Override
     public WebSocketClientConnector createWsClientConnector(WebSocketClientConnectorConfig clientConnectorConfig) {
         return new DefaultWebSocketClientConnector(clientConnectorConfig, clientGroup);
     }


### PR DESCRIPTION
If we have an HttpClientConnector creator method that accepts the client `BootstrapConfiguration` as an argument, it will be beneficial when we have to create multiple client connectors for the same client, as it avoids initializing the `BootstrapConfiguration` each time.

This PR introduces a new HttpClientConnector creator method to `HttpWsConnectorFactory` interface.