### PR TITLE
Initialise SSL context in the client initialisation

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpClientConnector.java
@@ -93,4 +93,11 @@ public interface HttpClientConnector {
      * @return returns the status of the asynchronous push response fetch action
      */
     HttpResponseFuture getPushResponse(Http2PushPromise pushPromise);
+
+    /**
+     * Initialize the SSL context.
+     *
+     * @throws Exception if an error occurs while initializing the SSL context.
+     */
+    void initializeSSLContext() throws Exception;
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/HttpWsConnectorFactory.java
@@ -54,6 +54,17 @@ public interface HttpWsConnectorFactory {
             SenderConfiguration senderConfiguration);
 
     /**
+     * This method can be used to get http client connectors with SSL context initialized.
+     *
+     * @param transportProperties configTargetHandler stuff like global timeout, number of outbound connections, etc.
+     * @param senderConfiguration contains SSL configuration and endpoint details.
+     * @throws Exception if the connector creation fails.
+     * @return HttpClientConnector.
+     */
+    HttpClientConnector createHttpsClientConnector(Map<String, Object> transportProperties,
+                                                   SenderConfiguration senderConfiguration) throws Exception;
+
+    /**
      * Creates a client connector with a given connection manager.
      *
      * @param transportProperties Represents the configurations related to HTTP client
@@ -62,7 +73,21 @@ public interface HttpWsConnectorFactory {
      * @return the HttpClientConnector
      */
     HttpClientConnector createHttpClientConnector(Map<String, Object> transportProperties,
-        SenderConfiguration senderConfiguration, ConnectionManager connectionManager);
+                                                  SenderConfiguration senderConfiguration,
+                                                  ConnectionManager connectionManager);
+
+    /**
+     * Creates a client connector with a given connection manager and SSL context.
+     *
+     * @param transportProperties Represents the configurations related to HTTP client
+     * @param senderConfiguration Represents the configurations related to client channel creation
+     * @param connectionManager   Manages the client pool
+     * @throws Exception if the connector creation fails.
+     * @return the HttpClientConnector
+     */
+    HttpClientConnector createHttpsClientConnector(Map<String, Object> transportProperties,
+                                                   SenderConfiguration senderConfiguration,
+                                                   ConnectionManager connectionManager) throws Exception;
 
     /**
      * Creates a client connector with given client bootstrap configuration and connection manager.
@@ -77,12 +102,36 @@ public interface HttpWsConnectorFactory {
                                                   ConnectionManager connectionManager);
 
     /**
+     * Creates a client connector with given client bootstrap configuration, connection manager and SSL context.
+     *
+     * @param bootstrapConfiguration Represents the client bootstrap configurations.
+     * @param senderConfiguration    Represents the configurations related to client channel creation
+     * @param connectionManager      Manages the client pool
+     * @throws Exception if the connector creation fails.
+     * @return the HttpClientConnector
+     */
+    HttpClientConnector createHttpsClientConnector(BootstrapConfiguration bootstrapConfiguration,
+                                                   SenderConfiguration senderConfiguration,
+                                                   ConnectionManager connectionManager) throws Exception;
+
+    /**
      * This method is used to get WebSocket client connector.
      *
      * @param clientConnectorConfig Properties to create a client connector.
      * @return WebSocketClientConnector.
      */
     WebSocketClientConnector createWsClientConnector(WebSocketClientConnectorConfig clientConnectorConfig);
+
+
+    /**
+     * This method is used to get WebSocket client connector with SSL context initialized.
+     *
+     * @param clientConnectorConfig Properties to create a client connector.
+     * @throws Exception if the connector creation fails.
+     * @return WebSocketClientConnector.
+     */
+    WebSocketClientConnector createWsClientConnectorWithSSL(WebSocketClientConnectorConfig clientConnectorConfig)
+            throws Exception;
 
     /**
      * Shutdown all the server channels and the accepted channels. It also shutdown all the eventloop groups.

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contract/websocket/WebSocketClientConnector.java
@@ -30,4 +30,11 @@ public interface WebSocketClientConnector {
      * @return ClientHandshakeFuture for the newly created connection.
      */
     ClientHandshakeFuture connect();
