### PR TITLE
Bump netty version to 4.1.108.Final to fix CVE-2024-29025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.104.Final</netty.version>
+        <netty.version>4.1.108.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>
@@ -455,7 +455,7 @@
         <org.atomikos.wso2.version>3.8.0.wso2v1</org.atomikos.wso2.version>
         <bcprov-jdk15on.version>1.69</bcprov-jdk15on.version>
         <bcpkix-jdk15on.version>1.69</bcpkix-jdk15on.version>
-        <netty-tcnative-boringssl-static.version>2.0.62.Final</netty-tcnative-boringssl-static.version>
+        <netty-tcnative-boringssl-static.version>2.0.65.Final</netty-tcnative-boringssl-static.version>
 
         <unirest.version>1.4.9</unirest.version>
         <httpclient.version>4.3.6</httpclient.version>


### PR DESCRIPTION
## Purpose
> Bump netty version to 4.1.108.Final to fix CVE-2024-29025

