### PR TITLE
Upgrading guava and netty versions

### DIFF
--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -95,7 +95,7 @@
             <artifactId>commons-pool</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.yaml</groupId>
+            <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
 

--- a/features/org.wso2.transport.http.netty.feature/pom.xml
+++ b/features/org.wso2.transport.http.netty.feature/pom.xml
@@ -171,9 +171,8 @@
                                     <symbolicName>commons-pool</symbolicName>
                                     <version>${commons.pool.version}</version>
                                 </bundle>
-
                                 <bundle>
-                                    <symbolicName>snakeyaml</symbolicName>
+                                    <symbolicName>org.yaml.snakeyaml</symbolicName>
                                     <version>${org.snakeyaml.version}</version>
                                 </bundle>
                                 <bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.orbit.org.yaml</groupId>
+                <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${org.snakeyaml.version}</version>
             </dependency>
@@ -405,7 +405,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.94.Final</netty.version>
+        <netty.version>4.1.97.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
@@ -434,8 +434,8 @@
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
 
         <carbon.p2.plugin.version>2.0.1</carbon.p2.plugin.version>
-        <org.snakeyaml.version>2.0.0.wso2v1</org.snakeyaml.version>
-        <org.snakeyaml.package.import.version.range>[1.32.0, 2.0.0)</org.snakeyaml.package.import.version.range>
+        <org.snakeyaml.version>2.0</org.snakeyaml.version>
+        <org.snakeyaml.package.import.version.range>[1.32.0, 3.0.0)</org.snakeyaml.package.import.version.range>
 
         <!-- Package exports -->
         <netty.transport.package.export.version>${project.version}</netty.transport.package.export.version>


### PR DESCRIPTION
## Purpose
Following dependencies have been upgraded
- guava -> 32.1.2-jre
- netty -> 4.1.97.Final
- snakeyaml -> 2.0