### PR TITLE
Update netty transport version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.71.Final</netty.version>
+        <netty.version>4.1.73.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
@@ -363,7 +363,7 @@
         <org.atomikos.wso2.version>3.8.0.wso2v1</org.atomikos.wso2.version>
         <bcprov-jdk15on.version>1.61</bcprov-jdk15on.version>
         <bcpkix-jdk15on.version>1.61</bcpkix-jdk15on.version>
-        <netty-tcnative-boringssl-static.version>2.0.46.Final</netty-tcnative-boringssl-static.version>
+        <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
 
         <unirest.version>1.4.9</unirest.version>
         <httpclient.version>4.3.6</httpclient.version>


### PR DESCRIPTION
## Purpose
Update to the following versions 

- netty version to 4.1.73.Final
- netty-tcnative-boringssl-static to 2.0.48.Final