### PR TITLE
Fix ChunkAlwaysHttpOnePointZeroClientTestCase for Netty 4.2.16

### DIFF
--- a/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
+++ b/components/org.wso2.transport.http.netty/src/main/java/org/wso2/transport/http/netty/contractimpl/common/Util.java
@@ -348,7 +348,7 @@ public class Util {
      * @return true if chunking should be enforced else false.
      */
     public static boolean shouldEnforceChunkingforHttpOneZero(ChunkConfig chunkConfig, String httpVersion) {
-        return chunkConfig == ChunkConfig.ALWAYS && Float.valueOf(httpVersion) >= Constants.HTTP_1_0;
+        return chunkConfig == ChunkConfig.ALWAYS && Float.valueOf(httpVersion) > Constants.HTTP_1_0;
     }
 
     /**

--- a/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
+++ b/components/org.wso2.transport.http.netty/src/test/java/org/wso2/transport/http/netty/http1point0test/ChunkAlwaysHttpOnePointZeroClientTestCase.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.transport.http.netty.chunkdisable.ChunkClientTemplate;
-import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 import org.wso2.transport.http.netty.util.TestUtil;
@@ -43,16 +42,18 @@ public class ChunkAlwaysHttpOnePointZeroClientTestCase extends ChunkClientTempla
     @Test
     public void postTest() {
         try {
+            // RFC 9112 §6.1: Transfer-Encoding is not allowed in HTTP/1.0.
+            // Netty 4.2.16+ enforces this, so ChunkConfig.ALWAYS falls back to Content-Length for HTTP/1.0.
             HttpCarbonMessage response = sendRequest(TestUtil.largeEntity);
-            Assert.assertNull("Content-Length header present in the response.",
+            Assert.assertNotNull("Content-Length header not present in the response.",
                     response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()));
-            Assert.assertEquals("Transfer-Encoding header is not present in the response.", Constants.CHUNKED,
+            Assert.assertNull("Transfer-Encoding header present in the response.",
                     response.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()));
 
             response = sendRequest(TestUtil.smallEntity);
-            Assert.assertNull("Content-Length header present in the response.",
+            Assert.assertNotNull("Content-Length header not present in the response.",
                     response.getHeader(HttpHeaderNames.CONTENT_LENGTH.toString()));
-            Assert.assertEquals("Transfer-Encoding header is not present in the response.", Constants.CHUNKED,
+            Assert.assertNull("Transfer-Encoding header present in the response.",
                     response.getHeader(HttpHeaderNames.TRANSFER_ENCODING.toString()));
 
         } catch (Exception e) {


### PR DESCRIPTION
## Purpose

Netty 4.2.13 and above enforces RFC 9112 §6.1, which prohibits Transfer-Encoding: chunked on HTTP/1.0 connections (CVE-2026-42581). shouldEnforceChunkingforHttpOneZero now correctly excludes HTTP/1.0 so ChunkConfig.ALWAYS falls back to Content-Length, and the test assertions are updated accordingly.