+
+    /**
+     * Initialize the SSL context.
+     *
+     * @throws Exception if an error occurs while initializing the SSL context.
+     */
+    void initializeSSLContext() throws Exception;
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpClientConnector.java
@@ -58,6 +58,7 @@ import org.wso2.transport.http.netty.message.ResponseHandle;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import static org.wso2.transport.http.netty.contract.Constants.REMOTE_SERVER_CLOSED_BEFORE_INITIATING_OUTBOUND_REQUEST;
 
@@ -362,5 +363,11 @@ public class DefaultHttpClientConnector implements HttpClientConnector {
         this.socketIdleTimeout = senderConfiguration.getSocketIdleTimeout(Constants.ENDPOINT_TIMEOUT);
         this.sslConfig = senderConfiguration.getClientSSLConfig();
         this.forwardedExtensionConfig = senderConfiguration.getForwardedExtensionConfig();
+    }
+
+    public void initializeSSLContext() throws Exception {
+        if (Objects.nonNull(sslConfig)) {
+            sslConfig.initializeSSLContext(isHttp2);
+        }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/DefaultHttpWsConnectorFactory.java
@@ -147,24 +147,64 @@ public class DefaultHttpWsConnectorFactory implements HttpWsConnectorFactory {
     }
 
     @Override
-    public HttpClientConnector createHttpClientConnector(
-        Map<String, Object> transportProperties, SenderConfiguration senderConfiguration,
-        ConnectionManager connectionManager) {
+    public HttpClientConnector createHttpsClientConnector(Map<String, Object> transportProperties,
+                                                          SenderConfiguration senderConfiguration) throws Exception {
+        BootstrapConfiguration bootstrapConfig = new BootstrapConfiguration(transportProperties);
+        ConnectionManager connectionManager = new ConnectionManager(senderConfiguration.getPoolConfiguration());
+        HttpClientConnector httpClientConnector = new DefaultHttpClientConnector(connectionManager,
+                senderConfiguration, bootstrapConfig, clientGroup);
+        httpClientConnector.initializeSSLContext();
+        return httpClientConnector;
+    }
+
+    @Override
+    public HttpClientConnector createHttpClientConnector(Map<String, Object> transportProperties,
+                                                         SenderConfiguration senderConfiguration,
+                                                         ConnectionManager connectionManager) {
         BootstrapConfiguration bootstrapConfig = new BootstrapConfiguration(transportProperties);
         return new DefaultHttpClientConnector(connectionManager, senderConfiguration, bootstrapConfig, clientGroup);
+    }
+
+    @Override
+    public HttpClientConnector createHttpsClientConnector(Map<String, Object> transportProperties,
+                                                          SenderConfiguration senderConfiguration,
+                                                          ConnectionManager connectionManager) throws Exception {
+        BootstrapConfiguration bootstrapConfig = new BootstrapConfiguration(transportProperties);
+        HttpClientConnector httpClientConnector = new DefaultHttpClientConnector(connectionManager,
+                senderConfiguration, bootstrapConfig, clientGroup);
+        httpClientConnector.initializeSSLContext();
+        return httpClientConnector;
     }
 
     @Override
     public HttpClientConnector createHttpClientConnector(BootstrapConfiguration bootstrapConfig,
                                                          SenderConfiguration senderConfiguration,
                                                          ConnectionManager connectionManager) {
-
         return new DefaultHttpClientConnector(connectionManager, senderConfiguration, bootstrapConfig, clientGroup);
+    }
+
+    @Override
+    public HttpClientConnector createHttpsClientConnector(BootstrapConfiguration bootstrapConfig,
+                                                          SenderConfiguration senderConfiguration,
+                                                          ConnectionManager connectionManager) throws Exception {
+        HttpClientConnector httpClientConnector = new DefaultHttpClientConnector(connectionManager,
+                senderConfiguration, bootstrapConfig, clientGroup);
+        httpClientConnector.initializeSSLContext();
+        return httpClientConnector;
     }
 
     @Override
     public WebSocketClientConnector createWsClientConnector(WebSocketClientConnectorConfig clientConnectorConfig) {
         return new DefaultWebSocketClientConnector(clientConnectorConfig, clientGroup);
+    }
+
+    @Override
+    public WebSocketClientConnector createWsClientConnectorWithSSL(
+            WebSocketClientConnectorConfig clientConnectorConfig) throws Exception {
+        WebSocketClientConnector webSocketClientConnector = new DefaultWebSocketClientConnector(clientConnectorConfig,
+                clientGroup);
+        webSocketClientConnector.initializeSSLContext();
+        return webSocketClientConnector;
     }
 
     @Override

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/ssl/SSLConfig.java
@@ -419,7 +419,6 @@ public class SSLConfig {
     }
 
     public boolean hasSslCtxInitialized() {
-        return Objects.nonNull(sslHandlerFactory) && (Objects.nonNull(sslContext) ||
-                Objects.nonNull(referenceCountedOpenSslContext));
+        return Objects.nonNull(sslHandlerFactory);
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/sender/websocket/WebSocketClient.java
@@ -132,8 +132,11 @@ public class WebSocketClient {
         clientBootstrap.group(wsClientEventLoopGroup).channel(NioSocketChannel.class).handler(
                 new ChannelInitializer<SocketChannel>() {
                     @Override
-                    protected void initChannel(SocketChannel socketChannel) throws SSLException {
+                    protected void initChannel(SocketChannel socketChannel) throws Exception {
                         if (sslConfig != null) {
+                            if (!sslConfig.hasSslCtxInitialized()) {
+                                sslConfig.initializeSSLContext(false);
+                            }
                             SSLEngine sslEngine = Util
                                     .configureHttpPipelineForSSL(socketChannel, host, port, sslConfig);
                             socketChannel.pipeline().addLast(Constants.SSL_COMPLETION_HANDLER,

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketClientConnector.java
@@ -23,7 +23,10 @@ import io.netty.channel.EventLoopGroup;
 import org.wso2.transport.http.netty.contract.websocket.ClientHandshakeFuture;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnector;
 import org.wso2.transport.http.netty.contract.websocket.WebSocketClientConnectorConfig;
+import org.wso2.transport.http.netty.contractimpl.common.ssl.SSLConfig;
 import org.wso2.transport.http.netty.contractimpl.sender.websocket.WebSocketClient;
+
+import java.util.Objects;
 
 /**
  * Implementation of WebSocket client connector.
@@ -31,14 +34,23 @@ import org.wso2.transport.http.netty.contractimpl.sender.websocket.WebSocketClie
 public class DefaultWebSocketClientConnector implements WebSocketClientConnector {
 
     private final WebSocketClient webSocketClient;
+    private final SSLConfig sslConfig;
 
     public DefaultWebSocketClientConnector(WebSocketClientConnectorConfig clientConnectorConfig,
             EventLoopGroup wsClientEventLoopGroup) {
         this.webSocketClient = new WebSocketClient(wsClientEventLoopGroup, clientConnectorConfig);
+        this.sslConfig = clientConnectorConfig.getClientSSLConfig();
     }
 
     @Override
     public ClientHandshakeFuture connect() {
         return webSocketClient.handshake();
+    }
+
+    @Override
+    public void initializeSSLContext() throws Exception {
+        if (Objects.nonNull(sslConfig)) {
+            sslConfig.initializeSSLContext(false);
+        }
     }
 }

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketClientConnector.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/websocket/DefaultWebSocketClientConnector.java
@@ -34,12 +34,12 @@ import java.util.Objects;
 public class DefaultWebSocketClientConnector implements WebSocketClientConnector {
 
     private final WebSocketClient webSocketClient;
-    private final SSLConfig sslConfig;
+    private final WebSocketClientConnectorConfig clientConnectorConfig;
 
     public DefaultWebSocketClientConnector(WebSocketClientConnectorConfig clientConnectorConfig,
             EventLoopGroup wsClientEventLoopGroup) {
         this.webSocketClient = new WebSocketClient(wsClientEventLoopGroup, clientConnectorConfig);
-        this.sslConfig = clientConnectorConfig.getClientSSLConfig();
+        this.clientConnectorConfig = clientConnectorConfig;
     }
 
     @Override
@@ -49,6 +49,7 @@ public class DefaultWebSocketClientConnector implements WebSocketClientConnector
 
     @Override
     public void initializeSSLContext() throws Exception {
+        SSLConfig sslConfig = clientConnectorConfig.getClientSSLConfig();
         if (Objects.nonNull(sslConfig)) {
             sslConfig.initializeSSLContext(false);
         }

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/disablessl/SslDisabledClientTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/disablessl/SslDisabledClientTest.java
@@ -49,7 +49,7 @@ public class SslDisabledClientTest {
     private ServerConnector serverConnector;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
         httpConnectorFactory = new DefaultHttpWsConnectorFactory();
 
         ListenerConfiguration listenerConfiguration = getListenerConfiguration();
@@ -59,7 +59,7 @@ public class SslDisabledClientTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = httpConnectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = httpConnectorFactory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private ListenerConfiguration getListenerConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/DisableSslTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/DisableSslTest.java
@@ -49,7 +49,7 @@ public class DisableSslTest {
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
         serverConnector = factory
@@ -60,7 +60,7 @@ public class DisableSslTest {
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
         http2ClientConnector = connectorFactory
-                .createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+                .createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     public static SenderConfiguration getSenderConfigs() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/Http2ALPNwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/Http2ALPNwithCertsTest.java
@@ -50,7 +50,7 @@ public class Http2ALPNwithCertsTest {
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
         serverConnector = factory
@@ -60,7 +60,7 @@ public class Http2ALPNwithCertsTest {
         future.sync();
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
-        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = connectorFactory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/Http2MutualSslTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/Http2MutualSslTest.java
@@ -48,7 +48,7 @@ public class Http2MutualSslTest {
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
         serverConnector = factory
@@ -59,7 +59,7 @@ public class Http2MutualSslTest {
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
         http2ClientConnector = connectorFactory
-                .createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+                .createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private SenderConfiguration getSenderConfigs() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/TestHttp2WithALPN.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http2/ssl/TestHttp2WithALPN.java
@@ -51,7 +51,7 @@ public class TestHttp2WithALPN {
     private HttpWsConnectorFactory connectorFactory;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         HttpWsConnectorFactory factory = new DefaultHttpWsConnectorFactory();
         serverConnector = factory
@@ -62,9 +62,9 @@ public class TestHttp2WithALPN {
 
         connectorFactory = new DefaultHttpWsConnectorFactory();
         http2ClientConnector = connectorFactory
-            .createHttpClientConnector(new HashMap<>(), getSenderConfigs(HTTP_2_0));
+                .createHttpsClientConnector(new HashMap<>(), getSenderConfigs(HTTP_2_0));
         http1ClientConnector = connectorFactory
-            .createHttpClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_1_1)));
+                .createHttpsClientConnector(new HashMap<>(), getSenderConfigs(String.valueOf(HTTP_1_1)));
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuitesTest.java
@@ -86,7 +86,7 @@ public class CipherSuitesTest {
      */
     @Test(dataProvider = "ciphers")
     public void setup(String clientCiphers, String serverCiphers, boolean hasException, int serverPort)
-            throws InterruptedException {
+            throws Exception {
 
         Parameter paramClientCiphers = new Parameter("ciphers", clientCiphers);
         clientParams = new ArrayList<>();
@@ -103,7 +103,7 @@ public class CipherSuitesTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
 
         testCiphersuites(hasException, serverPort);
         serverConnector.stop();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuiteswithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/CipherSuiteswithCertsTest.java
@@ -82,7 +82,7 @@ public class CipherSuiteswithCertsTest {
      */
     @Test(dataProvider = "ciphers")
     public void setup(String clientCiphers, String serverCiphers, boolean hasException, int serverPort)
-            throws InterruptedException {
+            throws Exception {
 
         Parameter paramClientCiphers = new Parameter("ciphers", clientCiphers);
         clientParams.add(paramClientCiphers);
@@ -100,7 +100,7 @@ public class CipherSuiteswithCertsTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
 
         testCiphersuitesWithCertsAndKeys(hasException, serverPort);
         serverConnector.stop();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HttpsInvalidServerCertificateTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/HttpsInvalidServerCertificateTest.java
@@ -56,7 +56,7 @@ public class HttpsInvalidServerCertificateTest {
     private String testValue = "Test Message";
 
     @BeforeClass
-    public void setup() {
+    public void setup() throws Exception {
         httpsServer = TestUtil.startHttpsServer(TestUtil.HTTPS_SERVER_PORT,
                                                 new MockServerInitializer(testValue, TEXT_PLAIN, 200));
 
@@ -68,7 +68,7 @@ public class HttpsInvalidServerCertificateTest {
         senderConfiguration.setHostNameVerificationEnabled(false);
         senderConfiguration.setScheme(HTTPS_SCHEME);
         connectorFactory = new DefaultHttpWsConnectorFactory();
-        httpClientConnector = connectorFactory.createHttpClientConnector(new HashMap<>(), senderConfiguration);
+        httpClientConnector = connectorFactory.createHttpsClientConnector(new HashMap<>(), senderConfiguration);
     }
 
     @Test

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLTestCase.java
@@ -51,7 +51,7 @@ public class MutualSSLTestCase {
     private ServerConnector connector;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         factory = new DefaultHttpWsConnectorFactory();
 
@@ -63,7 +63,7 @@ public class MutualSSLTestCase {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private ListenerConfiguration getListenerConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/MutualSSLwithCertsTest.java
@@ -49,7 +49,7 @@ public class MutualSSLwithCertsTest {
     private ServerConnector connector;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
 
         factory = new DefaultHttpWsConnectorFactory();
 
@@ -60,7 +60,7 @@ public class MutualSSLwithCertsTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private ListenerConfiguration getListenerConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/OptionalMutualSSLTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/OptionalMutualSSLTest.java
@@ -51,7 +51,7 @@ public class OptionalMutualSSLTest {
     private ServerConnector connector;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
         factory = new DefaultHttpWsConnectorFactory();
 
         ListenerConfiguration listenerConfiguration = getListenerConfiguration();
@@ -62,7 +62,7 @@ public class OptionalMutualSSLTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private ListenerConfiguration getListenerConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsTest.java
@@ -84,7 +84,7 @@ public class SSLProtocolsTest {
      */
     @Test(dataProvider = "protocols")
     public void setup(String clientProtocol, String serverProtocol, boolean hasException, int serverPort)
-            throws InterruptedException {
+            throws Exception {
 
         Parameter clientprotocols = new Parameter("sslEnabledProtocols", clientProtocol);
         clientParams = new ArrayList<>();
@@ -103,7 +103,7 @@ public class SSLProtocolsTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = httpWsConnectorFactory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
 
         testSSLProtocols(hasException, serverPort);
         serverConnector.stop();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsWithCertsTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/SSLProtocolsWithCertsTest.java
@@ -82,7 +82,7 @@ public class SSLProtocolsWithCertsTest {
      */
     @Test(dataProvider = "protocols")
     public void setup(String clientProtocol, String serverProtocol, boolean hasException, int serverPort)
-            throws InterruptedException {
+            throws Exception {
 
         Parameter clientprotocols = new Parameter("sslEnabledProtocols", clientProtocol);
         clientParams.add(clientprotocols);
@@ -100,7 +100,7 @@ public class SSLProtocolsWithCertsTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = httpWsConnectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = httpWsConnectorFactory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
 
         testSSLProtocols(hasException, serverPort);
         serverConnector.stop();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/ServerCloseConnectionDuringSslTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/https/ServerCloseConnectionDuringSslTest.java
@@ -57,7 +57,7 @@ public class ServerCloseConnectionDuringSslTest {
     private DefaultHttpConnectorListener listener;
 
     @BeforeClass
-    public void setup() {
+    public void setup() throws Exception {
         givenServerThatClosesConnection();
         givenANormalHttpsClient();
     }
@@ -116,9 +116,9 @@ public class ServerCloseConnectionDuringSslTest {
         return senderConfiguration;
     }
 
-    private void givenANormalHttpsClient() {
+    private void givenANormalHttpsClient() throws Exception {
         factory = new DefaultHttpWsConnectorFactory();
-        httpClientConnector = factory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = factory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private void givenServerThatClosesConnection() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughHttpsMessageProcessorListener.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/passthrough/PassthroughHttpsMessageProcessorListener.java
@@ -72,10 +72,10 @@ public class PassthroughHttpsMessageProcessorListener implements HttpConnectorLi
             try {
                 if (shareConnectionPool && connectionManager != null) {
                     clientConnector = httpWsConnectorFactory
-                        .createHttpClientConnector(new HashMap<>(), senderConfiguration, connectionManager);
+                        .createHttpsClientConnector(new HashMap<>(), senderConfiguration, connectionManager);
                 } else {
                     clientConnector = httpWsConnectorFactory
-                        .createHttpClientConnector(new HashMap<>(), senderConfiguration);
+                        .createHttpsClientConnector(new HashMap<>(), senderConfiguration);
                 }
                 HttpResponseFuture future = clientConnector.send(outboundRequest);
                 future.setHttpConnectorListener(new HttpConnectorListener() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/pkcs/PKCSTest.java
@@ -49,7 +49,7 @@ public class PKCSTest {
     private ServerConnector serverConnector;
 
     @BeforeClass
-    public void setup() throws InterruptedException {
+    public void setup() throws Exception {
         httpConnectorFactory = new DefaultHttpWsConnectorFactory();
 
         ListenerConfiguration listenerConfiguration = getListenerConfiguration();
@@ -59,7 +59,7 @@ public class PKCSTest {
         future.setHttpConnectorListener(new EchoMessageListener());
         future.sync();
 
-        httpClientConnector = httpConnectorFactory.createHttpClientConnector(new HashMap<>(), getSenderConfigs());
+        httpClientConnector = httpConnectorFactory.createHttpsClientConnector(new HashMap<>(), getSenderConfigs());
     }
 
     private ListenerConfiguration getListenerConfiguration() {

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/ssl/WebSocketSSLHandshakeFailureTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/ssl/WebSocketSSLHandshakeFailureTestCase.java
@@ -95,7 +95,7 @@ public class WebSocketSSLHandshakeFailureTestCase {
     @Test
     public void testClientConnectionWithSSL() throws Throwable {
         WebSocketClientConnector webSocketClientConnector =
-                httpConnectorFactory.createWsClientConnector(getWebSocketClientConnectorConfigWithSSL());
+                httpConnectorFactory.createWsClientConnectorWithSSL(getWebSocketClientConnectorConfigWithSSL());
         CountDownLatch countDownLatch = new CountDownLatch(1);
         AtomicReference<WebSocketConnection> webSocketConnectionAtomicReference = new AtomicReference<>();
         AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<>();

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/ssl/WebSocketSSLHandshakeSuccessfulTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/websocket/ssl/WebSocketSSLHandshakeSuccessfulTestCase.java
@@ -92,7 +92,7 @@ public class WebSocketSSLHandshakeSuccessfulTestCase {
     @Test
     public void testClientConnectionWithSSL() throws Throwable {
         WebSocketClientConnector webSocketClientConnector =
-                httpConnectorFactory.createWsClientConnector(getWebSocketClientConnectorConfigWithSSL());
+                httpConnectorFactory.createWsClientConnectorWithSSL(getWebSocketClientConnectorConfigWithSSL());
         CountDownLatch countDownLatch = new CountDownLatch(1);
         AtomicReference<WebSocketConnection> webSocketConnectionAtomicReference = new AtomicReference<>();
         AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<>();


### PR DESCRIPTION
## Purpose

Introduced new APIs to create HTTPS clients which can be created with SSL context initialisation

## Goals

- Move the SSL context initialisation to client initialisation