### PR TITLE
Compile transport-http on Java 11

### DIFF
--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>unirest-java</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Java11 dependencies -->
+        <dependency>
+            <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -153,7 +153,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
-                    <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>
+<!--                    <argLine>@{argLine} -Dfile.encoding=UTF-8</argLine>-->
+                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- TODO testing -->
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,14 @@
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-boringssl-static.version}</version>
             </dependency>
+
+            <!--Java 11 related dependencies-->
+            <dependency>
+                <groupId>org.wso2.orbit.javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${org.wso2.orbit.javax.xml.bind.version}</version>
+                <type>jar</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -370,6 +378,9 @@
         <httpasyncclient.version>4.0.2</httpasyncclient.version>
         <httpmime.version>4.3.6</httpmime.version>
         <commons-io.version>2.4</commons-io.version>
+
+        <!-- Java 11 related dependencies -->
+        <org.wso2.orbit.javax.xml.bind.version>2.3.1.wso2v1</org.wso2.orbit.javax.xml.bind.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -269,9 +269,15 @@
                 <version>${maven.checkstyle.plugin.version}</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${maven.findbugs.plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${maven.spotbugsplugin.version}</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <xmlOutput>true</xmlOutput>
+                    <excludeFilterFile>${maven.spotbugsplugin.exclude.file}</excludeFilterFile>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -357,8 +363,8 @@
 
         <!-- Following two properties should be removed once the versions are added the wso2 parent pom CARBON-15729 -->
         <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
-        <maven.findbugs.plugin.version>3.0.5</maven.findbugs.plugin.version>
-        
+        <maven.spotbugsplugin.exclude.file>spotbugs-exclude.xml</maven.spotbugsplugin.exclude.file>
+
         <maven.cobertura.plugin.version>2.7</maven.cobertura.plugin.version>
      
         <carbon.metrics.version>2.0.0</carbon.metrics.version>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <Match>
+        <Package name="~org\.wso2\.transport\.http\.netty.*" />
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contract.config.SslConfiguration" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.DefaultHttpClientConnector" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.DefaultHttpClientConnector$1" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.common.Util" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.listener.states.SendingEntityBody" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.sender.ConnectionAvailabilityFuture" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.sender.states.SendingHeaders" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.sender.websocket.WebSocketClient" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.message.HttpCarbonMessage" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.message.HttpMessageDataStreamer" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.statistics.internal.StatisticsServiceComponent" />
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contract.config.ConfigurationBuilder" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contract.config.SslConfiguration" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contract.config.YAMLTransportConfigurationBuilder" />
+        <Bug pattern="PATH_TRAVERSAL_IN" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.crl.CRLVerifier" />
+        <Bug pattern="URLCONNECTION_SSRF_FD" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.ocsp.OCSPVerifier" />
+        <Bug pattern="URLCONNECTION_SSRF_FD" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.listener.states.SendingEntityBody" />
+        <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+    </Match>
+    <Match>
+        <Class name="org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.ocsp.OCSPVerifier" />
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
```diff
- DO NOT MERGE UNTIL THE BELOW SPECIFIED TODOS ARE COMPLETED
```

## Purpose
> $subject. Resolves https://github.com/wso2/api-manager/issues/752

- [ ] **TODO:** Test fails with the below logs. Need to fix
```
[INFO] 
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ org.wso2.transport.http.netty ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] 
[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire-reports/2022-09-22T22-09-11_044-jvmRun1.dumpstream
[INFO] Results:
[INFO] 
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] WSO2 Carbon Transport Parent 6.3.38-SNAPSHOT ....... SUCCESS [  5.830 s]
[INFO] WSO2 Transport HTTP Netty Component ................ FAILURE [ 34.298 s]
[INFO] WSO2 Transport HTTP Netty Statistics ............... SKIPPED
[INFO] WSO2 Transport HTTP Netty Feature .................. SKIPPED
[INFO] WSO2 Transport HTTP Netty Statistics Feature 6.3.38-SNAPSHOT SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 41.833 s
[INFO] Finished at: 2022-09-22T22:09:11+05:30
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project org.wso2.transport.http.netty: There are test failures.
[ERROR] 
[ERROR] Please refer to /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty && /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home/bin/java -javaagent:/Users/senthuran/.m2/repository/org/jacoco/org.jacoco.agent/0.7.8/org.jacoco.agent-0.7.8-runtime.jar=destfile=/Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/coverage-reports/jacoco-unit.exec -Dfile.encoding=UTF-8 -jar /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire/surefirebooter1438493329179309096.jar /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire 2022-09-22T22-09-11_044-jvmRun1 surefire61139260676195095tmp surefire_016048590305474745884tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty && /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home/bin/java -javaagent:/Users/senthuran/.m2/repository/org/jacoco/org.jacoco.agent/0.7.8/org.jacoco.agent-0.7.8-runtime.jar=destfile=/Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/coverage-reports/jacoco-unit.exec -Dfile.encoding=UTF-8 -jar /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire/surefirebooter1438493329179309096.jar /Users/senthuran/Desktop/wso2/dev/2022/jdk17-update/transport-http/components/org.wso2.transport.http.netty/target/surefire 2022-09-22T22-09-11_044-jvmRun1 surefire61139260676195095tmp surefire_016048590305474745884tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:669)
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:282)
[ERROR]         at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:245)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1183)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1011)
[ERROR]         at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:857)
[ERROR]         at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
[ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR]         at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
[ERROR]         at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
[ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
[ERROR]         at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
[ERROR]         at org.apache.maven.cli.MavenCli.execute(MavenCli.java:954)
[ERROR]         at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
[ERROR]         at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR]         at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR]         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR]         at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :org.wso2.transport.http.netty

```

## Goals
> $subject

## Dependant PRs
- [ ] **TODO:** Release Carbon-parent after merging [this PR](https://github.com/wso2/carbon-parent/pull/54), and bump its version here.