### PR TITLE
Upgrade bouncy castle version

### DIFF
--- a/components/org.wso2.transport.http.netty/pom.xml
+++ b/components/org.wso2.transport.http.netty/pom.xml
@@ -87,13 +87,11 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bcprov-jdk15on.version}</version>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${bcpkix-jdk15on.version}</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/certificatevalidation/ocsp/OCSPVerifier.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/certificatevalidation/ocsp/OCSPVerifier.java
@@ -18,8 +18,8 @@
  */
 package org.wso2.transport.http.netty.contractimpl.common.certificatevalidation.ocsp;
 
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
 import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
@@ -291,7 +291,7 @@ public class OCSPVerifier implements RevocationVerifier {
 
             GeneralName gn = accessDescription.getAccessLocation();
             if (gn.getTagNo() == GeneralName.uniformResourceIdentifier) {
-                DERIA5String str = DERIA5String.getInstance(gn.getName());
+                ASN1IA5String str = ASN1IA5String.getInstance(gn.getName());
                 String accessLocation = str.getString();
                 ocspUrlList.add(accessLocation);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -257,13 +257,13 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bcprov-jdk15on.version}</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bcprov-jdk18on.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bcpkix-jdk15on.version}</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcpkix-jdk18on.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -408,8 +408,8 @@
         <jsch.version>0.1.51.wso2v1</jsch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.atomikos.wso2.version>3.8.0.wso2v1</org.atomikos.wso2.version>
-        <bcprov-jdk15on.version>1.69</bcprov-jdk15on.version>
-        <bcpkix-jdk15on.version>1.69</bcpkix-jdk15on.version>
+        <bcprov-jdk18on.version>1.83</bcprov-jdk18on.version>
+        <bcpkix-jdk18on.version>1.83</bcpkix-jdk18on.version>
         <netty-tcnative-boringssl-static.version>2.0.65.Final</netty-tcnative-boringssl-static.version>
 
         <unirest.version>1.4.9</unirest.version>


### PR DESCRIPTION
## Purpose
Upgrades bouncy castle version

- bcpkix-jdk15on -> bcpkix-jdk18on
- bcprov-jdk15on -> bcprov-jdk18on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cryptographic security libraries to Java 18-compatible versions for improved system compatibility.

* **Bug Fixes**
  * Enhanced certificate validation handling during OCSP verification operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->