### PR TITLE
Upgrade Netty and Guava versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.104.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -422,8 +422,7 @@
         <commons.pool.package.import.version.range>[1.5.6, 2.0.0)</commons.pool.package.import.version.range>
         <commons-io.wso2.version>2.11.0.wso2v1</commons-io.wso2.version>
         <commons-io.version.range>[2.4.0, 2.5)</commons-io.version.range>
-        <guava.version>18.0</guava.version>
-        <guava.version.range>[18.0,19.0)</guava.version.range>
+        <guava.version>33.0.0-jre</guava.version>
         <org.apache.commons.pool2.version>2.4.2</org.apache.commons.pool2.version>
         <commons-net.version>3.6</commons-net.version>
 


### PR DESCRIPTION
### Purpose
Upgrade the netty dependency version to 4.1.104.Final, and Guava version to the 33.0.0-jre.