### PR TITLE
Update io.netty version from 4.1.118.Final to 4.1.126.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <!-- Dependencies -->
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
 
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <netty.package.import.version.range>[4.0.30, 5.0.0)</netty.package.import.version.range>
         <equinox.osgi.version>3.10.2.v20150203-1939</equinox.osgi.version>
         <equinox.osgi.services.version>3.4.0.v20140312-2051</equinox.osgi.services.version>


### PR DESCRIPTION
This PR updates the Netty library to the latest stable 4.1.x version to improve security, performance, and compatibility.

### Changes Made

**Networking Libraries:**
- **io.netty**: `4.1.118.Final` → `4.1.126.Final`

Related Issue: https://github.com/wso2/api-manager/issues/3870
